### PR TITLE
disable QuickEdit Mode on EnableMouse() in Win10

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -183,7 +183,7 @@ func (s *cScreen) CharacterSet() string {
 }
 
 func (s *cScreen) EnableMouse() {
-	s.setInMode(modeResizeEn | modeMouseEn)
+	s.setInMode(modeResizeEn | modeMouseEn | modeExtndFlg)
 }
 
 func (s *cScreen) DisableMouse() {
@@ -926,6 +926,7 @@ func (s *cScreen) clearScreen(style Style) {
 }
 
 const (
+	modeExtndFlg uint32 = 0x0080
 	modeMouseEn  uint32 = 0x0010
 	modeResizeEn uint32 = 0x0008
 	modeWrapEOL  uint32 = 0x0002


### PR DESCRIPTION
As discussed in issue #182, no mouse events can be accepted as long as the console is in QuickEdit mode. According to the documentation of SetConsoleMode, the Quick Edit mode can be deactivated if the flag ENABLE_EXTENDED_FLAGS is passed without the flag ENABLE_QUICK_EDIT_MODE.
See the explanation of the flag ENABLE_QUICK_EDIT_MODE in the documentation:
https://docs.microsoft.com/en-us/windows/console/setconsolemode