### PR TITLE
Fixed Text widget incorrect width calculation for multiline strings

### DIFF
--- a/views/text.go
+++ b/views/text.go
@@ -190,9 +190,8 @@ func (t *Text) SetText(s string) {
 			t.lengths = append(t.lengths, length)
 			if length > t.width {
 				t.width = length
-				length = 0
 			}
-
+			length = 0
 		} else if t.widths[i] == 0 && length == 0 {
 			// If first character on line is combining, inject
 			// a leading space.  (Shame on the caller!)

--- a/views/text_test.go
+++ b/views/text_test.go
@@ -1,0 +1,19 @@
+package views
+
+import "testing"
+
+func TestText(t *testing.T) {
+	text := &Text{}
+
+	text.SetText(`
+This
+String
+Is
+Pretty
+Long
+12345678901234567890
+`)
+	if text.width != 20 {
+		t.Errorf("Incorrect width: %d, expected: %d", text.width, 20)
+	}
+}


### PR DESCRIPTION
Current Text widget behavior tries to compute the longest line length but unfortunately the `length` var wasn't resetting properly causing the total width to be incorrect.

I added a test which was failing before the fix