### PR TITLE
Provide a fallback terminal size if the OS returns (0,0)

### DIFF
--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -19,6 +19,7 @@ package tcell
 import (
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -115,5 +116,27 @@ func (t *tScreen) getWinSize() (int, int, error) {
 	if err != nil {
 		return -1, -1, err
 	}
-	return int(wsz.Col), int(wsz.Row), nil
+	cols := int(wsz.Col)
+	rows := int(wsz.Row)
+	if cols == 0 {
+		colsEnv := os.Getenv("COLUMNS")
+		if colsEnv != "" {
+			if cols, err = strconv.Atoi(colsEnv); err != nil {
+				return -1, -1, err
+			}
+		} else {
+			cols = t.ti.Columns
+		}
+	}
+	if rows == 0 {
+		rowsEnv := os.Getenv("LINES")
+		if rowsEnv != "" {
+			if rows, err = strconv.Atoi(rowsEnv); err != nil {
+				return -1, -1, err
+			}
+		} else {
+			rows = t.ti.Lines
+		}
+	}
+	return cols, rows, nil
 }


### PR DESCRIPTION
Sometimes, the TIOCGWINSZ ioctl returns all zeroes (including columns,
rows) without an error. I found this when experimenting with the jexer
TUI toolkit for java e.g.

mvn dependency:get -Dartifact=com.gitlab.klamonte:jexer:0.3.2
jexer -jar ~/.m2/repository/com/gitlab/klamonte/jexer/0.3.2/jexer-0.3.2.jar

Once the demo starts, click the "Terminal" button, then type

stty size

it returns

0 0

My understanding is that this is normal, and happens until SIGWINCH is
received, or the size is set explicitly with TIOCSWINSZ.

My tcell application crashed under the jexer terminal because I didn't
anticipate a window size of (0,0).

If you run vim under the jexer terminal, it correctly sizes itself to
80x24. The shell's TERM variable is xterm, and infocmp xterm | grep cols
shows a default of 80 and a default of 24 for lines. The documentation
for vim explains how it computes the terminal size:

https://github.com/vim/vim/blob/master/runtime/doc/term.txt#L629

- an ioctl call (TIOCGSIZE or TIOCGWINSZ, depends on your system)
- the environment variables "LINES" and "COLUMNS"
- from the termcap entries "li" and "co"

This PR replicates that logic in the getWinSize() function. I think it
makes sense here because tScreen holds the TermInfo struct but the
tcell.Screen interface does not expose TermInfo to clients - of course
because the screen is abstracted to work on Windows too.