### PR TITLE
Proposal fix for #129

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1261,9 +1261,6 @@ func (t *tScreen) inputLoop() {
 					chunkChan <- chunkInfo{chunk[:0], err} // unexpected error
 					return
 				}
-				//if n != 128 {
-				//	time.Sleep(5 * time.Millisecond)
-				//}
 			}
 		}
 	}()

--- a/tscreen_bsd.go
+++ b/tscreen_bsd.go
@@ -66,8 +66,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	ioc = uintptr(syscall.TIOCSETA)

--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -66,8 +66,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	// Well this kind of sucks, because we don't have TCSETSF, but only

--- a/tscreen_posix.go
+++ b/tscreen_posix.go
@@ -157,8 +157,8 @@ func (t *tScreen) termioInit() error {
 	// close file descriptors on systems like Darwin, where close does
 	// cause a wakeup.  (Probably we could reasonably increase this to
 	// something like 1 sec or 500 msec.)
-	newtios.c_cc[C.VMIN] = 0
-	newtios.c_cc[C.VTIME] = 1
+	newtios.c_cc[C.VMIN] = 1
+	newtios.c_cc[C.VTIME] = 0
 
 	if rv, e = C.tcsetattr(fd, C.TCSANOW|C.TCSAFLUSH, &newtios); rv != 0 {
 		goto failed


### PR DESCRIPTION
This uses non blocking reads and provide a quit mechanism.

In my testing (OSX only) it provides:
- Much lower energy use (no constant IDLE_WAKE)
- Closing the program does not incur a delay as in the other proposal.

@gdamore  Let me know if that seems ok, feel free to modify or reuse as you see fit.