### PR TITLE
fixes #302 merge extended terminfo definitions into default

### DIFF
--- a/terms_default.go
+++ b/terms_default.go
@@ -1,0 +1,23 @@
+// +build !tcell_minimal
+
+// Copyright 2019 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	// This imports the default terminal entries.  To disable, use the
+	// tcell_minimal build tag.
+	_ "github.com/gdamore/tcell/terminfo/extended"
+)

--- a/terms_dynamic.go
+++ b/terms_dynamic.go
@@ -1,0 +1,37 @@
+// +build !tcell_minimal,!nacl,!js,!zos,!plan9,!windows,!android
+
+// Copyright 2019 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	// This imports a dynamic version of the terminal database, which
+	// is built using infocmp.  This relies on a working installation
+	// of infocmp (typically supplied with ncurses).  We only do this
+	// for systems likely to have that -- i.e. UNIX based hosts.  We
+	// also don't support Android here, because you really don't want
+	// to run external programs there.  Generally the android terminals
+	// will be automatically included anyway.
+	"github.com/gdamore/tcell/terminfo"
+	"github.com/gdamore/tcell/terminfo/dynamic"
+)
+
+func loadDynamicTerminfo(term string) (*terminfo.Terminfo, error) {
+	ti, _, e := dynamic.LoadTerminfo(term)
+	if e != nil {
+		return nil, e
+	}
+	return ti, nil
+}

--- a/terms_static.go
+++ b/terms_static.go
@@ -1,0 +1,27 @@
+// +build tcell_minimal nacl js zos plan9 windows android
+
+// Copyright 2019 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	"errors"
+
+	"github.com/gdamore/tcell/terminfo"
+)
+
+func loadDynamicTerminfo(term string) (*terminfo.Terminfo, error) {
+	return nil, errors.New("terminal type unsupported")
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The TCell Authors
+// Copyright 2019 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/gdamore/tcell/terminfo"
-	"github.com/gdamore/tcell/terminfo/dynamic"
 
 	// import the stock terminals
 	_ "github.com/gdamore/tcell/terminfo/base"
@@ -43,7 +42,7 @@ import (
 func NewTerminfoScreen() (Screen, error) {
 	ti, e := terminfo.LookupTerminfo(os.Getenv("TERM"))
 	if e != nil {
-		ti, _, e = dynamic.LoadTerminfo(os.Getenv("TERM"))
+		ti, e = loadDynamicTerminfo(os.Getenv("TERM"))
 		if e != nil {
 			return nil, e
 		}


### PR DESCRIPTION
This makes the default build about 150k larger, but includes all
the good terminals needed to make most folks happy.  In addition,
it allows a build tag of tcell_minimal to suppress that.  Finally,
we do not include infocmp support on platforms unlikely to support
it, such as Windows, nacl, android, etc.