### PR TITLE
An attempt to work around a gopkg.in/module error in a dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/gdamore/tcell
 go 1.9
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3 // indirect
 	github.com/gdamore/encoding v1.0.0
-	github.com/lucasb-eyer/go-colorful v0.0.0-20181028223441-12d3b2882a08
+	github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e
 	github.com/mattn/go-runewidth v0.0.4
 	golang.org/x/text v0.3.0
-	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/lucasb-eyer/go-colorful v0.0.0-20181028223441-12d3b2882a08 h1:5MnxBC15uMxFv5FY/J/8vzyaBiArCOkMdFT9Jsw78iY=
-github.com/lucasb-eyer/go-colorful v0.0.0-20181028223441-12d3b2882a08/go.mod h1:NXg0ArsFk0Y01623LgUqoqcouGDB+PwCCQlrwrG6xJ4=
+github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e h1:G1iqXwyALtGWWRzm2R2dNilhVXnnrRi91iiPFzE8Obk=
+github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e/go.mod h1:NXg0ArsFk0Y01623LgUqoqcouGDB+PwCCQlrwrG6xJ4=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=


### PR DESCRIPTION
Hi - I tried to update my work to use your latest version of tcell using the command below, and ran into a grungy go modules error. It looks like the go-colorful repo has fixed their references to go-sqlmock with this commit: https://github.com/lucasb-eyer/go-colorful/commit/4de7d682992e4105e105acd8ec5deb03a5bc542a. In my fork of tcell, updating go-colorful with 

$ go get -u github.com/lucasb-eyer/go-colorful

seemed to resolve the issue.

Graham

$ go get -u -v github.com/gdamore/tcell
Fetching https://golang.org/x/text?go-get=1
Fetching https://gopkg.in/DATA-DOG/go-sqlmock.v1?go-get=1
Parsing meta tags from https://golang.org/x/text?go-get=1 (status code 200)
get "golang.org/x/text": found meta tag get.metaImport{Prefix:"golang.org/x/text", VCS:"git", RepoRoot:"https://go.googlesource.com/text"} at https://golang.org/x/text?go-get=1
Parsing meta tags from https://gopkg.in/DATA-DOG/go-sqlmock.v1?go-get=1 (status code 200)
get "gopkg.in/DATA-DOG/go-sqlmock.v1": found meta tag get.metaImport{Prefix:"gopkg.in/DATA-DOG/go-sqlmock.v1", VCS:"git", RepoRoot:"https://gopkg.in/DATA-DOG/go-sqlmock.v1"} at https://gopkg.in/DATA-DOG/go-sqlmock.v1?go-get=1
go: finding github.com/lucasb-eyer/go-colorful latest
go: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.3: go.mod has non-....v1 module path "github.com/DATA-DOG/go-sqlmock" at revision v1.3.3
go get: error loading module requirements