### PR TITLE
Parse control keys correctly

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -976,6 +976,18 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 	return true, false
 }
 
+func (t *tScreen) parseControlKey(buf *bytes.Buffer) bool {
+	b := buf.Bytes()
+
+	if b[0] < 0x80 {
+		by, _ := buf.ReadByte()
+		ev := NewEventKey(KeyRune, rune(by), ModNone)
+		t.PostEvent(ev)
+		return true
+	}
+	return false
+}
+
 func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 
 	t.Lock()
@@ -1017,6 +1029,10 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 			} else if part {
 				partials++
 			}
+		}
+
+		if comp := t.parseControlKey(buf); comp {
+			continue
 		}
 
 		if partials == 0 || expire {


### PR DESCRIPTION
Ok. I think I have solved #85. The problem is in `scanInput` in `tscreen.go`. When checking to see what kind of event it is, `parseRune` and `parseFunctionKey` are run, but neither of them check for control keys. So control keys are never parsed and they are only returned after waiting the full `VTIME`. 

To fix this, the control keys (keys `< 0x80`) need to be parsed at some point so I wrote a little function to do that.

Let me know if there is anything you'd like me to change.