### PR TITLE
Deliver tcell events more efficiently to tcell applications.

### DIFF
--- a/event_bundle.go
+++ b/event_bundle.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	"time"
+)
+
+// EventBundle wraps a slice of Events, allowing multiple events to
+// be posted "atomically" to the event-handling goroutine.
+type EventBundle struct {
+	t      time.Time
+	events []Event
+}
+
+// When returns the time when this event was created.
+func (ev *EventBundle) When() time.Time {
+	return ev.t
+}
+
+// Events returns the bundled events as a slice.
+func (ev *EventBundle) Events() []Event {
+	return ev.events
+}
+
+// NewEventBundle creates an EventBundle containing the provided
+// events.
+func NewEventBundle(events []Event) *EventBundle {
+	return &EventBundle{t: time.Now(), events: events}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gdamore/tcell
+module github.com/gcla/tcell
 
 go 1.12
 

--- a/screen.go
+++ b/screen.go
@@ -207,3 +207,19 @@ func NewScreen() (Screen, error) {
 		return nil, e
 	}
 }
+
+// NewScreen returns a Screen suitable for the user's terminal
+// environment. The screen supports sending events back to the
+// controlling application in bundles, rather than just one at a time,
+// so this API should be used if your application understands
+// and processes *tcell.EventBundle. If it does not handle
+// *tcell.EventBundle, then use NewScreen() instead.
+func NewScreenExt() (Screen, error) {
+	if s, _ := NewConsoleScreen(); s != nil {
+		return s, nil
+	} else if s, e := NewTerminfoScreenExt(); s != nil {
+		return s, nil
+	} else {
+		return nil, e
+	}
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -886,7 +886,10 @@ func (t *tScreen) clip(x, y int) (int, int) {
 	return x, y
 }
 
-func (t *tScreen) postMouseEvent(x, y, btn int) {
+// buildMouseEvent returns an event based on the supplied coordinates and button
+// state. Note that the screen's mouse button state is updated based on the
+// input to this function (i.e. it mutates the receiver).
+func (t *tScreen) buildMouseEvent(x, y, btn int) *EventMouse {
 
 	// XTerm mouse events only report at most one button at a time,
 	// which may include a wheel button.  Wheel motion events are
@@ -942,8 +945,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int) {
 	// to the screen in that case.
 	x, y = t.clip(x, y)
 
-	ev := NewEventMouse(x, y, button, mod)
-	t.PostEvent(ev)
+	return NewEventMouse(x, y, button, mod)
 }
 
 // parseSgrMouse attempts to locate an SGR mouse record at the start of the
@@ -951,7 +953,7 @@ func (t *tScreen) postMouseEvent(x, y, btn int) {
 // be removed from the buffer.  It returns true, false if the buffer might
 // contain such an event, but more bytes are necessary (partial match), and
 // false, false if the content is definitely *not* an SGR mouse record.
-func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1059,7 +1061,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			*evs = append(*evs, t.buildMouseEvent(x, y, btn))
 			return true, true
 		}
 	}
@@ -1070,7 +1072,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer) (bool, bool) {
 
 // parseXtermMouse is like parseSgrMouse, but it parses a legacy
 // X11 mouse record.
-func (t *tScreen) parseXtermMouse(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseXtermMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1112,14 +1114,14 @@ func (t *tScreen) parseXtermMouse(buf *bytes.Buffer) (bool, bool) {
 				buf.ReadByte()
 				i--
 			}
-			t.postMouseEvent(x, y, btn)
+			*evs = append(*evs, t.buildMouseEvent(x, y, btn))
 			return true, true
 		}
 	}
 	return true, false
 }
 
-func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseFunctionKey(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	partial := false
 	for e, k := range t.keycodes {
@@ -1138,8 +1140,7 @@ func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
 				mod |= ModAlt
 				t.escaped = false
 			}
-			ev := NewEventKey(k.key, r, mod)
-			t.PostEvent(ev)
+			*evs = append(*evs, NewEventKey(k.key, r, mod))
 			for i := 0; i < len(esc); i++ {
 				buf.ReadByte()
 			}
@@ -1152,7 +1153,7 @@ func (t *tScreen) parseFunctionKey(buf *bytes.Buffer) (bool, bool) {
 	return partial, false
 }
 
-func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
+func (t *tScreen) parseRune(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	if b[0] >= ' ' && b[0] <= 0x7F {
 		// printable ASCII easy to deal with -- no encodings
@@ -1161,8 +1162,7 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 			mod = ModAlt
 			t.escaped = false
 		}
-		ev := NewEventKey(KeyRune, rune(b[0]), mod)
-		t.PostEvent(ev)
+		*evs = append(*evs, NewEventKey(KeyRune, rune(b[0]), mod))
 		buf.ReadByte()
 		return true, true
 	}
@@ -1187,8 +1187,7 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 					mod = ModAlt
 					t.escaped = false
 				}
-				ev := NewEventKey(KeyRune, r, mod)
-				t.PostEvent(ev)
+				*evs = append(*evs, NewEventKey(KeyRune, r, mod))
 			}
 			for nin > 0 {
 				buf.ReadByte()
@@ -1202,6 +1201,19 @@ func (t *tScreen) parseRune(buf *bytes.Buffer) (bool, bool) {
 }
 
 func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
+	evs := t.collectEventsFromInput(buf, expire)
+
+	for _, ev := range evs {
+		t.PostEventWait(ev)
+	}
+}
+
+// Return an array of Events extracted from the supplied buffer. This is done
+// while holding the screen's lock - the events can then be queued for
+// application processing with the lock released.
+func (t *tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event {
+
+	res := make([]Event, 0, 20)
 
 	t.Lock()
 	defer t.Unlock()
@@ -1210,18 +1222,18 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		b := buf.Bytes()
 		if len(b) == 0 {
 			buf.Reset()
-			return
+			return res
 		}
 
 		partials := 0
 
-		if part, comp := t.parseRune(buf); comp {
+		if part, comp := t.parseRune(buf, &res); comp {
 			continue
 		} else if part {
 			partials++
 		}
 
-		if part, comp := t.parseFunctionKey(buf); comp {
+		if part, comp := t.parseFunctionKey(buf, &res); comp {
 			continue
 		} else if part {
 			partials++
@@ -1231,13 +1243,13 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		// mouse support
 
 		if t.ti.Mouse != "" {
-			if part, comp := t.parseXtermMouse(buf); comp {
+			if part, comp := t.parseXtermMouse(buf, &res); comp {
 				continue
 			} else if part {
 				partials++
 			}
 
-			if part, comp := t.parseSgrMouse(buf); comp {
+			if part, comp := t.parseSgrMouse(buf, &res); comp {
 				continue
 			} else if part {
 				partials++
@@ -1247,8 +1259,7 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		if partials == 0 || expire {
 			if b[0] == '\x1b' {
 				if len(b) == 1 {
-					ev := NewEventKey(KeyEsc, 0, ModNone)
-					t.PostEvent(ev)
+					res = append(res, NewEventKey(KeyEsc, 0, ModNone))
 					t.escaped = false
 				} else {
 					t.escaped = true
@@ -1266,8 +1277,7 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 				t.escaped = false
 				mod = ModAlt
 			}
-			ev := NewEventKey(KeyRune, rune(by), mod)
-			t.PostEvent(ev)
+			res = append(res, NewEventKey(KeyRune, rune(by), mod))
 			continue
 		}
 
@@ -1275,6 +1285,8 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 		// some more
 		break
 	}
+
+	return res
 }
 
 func (t *tScreen) mainLoop() {


### PR DESCRIPTION
This patch introduces a new tcell event type, EventBundle, which comprises a
slice of tcell.Events. Prior to this change, tcell will deliver events one at
a time (key, mouse, etc) to applications over an event channel of type
Event. The receiving application can call screen.PollEvent(), perhaps in a
goroutine - that function will return each event in sequence, blocking if none
are present. The application might then issue a type switch on the concrete
type of Event, processing *EventKey, *EventMouse, etc.

One problem the receiving application has to manage is when to issue a
redraw. For an application to feel responsive, it should update its UI as
quickly as possible after handling input. To do this, the application can
redraw after each call to PollEvent(). But this might result in unnecessarily
many redraws - for example, if a user has pasted a block of text into a tcell
application with the mouse, the application would redraw after each
character. A more complicated approach would be to redraw a short time
interval after the last call to PollEvent() (via a separate goroutine), while
cancelling and restarting a timer for that interval if another PollEvent()
returns in the meantime. This could work, but choosing the delay length
requires a trade-off between UI responsiveness and minimizing redraws.

Another way to handle this would be for tcell to send more than one event at
once, if possible. For example, if multiple events are extracted from the tty
input stream in one call to scanInput(), tcell could send them in a single
bundle via the event channel. This patch makes that possible with the new
EventBundle type.

Existing tcell applications have been built to handle the current set of tcell
types that implement tcell.Event. Because they would not understand and
process the EventBundle type, this feature must be opt-in. This is handled via
new Ext() APIs for creating a tcell screen - NewTerminfoScreenExt() and
NewScreenExt(). These both return a Screen that is identical to that returned
by NewTerminfoScreen() and NewScreen() respectively except that the screen
will send events over the event channel in bundles if possible.