### PR TITLE
On windows, don't change cursor position if about to hide cursor.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -283,7 +283,6 @@ func (s *cScreen) doCursor() {
 	x, y := s.curx, s.cury
 
 	if x < 0 || y < 0 || x >= s.w || y >= s.h {
-		s.setCursorPos(0, 0)
 		s.hideCursor()
 	} else {
 		s.setCursorPos(x, y)


### PR DESCRIPTION
A gowid user reported that mouse movement in their gowid(tcell) application
was causing the console cursor to flicker on windows, jumping from the current
position in the console to the top left corner, and back again. In part, this
is an artifact of the way I render a gowid "canvas" - calling HideCursor()
unilaterally, then calling ShowCursor(x, y) if the canvas contains a logical
cursor that is within bounds. Because currently every mouse event causes a
gowid application redraw, on windows the effect is to cause the cursor to jump
to the top left briefly, disappear, then reappear in the previous
position. You can see it most easily by moving the mouse rapidly left and
right.

An upstream fix is for me to only call HideCursor() if I know I'm not going to
call ShowCursor(x, y). But the flicker can also be eliminated by removing the
call to setCursorPos(0, 0) in console_win.go before hiding the cursor. The
single call to showCursor() in console_win.go is preceded by setting cursor
coordinates explicitly, so I don't think anything depends on the assumption
that a hidden cursor has been set to position (0, 0) first.