### PR TITLE
add support for bracketed paste

### DIFF
--- a/key.go
+++ b/key.go
@@ -373,6 +373,8 @@ const (
 	KeyF62
 	KeyF63
 	KeyF64
+	KeyPasteBegin
+	KeyPasteEnd
 )
 
 // These are the control keys.  Note that they overlap with other keys,

--- a/paste.go
+++ b/paste.go
@@ -1,0 +1,38 @@
+package tcell
+
+import "time"
+
+const (
+	PasteBegin = "\x1b[200~"
+	PasteEnd   = "\x1b[201~"
+)
+
+type EventKeyPasteBegin struct {
+	t time.Time
+}
+
+var _ Event = (*EventKeyPasteBegin)(nil)
+
+// When returns the time when this EventKeyPasteBegin was created.
+func (ev *EventKeyPasteBegin) When() time.Time {
+	return ev.t
+}
+
+func NewEventKeyPasteBegin() *EventKeyPasteBegin {
+	return &EventKeyPasteBegin{t: time.Now()}
+}
+
+type EventKeyPasteEnd struct {
+	t time.Time
+}
+
+var _ Event = (*EventKeyPasteEnd)(nil)
+
+// When returns the time when this EventKeyPasteEnd was created.
+func (ev *EventKeyPasteEnd) When() time.Time {
+	return ev.t
+}
+
+func NewEventKeyPasteEnd() *EventKeyPasteEnd {
+	return &EventKeyPasteEnd{t: time.Now()}
+}


### PR DESCRIPTION
Attempting to resolve #120 
Does not support windows yet, but shouldn't be too hard to define a separate `paste.go` file for windows with the correct event information.

Rebased since #137 

It's been so long that I'm not sure how to test it, but it looks right to me.