### PR TITLE
Base for bracketed paste

### DIFF
--- a/key.go
+++ b/key.go
@@ -171,6 +171,8 @@ var KeyNames = map[Key]string{
 	KeyF62:            "F62",
 	KeyF63:            "F63",
 	KeyF64:            "F64",
+	KeyPasteBegin:     "PasteBegin",
+	KeyPasteEnd:       "PasteEnd",
 	KeyCtrlA:          "Ctrl-A",
 	KeyCtrlB:          "Ctrl-B",
 	KeyCtrlC:          "Ctrl-C",
@@ -373,6 +375,8 @@ const (
 	KeyF62
 	KeyF63
 	KeyF64
+	KeyPasteBegin
+	KeyPasteEnd
 )
 
 // These are the control keys.  Note that they overlap with other keys,

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -206,6 +206,8 @@ type Terminfo struct {
 	KeyAltShfEnd    string
 	KeyMetaShfHome  string
 	KeyMetaShfEnd   string
+	KeyPasteBegin   string
+	KeyPasteEnd     string
 }
 
 type stackElem struct {

--- a/tscreen.go
+++ b/tscreen.go
@@ -364,6 +364,9 @@ func (t *tScreen) prepareKeys() {
 		t.prepareKey(KeyHome, "\x1bOH")
 	}
 
+	t.prepareKey(KeyPasteBegin, ti.KeyPasteBegin)
+	t.prepareKey(KeyPasteEnd, ti.KeyPasteEnd)
+
 outer:
 	// Add key mappings for control keys.
 	for i := 0; i < ' '; i++ {


### PR DESCRIPTION
It doesn't touch any of the specific terminfos until it's finalized how each terminal handles it.
This change at least allows implementations to do their own thing, example:

```go
termName := os.Getenv("TERM")
isXterm := strings.Index(termName, "xterm") != -1
hasPasteMode := false
if (isXterm && os.Getenv("BRACKETED_PASTE") != "0") || os.Getenv("BRACKETED_PASTE") == "1" {
	ti, _ := terminfo.LookupTerminfo(termName)
	if ti != nil {
		hasPasteMode = true
		ti.KeyPasteBegin = "\x1b[200~"
		ti.KeyPasteEnd = "\x1b[201~"
		os.Stdout.WriteString("\x1b[?2004h")       // Enable bracketed paste.
		defer os.Stdout.WriteString("\x1b[?2004l") // Disable bracketed paste.
	}
}
```

This example allows bracketed paste for xterm by default as long as env var BRACKETED_PASTE isn't 0, or force allows it if BRACKETED_PASTE=1. Although this may not be the correct key codes for all terminals, at least the user can check and decide. The example is not ideal, but seems like a decent workaround for now.

See: #120