### PR TITLE
Adding Widget Resize to BoxLayout function

### DIFF
--- a/views/boxlayout.go
+++ b/views/boxlayout.go
@@ -99,6 +99,7 @@ func (b *BoxLayout) hLayout() {
 		cw += c.pad
 
 		c.view.Resize(x, y, cw, h)
+		c.widget.Resize()
 		x += xinc
 	}
 }
@@ -162,6 +163,7 @@ func (b *BoxLayout) vLayout() {
 		yinc = ch + c.pad
 		ch += c.pad
 		c.view.Resize(x, y, w, ch)
+		c.widget.Resize()
 		y += yinc
 	}
 }


### PR DESCRIPTION
- Widget might be using not just View but other mechanisms for rendering
  aware of the view size (e.g. `ViewPort`).
- By using the view reference out of the `Widget`, `Widget` doesn't have a
  chance to react on this layout algorithm
- That's an existing bug that happens when we try to use `CellView` inside
  of an `BoxLayout`