### PR TITLE
allocate inputLoop buffer once, outside the loop

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1351,9 +1351,9 @@ func (t *tScreen) mainLoop() {
 }
 
 func (t *tScreen) inputLoop() {
+	chunk := make([]byte, 128)
 
 	for {
-		chunk := make([]byte, 128)
 		n, e := t.in.Read(chunk)
 		switch e {
 		case io.EOF:


### PR DESCRIPTION
Hello,

This is a simple change that brings a noticeable improvement in memory efficiency, by allocating the buffer to read the input key once, outside the loop, and reuse it instead of allocating on each iteration.

This is a bit tricky to test and benchmark because it is deep in the internals of tScreen, so what I did is run this program:

```
func main() {
	s, err := tcell.NewScreen()
	if err != nil {
		log.Fatal(err)
	}
	if err := s.Init(); err != nil {
		log.Fatal(err)
	}

	var before, after runtime.MemStats
	runtime.ReadMemStats(&before)
	defer func() {
		runtime.ReadMemStats(&after)
		s.Fini()
		diff := after.TotalAlloc - before.TotalAlloc
		fmt.Printf("\n%d bytes (%dKB) allocated\n", diff, diff/1024)
	}()

	for ev := s.PollEvent(); ev != nil; ev = s.PollEvent() {
		switch ev := ev.(type) {
		case *tcell.EventKey:
			if ev.Key() == tcell.KeyRune {
				fmt.Print(string(ev.Rune()))
			} else if ev.Key() == tcell.KeyEscape {
				return
			}
		}
	}
}
```

With and without the change, enter the same amount of key presses in both cases and compare the memory allocated. I ran this a number of times and got consistent results. For a full line of my terminal, I get ~82KB without the change and ~62KB with it. I tested with 2 lines of key presses and got ~160KB vs 118KB. Note that my terminal gives:

```
$ tput cols
158
```

So 158 columns * 128 bytes allocated = ~20KB less per row, which matches the results.

Thanks,
Martin