### PR TITLE
Remove SetCursor(0,0) from CellArea SetModel

### DIFF
--- a/views/cellarea.go
+++ b/views/cellarea.go
@@ -241,7 +241,6 @@ func (a *CellView) GetModel() CellModel {
 // SetModel sets the model for this CellView.
 func (a *CellView) SetModel(model CellModel) {
 	w, h := model.GetBounds()
-	model.SetCursor(0, 0)
 	a.model = model
 	a.port.SetContentSize(w, h, true)
 	a.port.ValidateView()


### PR DESCRIPTION
Removing SetCursor makes it possible to add lines to the model on the fly, while keeping the cursor in position.

Go also initializes them with 0, no need to set it manually.

I am not perfectly sure about what consequences it could cause.
I have tried to make it panic with the following:
```
    ta := views.NewTextArea()
    ta.SetContent("One\nTwo\nThree")
    ta.EnableCursor(true)
    ta.SetCursor(5,3)
    ta.SetContent("Boo!")
```
But first cursor movement jumps back to the model. So I think it will not cause regression, but let me know if I should try something else too.
