### PR TITLE
Make keyNames variable public

### DIFF
--- a/key.go
+++ b/key.go
@@ -78,6 +78,8 @@ func (ev *EventKey) Modifiers() ModMask {
 	return ev.mod
 }
 
+// KeyNames holds the written names of special keys. Useful to echo back a key
+// name, or to look up a key from a string value.
 var KeyNames = map[Key]string{
 	KeyEnter:          "Enter",
 	KeyBackspace:      "Backspace",

--- a/key.go
+++ b/key.go
@@ -78,7 +78,7 @@ func (ev *EventKey) Modifiers() ModMask {
 	return ev.mod
 }
 
-var keyNames = map[Key]string{
+var KeyNames = map[Key]string{
 	KeyEnter:          "Enter",
 	KeyBackspace:      "Backspace",
 	KeyTab:            "Tab",
@@ -218,7 +218,7 @@ func (ev *EventKey) Name() string {
 	}
 
 	ok := false
-	if s, ok = keyNames[ev.key]; !ok {
+	if s, ok = KeyNames[ev.key]; !ok {
 		if ev.key == KeyRune {
 			s = "Rune[" + string(ev.ch) + "]"
 		} else {


### PR DESCRIPTION
This map of variables might be useful to applications wanting to convert text to keys, e.g. for key bindings.