### PR TITLE
Mark tui-go as deprecated

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ image::logos/tcell.png[float="right"]
 * https://github.com/zyedidia/micro/[micro] - lightweight text editor with syntax-highlighting and themes
 * https://github.com/viktomas/godu[godu] - simple golang utility helping to discover large files/folders.
 * https://github.com/rivo/tview[tview] - rich interactive widgets for terminal UIs
-* https://github.com/marcusolsson/tui-go[tui-go] - UI library for terminal apps
+* https://github.com/marcusolsson/tui-go[tui-go] - UI library for terminal apps (_deprecated_)
 * https://github.com/rgm3/gomandelbrot[gomandelbrot] - Mandelbrot!
 * https://github.com/senorprogrammer/wtf[WTF]- Personal information dashboard for your terminal
 * https://github.com/browsh-org/browsh[browsh] - A fully-modern text-based browser, rendering to TTY and browsers (https://www.youtube.com/watch?v=HZq86XfBoRo[video])


### PR DESCRIPTION
As mentioned at on its homepage, the project is no longer being maintained and has been archived