### PR TITLE
An attempt to speed up tcell screen rendering.

### DIFF
--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -616,28 +616,27 @@ func (t *Terminfo) TParm(s string, p ...int) string {
 	return pb.End()
 }
 
-// InterpretDelays translates the input string by expanding inline padding
-// indications (of the form $<[delay]> where [delay] is msec) to a suitable
-// number of padding characters (usually null bytes) based upon the supplied
-// baud.  At high baud rates, more padding characters will be inserted. This
-// function is used by TPuts() to make strings suitable for sending to the
-// terminal.
-func (t *Terminfo) InterpretDelays(s string, baud int) string {
-	var res bytes.Buffer
+// TPuts emits the string to the writer, but expands inline padding
+// indications (of the form $<[delay]> where [delay] is msec) to
+// a suitable number of padding characters (usually null bytes) based
+// upon the supplied baud.  At high baud rates, more padding characters
+// will be inserted.  All Terminfo based strings should be emitted using
+// this function.
+func (t *Terminfo) TPuts(w io.Writer, s string, baud int) {
 	for {
 		beg := strings.Index(s, "$<")
 		if beg < 0 {
 			// Most strings don't need padding, which is good news!
-			res.WriteString(s)
-			return res.String()
+			io.WriteString(w, s)
+			return
 		}
-		res.WriteString(s[:beg])
+		io.WriteString(w, s[:beg])
 		s = s[beg+2:]
 		end := strings.Index(s, ">")
 		if end < 0 {
 			// unterminated.. just emit bytes unadulterated
-			res.WriteString("$<" + s)
-			return res.String()
+			io.WriteString(w, "$<"+s)
+			return
 		}
 		val := s[:end]
 		s = s[end+1:]
@@ -665,18 +664,10 @@ func (t *Terminfo) InterpretDelays(s string, baud int) string {
 		}
 		cnt := int(((baud / 8) * padus) / unit)
 		for cnt > 0 {
-			res.WriteString(t.PadChar)
+			io.WriteString(w, t.PadChar)
 			cnt--
 		}
 	}
-}
-
-// TPuts emits the string to the writer, but expands inline padding
-// indications using InterpretDelays().  All Terminfo based strings should be
-// emitted using this function.
-func (t *Terminfo) TPuts(w io.Writer, s string, baud int) {
-	output := t.InterpretDelays(s, baud)
-	io.WriteString(w, output)
 }
 
 // TGoto returns a string suitable for addressing the cursor at the given


### PR DESCRIPTION
I've noticed that my tcell applications can be quite slow updating the screen
over an ssh connection, especially compared to frameworks like
urwid. Debugging with strace showed that each cell was written to the terminal
interleaved with calls to epoll_pwait() e.g. here rendering two bytes, chosen
randomly from my strace capture:

9874  22:56:10.508632 write(5, "f", 1)  = 1
9871  22:56:10.508654 <... epoll_pwait resumed> [{EPOLLOUT, {u32=754322992, u64=139801939807792}}, {EPOLLOUT, {u32=754323200, u64=139801939808000}}], 128, -1, NULL, 3) = 2
9871  22:56:10.508674 epoll_pwait(4,  <unfinished ...>
9874  22:56:10.508806 write(5, " ", 1 <unfinished ...>
9871  22:56:10.508820 <... epoll_pwait resumed> [{EPOLLOUT, {u32=754322992, u64=139801939807792}}, {EPOLLOUT, {u32=754323200, u64=139801939808000}}], 128, -1, NULL, 3) = 2
9874  22:56:10.508847 <... write resumed> ) = 1
9871  22:56:10.508855 epoll_pwait(4,  <unfinished ...>

To render its screen, tcell processes each dirty cell in sequence - for each
cell it generates the appropriate bytes for the terminal, and then calls
io.WriteString() with the terminal file handle as an io.Writer and the cell's
rendered bytes. Behind the scenes, this calls File.Write() which itself calls
epipecheck() resulting in the epoll_pwait() syscall (from src/os/file.go). The
call to epipecheck() exists so that the runtime can terminate a program in the
case of EPIPE i.e. writing to a closed pipe (for more see
https://github.com/golang/go/issues/11845). The typical result is a syscall to
write 1 byte to the terminal followed by epoll_pwait(), for each dirty cell in
the screen.

This change coalesces the terminal file handle writes into 1 call to
io.WriteString() per screen render. The function drawCell() is renamed
renderCell() and returns two strings in addition to the rendered cell
width. The first string may contain "delay" codes like $<100> and should be
rendered with TPuts(). The second string is the representation of the cell
contents. Instead of sending them to the terminal file handle, now both
strings are concatenated to a bytes.Buffer, the first post-processed by
turning "delay" codes into padding bytes. Once each dirty cell has been
processed in this way, the bytes.Buffer is converted to a string and that
string is written to the terminal.

Here is an example of a simple tcell application before this change:
https://drive.google.com/open?id=1k1CjK3vF3yOyubUhGCaPxyNsUbSrDmWs

And here is the same application after the change:
https://drive.google.com/open?id=1ERdYcjN23-WPPk-Mf7imcljFYR2ShiF8

I simulated a slower-than-normal VPN connection using

$ tc qdisc add dev tun0 root netem delay 200ms