### PR TITLE
Fix idle wakeup problem (second attempt)

### DIFF
--- a/tscreen_darwin.go
+++ b/tscreen_darwin.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build darwin freebsd netbsd openbsd dragonfly
 
 // Copyright 2015 The TCell Authors
 //
@@ -17,10 +17,11 @@
 package tcell
 
 import (
-	"os"
 	"os/signal"
 	"syscall"
 	"unsafe"
+
+	"github.com/zyedidia/poller"
 )
 
 type termiosPrivate syscall.Termios
@@ -33,23 +34,23 @@ func (t *tScreen) termioInit() error {
 	var ioc uintptr
 	t.tiosp = &termiosPrivate{}
 
-	if t.in, e = os.OpenFile("/dev/tty", os.O_RDONLY, 0); e != nil {
+	if t.in, e = poller.Open("/dev/tty", poller.O_RO); e != nil {
 		goto failed
 	}
-	if t.out, e = os.OpenFile("/dev/tty", os.O_WRONLY, 0); e != nil {
+	if t.out, e = poller.Open("/dev/tty", poller.O_WO); e != nil {
 		goto failed
 	}
 
 	tios = uintptr(unsafe.Pointer(t.tiosp))
-	ioc = uintptr(syscall.TCGETS)
-	fd = uintptr(t.out.(*os.File).Fd())
+	ioc = uintptr(syscall.TIOCGETA)
+	fd = uintptr(t.out.(*poller.FD).Sysfd())
 	if _, _, e1 := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0); e1 != 0 {
 		e = e1
 		goto failed
 	}
 
-	// On this platform, the baud rate is stored
-	// directly as an integer in termios.c_ospeed.
+	// On this platform (FreeBSD and family), the baud rate is stored
+	// directly as an integer in termios.c_ospeed.  No bitmasking required.
 	t.baud = int(t.tiosp.Ospeed)
 	newtios = *t.tiosp
 	newtios.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK |
@@ -66,9 +67,7 @@ func (t *tScreen) termioInit() error {
 	newtios.Cc[syscall.VTIME] = 0
 	tios = uintptr(unsafe.Pointer(&newtios))
 
-	// Well this kind of sucks, because we don't have TCSETSF, but only
-	// TCSETS.  This can leave some output unflushed.
-	ioc = uintptr(syscall.TCSETS)
+	ioc = uintptr(syscall.TIOCSETA)
 	if _, _, e1 := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0); e1 != 0 {
 		e = e1
 		goto failed
@@ -84,10 +83,10 @@ func (t *tScreen) termioInit() error {
 
 failed:
 	if t.in != nil {
-		t.in.(*os.File).Close()
+		t.in.(*poller.FD).Close()
 	}
 	if t.out != nil {
-		t.out.(*os.File).Close()
+		t.out.(*poller.FD).Close()
 	}
 	return e
 }
@@ -97,21 +96,20 @@ func (t *tScreen) termioFini() {
 	signal.Stop(t.sigwinch)
 
 	if t.out != nil {
-		fd := uintptr(t.out.(*os.File).Fd())
-		// XXX: We'd really rather do TCSETSF here!
-		ioc := uintptr(syscall.TCSETS)
+		fd := uintptr(t.out.(*poller.FD).Sysfd())
+		ioc := uintptr(syscall.TIOCSETAF)
 		tios := uintptr(unsafe.Pointer(t.tiosp))
 		syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0)
-		t.out.(*os.File).Close()
+		t.out.(*poller.FD).Close()
 	}
 	if t.in != nil {
-		t.in.(*os.File).Close()
+		t.in.(*poller.FD).Close()
 	}
 }
 
 func (t *tScreen) getWinSize() (int, int, error) {
 
-	fd := uintptr(t.out.(*os.File).Fd())
+	fd := uintptr(t.out.(*poller.FD).Sysfd())
 	dim := [4]uint16{}
 	dimp := uintptr(unsafe.Pointer(&dim))
 	ioc := uintptr(syscall.TIOCGWINSZ)


### PR DESCRIPTION
I found this package: https://github.com/npat-efault/poller which seems to use poll in some way to fix the issue on MacOS that we were having with the Close and Read.

For example, this code works as expected:

```go
package main

import (
    "fmt"
    "os"
    "time"

    "github.com/npat-efault/poller"
)

func main() {
    f, e := poller.Open("/dev/tty", poller.O_RW)
    if e != nil {
        fmt.Println("Cannot open /dev/tty:", e)
        os.Exit(1)
    }

    go func() {
        time.Sleep(time.Second * 4)
        fmt.Println("Closing...")
        f.Close()
        fmt.Println("Close finished")
    }()

    data := make([]byte, 128)

    for {
        n, e := f.Read(data)
        if e != nil {
            fmt.Println("Error: ", e)
            return
        }
        fmt.Println("Got", n, "bytes")
    }
}
```

The original library used some cgo on all systems other than Linux, so I have made a fork and removed the need for cgo (fork at https://github.com/zyedidia/poller).

Since it appears that this problem only occurs on Mac, the implementations for Linux, bsd... do not use this library (perhaps bsd is buggy? I have only been able to test on MacOS and Linux -- edit: I tested on FreeBSD and it did not exhibit the bug that MacOS does). The poller is only used on Mac so now darwin should get its own tscreen file. 

I have also set `VTIME=0` and `VMIN=1` so that tcell doesn't wake up unless there is data to read.

I removed the whole `indoneq` channel because it was just blocking (I think it was used for syncing the wakeup with the close?) and didn't seem to be of any use.

I also encountered a problem with the Alt keys after this change -- they were only responding on the next keypress. But if `expire` was always true then it worked well, so I effectively always made `expire` true by removing that if statement.

Let me know if you see any problems. I think this is a pretty good solution because it allows restarting the library during the program. Tcell in general is also a little snappier as a result (there is no 1/10th second delay when quitting or when use Alt keys).

Ref #129 