### PR TITLE
Fix idle wakeup problem

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -77,6 +77,7 @@ type tScreen struct {
 	sigwinch  chan os.Signal
 	quit      chan struct{}
 	indoneq   chan struct{}
+	inputchan chan InputPacket
 	keyexist  map[Key]bool
 	keycodes  map[string]*tKeyCode
 	cx        int
@@ -100,6 +101,12 @@ type tScreen struct {
 	buttondn  bool
 
 	sync.Mutex
+}
+
+type InputPacket struct {
+	n     int
+	e     error
+	chunk []byte
 }
 
 func (t *tScreen) Init() error {
@@ -386,6 +393,7 @@ func (t *tScreen) Fini() {
 	t.curstyle = Style(-1)
 	t.clear = false
 	t.fini = true
+	close(t.inputchan)
 	t.Unlock()
 
 	if t.quit != nil {
@@ -1235,9 +1243,16 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 }
 
 func (t *tScreen) inputLoop() {
+	t.inputchan = make(chan InputPacket)
 	buf := &bytes.Buffer{}
 
-	chunk := make([]byte, 128)
+	go func() {
+		chunk := make([]byte, 128)
+		for {
+			n, e := t.in.Read(chunk)
+			t.inputchan <- InputPacket{n, e, chunk}
+		}
+	}()
 	for {
 		select {
 		case <-t.quit:
@@ -1254,7 +1269,14 @@ func (t *tScreen) inputLoop() {
 			continue
 		default:
 		}
-		n, e := t.in.Read(chunk)
+
+		in, ok := <-t.inputchan
+		if !ok {
+			close(t.indoneq)
+			return
+		}
+		n, e, chunk := in.n, in.e, in.chunk
+
 		switch e {
 		case io.EOF:
 			// If we timeout waiting for more bytes, then it's

--- a/tscreen_bsd.go
+++ b/tscreen_bsd.go
@@ -66,8 +66,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	ioc = uintptr(syscall.TIOCSETA)
@@ -106,9 +106,6 @@ func (t *tScreen) termioFini() {
 		tios := uintptr(unsafe.Pointer(t.tiosp))
 		syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0)
 		t.out.Close()
-	}
-	if t.in != nil {
-		t.in.Close()
 	}
 }
 

--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -66,8 +66,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	// Well this kind of sucks, because we don't have TCSETSF, but only
@@ -109,9 +109,6 @@ func (t *tScreen) termioFini() {
 		tios := uintptr(unsafe.Pointer(t.tiosp))
 		syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0)
 		t.out.Close()
-	}
-	if t.in != nil {
-		t.in.Close()
 	}
 }
 

--- a/tscreen_posix.go
+++ b/tscreen_posix.go
@@ -157,8 +157,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.c_cc[C.VMIN] = 0
-	newtios.c_cc[C.VTIME] = 1
+	newtios.c_cc[C.VMIN] = 1
+	newtios.c_cc[C.VTIME] = 0
 
 	if rv, e = C.tcsetattr(fd, C.TCSANOW|C.TCSAFLUSH, &newtios); rv != 0 {
 		goto failed
@@ -192,9 +192,6 @@ func (t *tScreen) termioFini() {
 		fd := C.int(t.out.Fd())
 		C.tcsetattr(fd, C.TCSANOW|C.TCSAFLUSH, &t.tiosp.tios)
 		t.out.Close()
-	}
-	if t.in != nil {
-		t.in.Close()
 	}
 }
 


### PR DESCRIPTION
This PR should fix #129.

The way I fixed this is a bit of a hack but I think it works just fine. I changed `VTIME` to 0 and `VMIN` to 1, but that causes the `t.in.Read(chunk)` call to block which in turn causes `<-indoneq` to block or `t.in.Close()` to block. So I put the `Read()` call in a separate goroutine which communicates to the normal input loop with a channel. When `Fini()` is called, the channel is closed causing `inputLoop()` to return instead of hanging.

I also had to get rid of the `Close()` call on `t.in` (because it would block while `Read()` blocks) which is less than ideal but I don't think it actually causes any problems because `t.in` is read-only and the program terminates right afterwards.

Also tcell now closes immediately instead of waiting 1/10th of a second.

Let me know what you think/if I created more problems than I fixed.
