### PR TITLE
viewport: truncate size to area avaiable in parent

### DIFF
--- a/views/boxlayout.go
+++ b/views/boxlayout.go
@@ -289,11 +289,15 @@ func (b *BoxLayout) InsertWidget(index int, widget Widget, fill float64) {
 
 // RemoveWidget removes a Widget from the layout.
 func (b *BoxLayout) RemoveWidget(widget Widget) {
+	changed := false
 	for i := 0; i < len(b.cells); i++ {
 		if b.cells[i].widget == widget {
 			b.cells = append(b.cells[:i], b.cells[i+1:]...)
-			return
+			changed = true
 		}
+	}
+	if !changed {
+		return
 	}
 	b.changed = true
 	widget.Unwatch(b)

--- a/views/view.go
+++ b/views/view.go
@@ -265,18 +265,15 @@ func (v *ViewPort) Resize(x, y, width, height int) {
 	if y >= 0 && y < py {
 		v.physy = y
 	}
-	if width < 0 {
+	if width < 0 || width > px-x {
 		width = px - x
 	}
-	if height < 0 {
+	if height < 0 || height > py-y {
 		height = py - y
 	}
-	if width <= x+px {
-		v.width = width
-	}
-	if height <= y+py {
-		v.height = height
-	}
+
+	v.width = width
+	v.height = height
 }
 
 // SetView is called during setup, to provide the parent View.


### PR DESCRIPTION
Constrain viewport visible dimensions to fit within the parent view (`width = min(width,px-x)`).  Currently can overflow (`width > px && width < x+px`) or ignore the requested value (`width > x+px`)