### PR TITLE
CellView changes

### DIFF
--- a/views/cellarea.go
+++ b/views/cellarea.go
@@ -37,8 +37,6 @@ type CellView struct {
 	view     View
 	content  Widget
 	contentV *ViewPort
-	cursorX  int
-	cursorY  int
 	style    tcell.Style
 	lines    []string
 	model    CellModel
@@ -274,19 +272,19 @@ func (a *CellView) Resize() {
 
 // SetCursor sets the the cursor position.
 func (a *CellView) SetCursor(x, y int) {
-	a.cursorX = x
-	a.cursorY = y
 	a.model.SetCursor(x, y)
 }
 
 // SetCursorX sets the the cursor column.
 func (a *CellView) SetCursorX(x int) {
-	a.SetCursor(x, a.cursorY)
+	_, y, _, _ := a.model.GetCursor()
+	a.SetCursor(x, y)
 }
 
 // SetCursorY sets the the cursor row.
 func (a *CellView) SetCursorY(y int) {
-	a.SetCursor(a.cursorX, y)
+	x, _, _, _ := a.model.GetCursor()
+	a.SetCursor(x, y)
 }
 
 // MakeVisible makes the given coordinates visible, if they are not already.

--- a/views/cellarea.go
+++ b/views/cellarea.go
@@ -233,6 +233,11 @@ func (a *CellView) Size() (int, int) {
 	return w, h
 }
 
+// GetModel gets the model for this CellView
+func (a *CellView) GetModel() CellModel {
+	return a.model
+}
+
 // SetModel sets the model for this CellView.
 func (a *CellView) SetModel(model CellModel) {
 	w, h := model.GetBounds()


### PR DESCRIPTION
The PR changes two things:

Removes cursor position keeping from CellView, leaves it to CellModel.

Adds GetModel() method to CellView, so one can build on existing model functions in TextArea for example.