### PR TITLE
Fix panic when quit chan is double closed

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -383,8 +383,10 @@ outer:
 }
 
 func (t *tScreen) Fini() {
-	ti := t.ti
 	t.Lock()
+	defer t.Unlock()
+	
+	ti := t.ti	
 	t.cells.Resize(0, 0)
 	t.TPuts(ti.ShowCursor)
 	t.TPuts(ti.AttrOff)
@@ -395,11 +397,12 @@ func (t *tScreen) Fini() {
 	t.curstyle = Style(-1)
 	t.clear = false
 	t.fini = true
-	t.Unlock()
 
 	if t.quit != nil {
 		close(t.quit)
+		t.quit = nil
 	}
+	
 	t.termioFini()
 }
 


### PR DESCRIPTION
I've been experiencing  panics occasionally/randomly on this `close(t.quit)` for double closes.

The changes seem to fix some of the obscure panics.