### PR TITLE
add support for bracketed paste

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Garrett D'Amore <garrett@damore.org>
 Zachary Yedidia <zyedidia@gmail.com>
+Junegunn Choi <junegunn.c@gmail.com>

--- a/encoding.go
+++ b/encoding.go
@@ -46,7 +46,7 @@ var encodingFallback EncodingFallback = EncodingFallbackFail
 // Aliases can be registered as well, for example "8859-15" could be an alias
 // for "ISO8859-15".
 //
-// For POSIX systems, the tcell pacakge will check the environment variables
+// For POSIX systems, the tcell package will check the environment variables
 // LC_ALL, LC_CTYPE,  and LANG (in that order) to determine the character set.
 // These are expected to have the following pattern:
 //

--- a/key.go
+++ b/key.go
@@ -371,6 +371,8 @@ const (
 	KeyF62
 	KeyF63
 	KeyF64
+	KeyPasteBegin
+	KeyPasteEnd
 )
 
 // These are the control keys.  Note that they overlap with other keys,

--- a/mkinfo.go
+++ b/mkinfo.go
@@ -93,8 +93,8 @@ func setupterm(name string) error {
 	}
 	plist = append(plist, "")
 	rsn := C.int(0)
-	
-	for _, p := range(plist) {
+
+	for _, p := range plist {
 		// Override environment
 		if p == "" {
 			os.Unsetenv("TERMINFO")
@@ -145,7 +145,7 @@ func getinfo(name string) (*tcell.Terminfo, error) {
 		if strings.HasSuffix(name, "-truecolor") {
 			base := name[:len(name)-len("-truecolor")]
 			// Probably -256color is closest to what we want
-			if err = setupterm(base+"-256color"); err != nil {
+			if err = setupterm(base + "-256color"); err != nil {
 				err = setupterm(base)
 			}
 			if err == nil {
@@ -638,7 +638,7 @@ func main() {
 			}
 		} else {
 			tdata[t.Name] = t
-			if t2, e := getinfo(term+"-256color"); e == nil {
+			if t2, e := getinfo(term + "-256color"); e == nil {
 				tdata[t2.Name] = t2
 			}
 		}

--- a/paste.go
+++ b/paste.go
@@ -1,0 +1,38 @@
+package tcell
+
+import "time"
+
+const (
+	PasteBegin = "\x1b[200~"
+	PasteEnd   = "\x1b[201~"
+)
+
+type EventKeyPasteBegin struct {
+	t time.Time
+}
+
+var _ Event = (*EventKeyPasteBegin)(nil)
+
+// When returns the time when this EventKeyPasteBegin was created.
+func (ev *EventKeyPasteBegin) When() time.Time {
+	return ev.t
+}
+
+func NewEventKeyPasteBegin() *EventKeyPasteBegin {
+	return &EventKeyPasteBegin{t: time.Now()}
+}
+
+type EventKeyPasteEnd struct {
+	t time.Time
+}
+
+var _ Event = (*EventKeyPasteEnd)(nil)
+
+// When returns the time when this EventKeyPasteEnd was created.
+func (ev *EventKeyPasteEnd) When() time.Time {
+	return ev.t
+}
+
+func NewEventKeyPasteEnd() *EventKeyPasteEnd {
+	return &EventKeyPasteEnd{t: time.Now()}
+}

--- a/screen.go
+++ b/screen.go
@@ -133,7 +133,7 @@ type Screen interface {
 	Sync()
 
 	// CharacterSet returns information about the character set.
-	// This isn't the full locale, but it does give us the input/ouput
+	// This isn't the full locale, but it does give us the input/output
 	// character set.  Note that this is just for diagnostic purposes,
 	// we normally translate input/output to/from UTF-8, regardless of
 	// what the user's environment is.

--- a/simulation.go
+++ b/simulation.go
@@ -417,7 +417,7 @@ outer:
 		continue
 	}
 
-	return failed == false
+	return !failed
 }
 
 func (s *simscreen) Sync() {

--- a/terminfo.go
+++ b/terminfo.go
@@ -725,7 +725,7 @@ func loadFromFile(fname string, term string) (*Terminfo, error) {
 	}
 }
 
-// LookupTerminfo attemps to find a definition for the named $TERM.
+// LookupTerminfo attempts to find a definition for the named $TERM.
 // It first looks in the builtin database, which should cover just about
 // everyone.  If it can't find one there, then it will attempt to read
 // one from the JSON file located in either $TCELLDB, $HOME/.tcelldb

--- a/tscreen.go
+++ b/tscreen.go
@@ -487,7 +487,7 @@ func (t *tScreen) sendFgBg(fg Color, bg Color) {
 					int(r), int(g), int(b)))
 			}
 			if bg != ColorDefault && ti.SetBgRGB != "" {
-				r, g, b := fg.RGB()
+				r, g, b := bg.RGB()
 				t.TPuts(ti.TParm(ti.SetBgRGB,
 					int(r), int(g), int(b)))
 			}


### PR DESCRIPTION
Attempting to resolve #120 
Does not support windows yet, but shouldn't be too hard to define a separate `paste.go` file for windows with the correct event information.