### PR TITLE
fix build on illumos after Beep() API

### DIFF
--- a/tscreen_solaris.go
+++ b/tscreen_solaris.go
@@ -1,6 +1,6 @@
-// +build solaris
+// +build solaris illumos
 
-// Copyright 2019 The TCell Authors
+// Copyright 2020 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -114,4 +114,9 @@ func (t *tScreen) getWinSize() (int, int, error) {
 		return -1, -1, err
 	}
 	return int(wsz.Col), int(wsz.Row), nil
+}
+
+func (t *tScreen) Beep() error {
+	t.writeString(string(byte(7)))
+	return nil
 }


### PR DESCRIPTION
The build for the "solaris" and "illumos" tags appears to have been
broken by commit 8ec73b6fa6c543d5d067722c0444b07f7607ba2f, which
introduced the Beep() API.  Restore functionality by using the same
implementation as every other UNIX family platform.