### PR TITLE
Add motion to EventMouse

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -553,7 +553,7 @@ func (s *cScreen) getConsoleInput() error {
 		btns := mrec2btns(mrec.btns, mrec.flags)
 		// we ignore double click, events are delivered normally
 		s.PostEvent(NewEventMouse(int(mrec.x), int(mrec.y), btns,
-			mod2mask(mrec.mod)))
+			mod2mask(mrec.mod), false))
 
 	case resizeEvent:
 		var rrec resizeRecord

--- a/mouse.go
+++ b/mouse.go
@@ -35,11 +35,12 @@ import (
 // Applications can inspect the time between events to resolve double or
 // triple clicks.
 type EventMouse struct {
-	t   time.Time
-	btn ButtonMask
-	mod ModMask
-	x   int
-	y   int
+	t      time.Time
+	btn    ButtonMask
+	mod    ModMask
+	motion bool
+	x      int
+	y      int
 }
 
 // When returns the time when this EventMouse was created.
@@ -64,10 +65,15 @@ func (ev *EventMouse) Position() (int, int) {
 	return ev.x, ev.y
 }
 
+// HasMotion returns whether the mouse event was a mouse motion event or not
+func (ev *EventMouse) HasMotion() bool {
+	return ev.motion
+}
+
 // NewEventMouse is used to create a new mouse event.  Applications
 // shouldn't need to use this; its mostly for screen implementors.
-func NewEventMouse(x, y int, btn ButtonMask, mod ModMask) *EventMouse {
-	return &EventMouse{t: time.Now(), x: x, y: y, btn: btn, mod: mod}
+func NewEventMouse(x, y int, btn ButtonMask, mod ModMask, motion bool) *EventMouse {
+	return &EventMouse{t: time.Now(), x: x, y: y, btn: btn, mod: mod, motion: motion}
 }
 
 // ButtonMask is a mask of mouse buttons and wheel events.  Mouse button presses

--- a/simulation.go
+++ b/simulation.go
@@ -361,7 +361,7 @@ func (s *simscreen) PostEvent(ev Event) error {
 }
 
 func (s *simscreen) InjectMouse(x, y int, buttons ButtonMask, mod ModMask) {
-	ev := NewEventMouse(x, y, buttons, mod)
+	ev := NewEventMouse(x, y, buttons, mod, false)
 	s.PostEvent(ev)
 }
 

--- a/tscreen.go
+++ b/tscreen.go
@@ -751,7 +751,7 @@ func (t *tScreen) clip(x, y int) (int, int) {
 	return x, y
 }
 
-func (t *tScreen) postMouseEvent(x, y, btn int) {
+func (t *tScreen) postMouseEvent(x, y, btn int, motion bool) {
 
 	// XTerm mouse events only report at most one button at a time,
 	// which may include a wheel button.  Wheel motion events are
@@ -807,7 +807,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int) {
 	// to the screen in that case.
 	x, y = t.clip(x, y)
 
-	ev := NewEventMouse(x, y, button, mod)
+	ev := NewEventMouse(x, y, button, mod, motion)
 	t.PostEvent(ev)
 }
 
@@ -896,7 +896,9 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 			}
 			y = val - 1
 
-			// We don't care about the motion bit
+			// Store whether or not the terminal reports motion
+			motion := btn >= 32
+
 			btn &^= 32
 			if b[i] == 'm' {
 				// mouse release, clear all buttons
@@ -908,7 +910,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			t.postMouseEvent(x, y, btn, motion)
 			return true, true
 		}
 	}
@@ -961,7 +963,7 @@ func (t *tScreen) parseXtermMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			t.postMouseEvent(x, y, btn, false)
 			return true, true
 		}
 	}


### PR DESCRIPTION
This pull request changes `EventMouse` to also store whether or not the event was sent as a motion event. In the current version of tcell, the motion bit is just thrown away, but this can be useful information on systems which are more limited in mouse reporting and don't always report correctly.

For example, on Elementary OS, the mouse button is always sent as `32` when there is motion, even when mouse button 1 is not pressed. With this PR I can tell whether the key was actually pushed down or not by storing when the key was first pressed without motion and then registering the motion events.