### PR TITLE
Do What It Takes ™ To Get More Colors

### DIFF
--- a/terminfo/mkinfo.go
+++ b/terminfo/mkinfo.go
@@ -225,6 +225,11 @@ func getinfo(name string) (*terminfo.Terminfo, string, error) {
 			return nil, "", err
 		}
 	}
+
+	if !addTrueColor && tc.getstr("Tc") != "" {
+		addTrueColor = true
+	}
+
 	t := &terminfo.Terminfo{}
 	// If this is an alias record, then just emit the alias
 	t.Name = tc.name


### PR DESCRIPTION
Some logic, and further TODO notes borrowed from neovim:
- here's their docs: https://github.com/neovim/neovim/blob/master/runtime/doc/term.txt#L125
- here's the more conservative choices vim 8 made: https://github.com/vim/vim/blob/master/runtime/doc/term.txt#L482
- and here's the full depth of What It Takes ™ for neovim to implement that documentation: https://github.com/neovim/neovim/blob/master/src/nvim/tui/tui.c#L1614

Experimentally on my systems (tmux inside xfce-terminal (( a libvte terminal )), and tmux inside iTerm2) `COLORTERM=truecolor` was set. So I've left the `$TERM_PROGRAM` and `$VTE_VERSION` heuristics out for discussion.

I've not yet gotten a chance to rebuild the terminfo database (developed this PR on a Mac, and didn't take the time to setup a Linux docker image ...) to see how effective the `Tc` logic is under mkinfo.