### PR TITLE
Update go-colorful dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/gdamore/tcell
 
-go 1.9
+go 1.12
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.3.3 // indirect
 	github.com/gdamore/encoding v1.0.0
-	github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e
+	github.com/lucasb-eyer/go-colorful v1.0.2
 	github.com/mattn/go-runewidth v0.0.4
 	golang.org/x/text v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFD
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e h1:G1iqXwyALtGWWRzm2R2dNilhVXnnrRi91iiPFzE8Obk=
-github.com/lucasb-eyer/go-colorful v0.0.0-20190323151624-4de7d682992e/go.mod h1:NXg0ArsFk0Y01623LgUqoqcouGDB+PwCCQlrwrG6xJ4=
+github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=
+github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
go-sqlmock, which is a dependency for go-colorful tests, have switched from
gopkg.in to Go modules. This repository still records the old gopkg.in import
path in the go.mod file, which confuses `go mod`:

    go: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.3: go.mod has non-....v1 module path "github.com/DATA-DOG/go-sqlmock" at revision v1.3.3

This commit updates the go.mod file to use the new import path.

Can you release a new minor version after this is merged, so that we can use this library without hitting errors? Thanks!