### PR TITLE
fixes #129 Very high IDLE_WAKE - Power consumption

### DIFF
--- a/tscreen_bsd.go
+++ b/tscreen_bsd.go
@@ -1,6 +1,6 @@
 // +build darwin freebsd netbsd openbsd dragonfly
 
-// Copyright 2015 The TCell Authors
+// Copyright 2017 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -61,13 +61,6 @@ func (t *tScreen) termioInit() error {
 	newtios.Cflag &^= syscall.CSIZE | syscall.PARENB
 	newtios.Cflag |= syscall.CS8
 
-	// We wake up at the earliest of 100 msec or when data is received.
-	// We need to wake up frequently to permit us to exit cleanly and
-	// close file descriptors on systems like Darwin, where close does
-	// cause a wakeup.  (Probably we could reasonably increase this to
-	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	ioc = uintptr(syscall.TIOCSETA)

--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-// Copyright 2015 The TCell Authors
+// Copyright 2017 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -61,13 +61,13 @@ func (t *tScreen) termioInit() error {
 	newtios.Cflag &^= syscall.CSIZE | syscall.PARENB
 	newtios.Cflag |= syscall.CS8
 
-	// We wake up at the earliest of 100 msec or when data is received.
-	// We need to wake up frequently to permit us to exit cleanly and
-	// close file descriptors on systems like Darwin, where close does
-	// cause a wakeup.  (Probably we could reasonably increase this to
-	// something like 1 sec or 500 msec.)
-	newtios.Cc[syscall.VMIN] = 0
-	newtios.Cc[syscall.VTIME] = 1
+	// This is setup for blocking reads.  In the past we attempted to
+	// use non-blocking reads, but now a separate input loop and timer
+	// copes with the problems we had on some systems (BSD/Darwin)
+	// where close hung forever.
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
+
 	tios = uintptr(unsafe.Pointer(&newtios))
 
 	// Well this kind of sucks, because we don't have TCSETSF, but only

--- a/tscreen_posix.go
+++ b/tscreen_posix.go
@@ -1,6 +1,6 @@
 // +build solaris
 
-// Copyright 2015 The TCell Authors
+// Copyright 2017 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -152,13 +152,12 @@ func (t *tScreen) termioInit() error {
 	newtios.c_cflag &^= C.CSIZE | C.PARENB
 	newtios.c_cflag |= C.CS8
 
-	// We wake up at the earliest of 100 msec or when data is received.
-	// We need to wake up frequently to permit us to exit cleanly and
-	// close file descriptors on systems like Darwin, where close does
-	// cause a wakeup.  (Probably we could reasonably increase this to
-	// something like 1 sec or 500 msec.)
-	newtios.c_cc[C.VMIN] = 0
-	newtios.c_cc[C.VTIME] = 1
+	// This is setup for blocking reads.  In the past we attempted to
+	// use non-blocking reads, but now a separate input loop and timer
+	// copes with the problems we had on some systems (BSD/Darwin)
+	// where close hung forever.
+	newtios.Cc[syscall.VMIN] = 1
+	newtios.Cc[syscall.VTIME] = 0
 
 	if rv, e = C.tcsetattr(fd, C.TCSANOW|C.TCSAFLUSH, &newtios); rv != 0 {
 		goto failed


### PR DESCRIPTION
fixes #164 KeyEscape does not work in Go 1.9 under Linux

This is a complete refactor of the input loop for UNIX systems.
We use a blocking reader on the TTY, and a separate select
loop for timers and other events.  This means that our idle
use should be low now.