### PR TITLE
Call SetDirty method on the back place of full-width characters.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -787,7 +787,9 @@ func (s *cScreen) draw() {
 			if len(combc) != 0 {
 				wcs = append(wcs, utf16.Encode(combc)...)
 			}
-			s.cells.SetDirty(x, y, false)
+			for dx := 0; dx < width; dx++ {
+				s.cells.SetDirty(x + dx, y, false)
+			}
 			x += width - 1
 		}
 		s.writeString(lx, ly, lstyle, wcs)


### PR DESCRIPTION
This Pull-Request is a modification of this issue: https://github.com/gdamore/tcell/issues/250

When content is full-width character, this following `width` is `2`.
https://github.com/gdamore/tcell/blob/master/console_win.go#L758

But, `SetDirty` method is called only at the beginning.
So, I have modified it to call `SetDirty` method at the back place of full-width characters.