### PR TITLE
fix #172, don't crash on empty name string on call to LookupTerminfo

### DIFF
--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -756,6 +756,12 @@ func loadFromFile(fname string, term string) (*Terminfo, error) {
 // one from the JSON file located in either $TCELLDB, $HOME/.tcelldb
 // or in this package's source directory as database.json).
 func LookupTerminfo(name string) (*Terminfo, error) {
+	if name == "" {
+		// else on windows: index out of bounds
+		// on the name[0] reference below
+		return nil, ErrTermNotFound
+	}
+
 	dblock.Lock()
 	t := terminfos[name]
 	dblock.Unlock()


### PR DESCRIPTION
On Windows 10, LookupTerminfo(name string) in terminfo.go was getting passed an empty string, then crashing on name[0] being out of bounds.