### PR TITLE
Fix data race in tScreen shutdown

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -398,9 +398,12 @@ func (t *tScreen) Fini() {
 	t.clear = false
 	t.fini = true
 
-	if t.quit != nil {
+	select {
+	case <-t.quit:
+		// do nothing, already closed
+
+	default:
 		close(t.quit)
-		t.quit = nil
 	}
 	
 	t.termioFini()


### PR DESCRIPTION
Setting t.quit to nil while the mainLoop is running causes a race condition when the Fini() method is called. This change instead never sets the `t.quit` channel to nil, instead using a select expression with a default to guard against closing the channel twice.

Original `-race` output:

```
==================
WARNING: DATA RACE
Write at 0x00c420426218 by goroutine 23:
github.com/gdamore/tcell.(*tScreen).Fini()
/Users/tylersommer/go/src/github.com/gdamore/tcell/tscreen.go:403 +0x322
github.com/rivo/tview.(*Application).Stop()
/Users/tylersommer/go/src/github.com/rivo/tview/application.go:179 +0xb2
github.com/rivo/tview.(*Application).Run()
/Users/tylersommer/go/src/github.com/rivo/tview/application.go:148 +0x4a3
github.com/motki/cli/command.InventoryV2Command.Handle()
/Users/tylersommer/go/src/github.com/motki/cli/command/inventory_v2.go:471 +0x20ac
github.com/motki/cli/command.(*InventoryV2Command).Handle()
<autogenerated>:1 +0xbc
github.com/motki/cli.(*Server).LoopCLI.func1()
/Users/tylersommer/go/src/github.com/motki/cli/cli.go:144 +0x53b
github.com/motki/cli.(*Server).LoopCLI()
/Users/tylersommer/go/src/github.com/motki/cli/cli.go:150 +0x135
github.com/motki/cli/app.(*CLIEnv).LoopCLI()
/Users/tylersommer/go/src/github.com/motki/cli/app/cli.go:130 +0x52

Previous read at 0x00c420426218 by goroutine 67:
github.com/gdamore/tcell.(*tScreen).mainLoop()
/Users/tylersommer/go/src/github.com/gdamore/tcell/tscreen.go:1253 +0xbb

Goroutine 23 (running) created at:
main.main()
/Users/tylersommer/go/src/github.com/motki/cli/cmd/motki/main.go:104 +0x61f

Goroutine 67 (finished) created at:
github.com/gdamore/tcell.(*tScreen).Init()
/Users/tylersommer/go/src/github.com/gdamore/tcell/tscreen.go:175 +0xa4f
github.com/rivo/tview.(*Application).Run()
/Users/tylersommer/go/src/github.com/rivo/tview/application.go:85 +0x117
github.com/motki/cli/command.InventoryV2Command.Handle()
/Users/tylersommer/go/src/github.com/motki/cli/command/inventory_v2.go:471 +0x20ac
github.com/motki/cli/command.(*InventoryV2Command).Handle()
<autogenerated>:1 +0xbc
github.com/motki/cli.(*Server).LoopCLI.func1()
/Users/tylersommer/go/src/github.com/motki/cli/cli.go:144 +0x53b
github.com/motki/cli.(*Server).LoopCLI()
/Users/tylersommer/go/src/github.com/motki/cli/cli.go:150 +0x135
github.com/motki/cli/app.(*CLIEnv).LoopCLI()
/Users/tylersommer/go/src/github.com/motki/cli/app/cli.go:130 +0x52
==================
```