### PR TITLE
Use a new windows console screen buffer to preserve window contents.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -113,7 +113,6 @@ var (
 	procFillConsoleOutputAttribute   = k32.NewProc("FillConsoleOutputAttribute")
 	procFillConsoleOutputCharacter   = k32.NewProc("FillConsoleOutputCharacterW")
 	procSetConsoleWindowInfo         = k32.NewProc("SetConsoleWindowInfo")
-	procSetConsoleScreenBufferSize   = k32.NewProc("SetConsoleScreenBufferSize")
 	procSetConsoleTextAttribute      = k32.NewProc("SetConsoleTextAttribute")
 	procCreateConsoleScreenBuffer    = k32.NewProc("CreateConsoleScreenBuffer")
 	procSetConsoleActiveScreenBuffer = k32.NewProc("SetConsoleActiveScreenBuffer")
@@ -903,12 +902,6 @@ func (s *cScreen) setCursorPos(x, y int) {
 		coord{int16(x), int16(y)}.uintptr())
 }
 
-func (s *cScreen) setBufferSize(x, y int) {
-	procSetConsoleScreenBufferSize.Call(
-		uintptr(s.out),
-		coord{int16(x), int16(y)}.uintptr())
-}
-
 func (s *cScreen) Size() (int, int) {
 	s.Lock()
 	w, h := s.w, s.h
@@ -931,8 +924,6 @@ func (s *cScreen) resize() {
 	s.cells.Resize(w, h)
 	s.w = w
 	s.h = h
-
-	s.setBufferSize(w, h)
 
 	r := rect{0, 0, int16(w - 1), int16(h - 1)}
 	procSetConsoleWindowInfo.Call(


### PR DESCRIPTION
This change attempts to eliminate some lingering console issues when a windows
tcell application terminates. Here's a link to one such issue, in termshark:
https://github.com/gcla/termshark/issues/25.

Rather than restoring the original console window settings, this change saves
the current console buffer, then creates and switches to a new console window
buffer, using CreateConsoleScreenBuffer and SetConsoleActiveScreenBuffer. The
Fini function restores the saved console buffer. This eliminates the
above-linked termshark issue, and has the side benefit of preserving the
existing console contents which are restored after the tcell application
terminates.

Tested on both cmd.exe and Windows Powershell.