### PR TITLE
Document and publish color names and RGB values.

### DIFF
--- a/color.go
+++ b/color.go
@@ -976,7 +976,7 @@ func (c Color) Hex() int32 {
 	if c&ColorIsRGB != 0 {
 		return (int32(c) & 0xffffff)
 	}
-	if v, ok := colorValues[c]; ok {
+	if v, ok := ColorValues[c]; ok {
 		return v
 	}
 	return -1
@@ -1007,7 +1007,7 @@ func NewHexColor(v int32) Color {
 // GetColor creates a Color from a color name (W3C name). A hex value may
 // be supplied as a string in the format "#ffffff".
 func GetColor(name string) Color {
-	if c, ok := colorNames[name]; ok {
+	if c, ok := ColorNames[name]; ok {
 		return c
 	}
 	if len(name) == 7 && name[0] == '#' {

--- a/color.go
+++ b/color.go
@@ -435,7 +435,8 @@ const (
 	ColorSlateGrey      = ColorSlateGray
 )
 
-var colorValues = map[Color]int32{
+// ColorValues maps color constants to their RGB values.
+var ColorValues = map[Color]int32{
 	ColorBlack:                0x000000,
 	ColorMaroon:               0x800000,
 	ColorGreen:                0x008000,
@@ -817,7 +818,9 @@ var colorValues = map[Color]int32{
 	ColorYellowGreen:          0x9ACD32,
 }
 
-var colorNames = map[string]Color{
+// ColorNames holds the written names of colors. Useful to present a list of
+// recognized named colors.
+var ColorNames = map[string]Color{
 	"black":                ColorBlack,
 	"maroon":               ColorMaroon,
 	"green":                ColorGreen,


### PR DESCRIPTION
This patch makes `ColorNames` and `ColorValues` public, and adds documentation. I am unsure about the origin of the names, maybe someone else can shed some light on this?

The variables can be useful when implementing help screens or tab completion in programs which have configurable colors.