### PR TITLE
Parse terminfo values containing numbers expressed in octal syntax.

### DIFF
--- a/terminfo/mkinfo.go
+++ b/terminfo/mkinfo.go
@@ -101,8 +101,13 @@ func unescape(s string) string {
 			switch c {
 			case 'E', 'e':
 				buf.WriteByte(0x1b)
-			case '0':
-				buf.WriteByte(0)
+			case '0', '1', '2', '3', '4', '5', '6', '7':
+				if i+2 < len(s) && s[i+1] >= '0' && s[i+1] <= '7' && s[i+2] >= '0' && s[i+2] <= '7' {
+					buf.WriteByte(((c - '0') * 64) + ((s[i+1] - '0') * 8) + (s[i+2] - '0'))
+					i = i + 2
+				} else if c == '0' {
+					buf.WriteByte(0)
+				}
 			case 'n':
 				buf.WriteByte('\n')
 			case 'r':

--- a/terminfo/term_screen.go
+++ b/terminfo/term_screen.go
@@ -15,7 +15,7 @@ func init() {
 		ExitCA:       "\x1b[?1049l",
 		ShowCursor:   "\x1b[34h\x1b[?25h",
 		HideCursor:   "\x1b[?25l",
-		AttrOff:      "\x1b[m\x0017",
+		AttrOff:      "\x1b[m\x0f",
 		Underline:    "\x1b[4m",
 		Bold:         "\x1b[1m",
 		Blink:        "\x1b[5m",

--- a/terminfo/term_screen_256color.go
+++ b/terminfo/term_screen_256color.go
@@ -15,7 +15,7 @@ func init() {
 		ExitCA:       "\x1b[?1049l",
 		ShowCursor:   "\x1b[34h\x1b[?25h",
 		HideCursor:   "\x1b[?25l",
-		AttrOff:      "\x1b[m\x0017",
+		AttrOff:      "\x1b[m\x0f",
 		Underline:    "\x1b[4m",
 		Bold:         "\x1b[1m",
 		Blink:        "\x1b[5m",


### PR DESCRIPTION
I noticed that when running a tcell application under tmux using
TERM=screen-256color, some text rendered with style attributes
like bold and underline appeared preceded with "17". This seemed
to come from tcell sending "AttrOff"/sgr0, which in
term_screen_256color.go looks like:

AttrOff:      "\x1b[m\x0017"

infocmp screen-256color expresses sgr0 like this:

sgr0=\E[m\017

This terminfo man page implies that \017 should be interpreted as
the octal representation of 15 decimal.

https://www.mkssoftware.com/docs/man5/terminfo.5.asp

The terminfo generator mkinfo.go parses the \0 as a zero, then
the following 17 as the digits 1 and 7. This patch modifies
mkinfo.go and results in the following instead

AttrOff:      "\x1b[m\x0f"

This seems to clear up the "17" problem for me. But I am not a
terminal expert by any means, so perhaps my interpretation is
incorrect!