### PR TITLE
Initialize quit chan of simscreen so that PollEvent returns nil when Fini called

### DIFF
--- a/simulation.go
+++ b/simulation.go
@@ -109,6 +109,7 @@ type simscreen struct {
 
 func (s *simscreen) Init() error {
 	s.evch = make(chan Event, 10)
+	s.quit = make(chan struct{})
 	s.fillchar = 'X'
 	s.fillstyle = StyleDefault
 	s.mouse = false


### PR DESCRIPTION
This pull request fixes SimulationScreen to ensure that PollEvent returns nil when simscreen#Fini is called.