### PR TITLE
mkdatabase.sh: Use sh instead of ksh

### DIFF
--- a/mkdatabase.sh
+++ b/mkdatabase.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/bin/sh
 
 # Copyright 2015 The TCell Authors
 #

--- a/mkdatabase.sh
+++ b/mkdatabase.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/dash
 
 # Copyright 2015 The TCell Authors
 #


### PR DESCRIPTION
Not everyone has ksh, but everyone has dash or bash symlinked to sh.