### PR TITLE
Fix control-character encoding for non-alphabet characters

### DIFF
--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -82,7 +82,7 @@ func unescape(s string) string {
 				buf.WriteByte(c)
 			}
 		case control:
-			buf.WriteByte(c - 0x40)
+			buf.WriteByte(c ^ 1<<6)
 			esc = none
 		case escaped:
 			switch c {

--- a/terminfo/mkinfo.go
+++ b/terminfo/mkinfo.go
@@ -95,7 +95,7 @@ func unescape(s string) string {
 				buf.WriteByte(c)
 			}
 		case CTRL:
-			buf.WriteByte(c - 0x40)
+			buf.WriteByte(c ^ 1<<6)
 			esc = NONE
 		case ESC:
 			switch c {


### PR DESCRIPTION
@klamonte opened this issue against gowid, a package that relies on tcell for
all its terminal handling: https://github.com/gcla/gowid/issues/24. It
describes how a shell inside a terminal widget that the TUI launches freezes
when the user hits backspace. The TUI loads a tcell TermInfo struct for the
screen-256color terminal and that struct codes KeyBackspace as the single byte
0xff - and so the byte 0xff was sent to the tty. On my Ubuntu 19.04 machine,
`infocmp screen-256color` shows `kbs` is `^?` According to
https://en.wikipedia.org/wiki/Caret_notation, `^?` should map to 0x7f (127) -
"The digraph stands for the control character whose ASCII code is the same as
the character's ASCII code with the uppermost bit, in a 7-bit encoding,
reversed". This affects both mkinfo.go, the generator of the JSON terminfo
database files, and the dynamic terminfo generator.