### PR TITLE
Make sure 0,0 mouse coordinates is the top left

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -881,7 +881,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 				btn, val = val, 0
 				neg, dig, state = false, false, 4
 			case 4:
-				x, val = val, 0
+				x, val = val-1, 0
 				neg, dig, state = false, false, 5
 			default:
 				return false, false
@@ -894,7 +894,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 			if neg {
 				val = -val
 			}
-			y = val
+			y = val - 1
 
 			// We don't care about the motion bit
 			btn &^= 32


### PR DESCRIPTION
As per the documentation, 0,0 should be the top left for mouse coordinates, but sgr reporting reports the top left as 1,1. This PR simply adjusts the coordinates to stay consistent.