### PR TITLE
fixes #314 Implement `setf` & `setb`

### DIFF
--- a/_demos/boxes.go
+++ b/_demos/boxes.go
@@ -46,7 +46,7 @@ func makebox(s tcell.Screen) {
 		rgb := tcell.NewHexColor(int32(rand.Int() & 0xffffff))
 		st = st.Background(rgb)
 	} else if s.Colors() > 1 {
-		st = st.Background(tcell.Color(rand.Int() % s.Colors()))
+		st = st.Background(tcell.Color(rand.Int() % s.Colors()) | tcell.ColorValid)
 	} else {
 		st = st.Reverse(rand.Int()%2 == 0)
 		gl = glyphs[rand.Int()%len(glyphs)]

--- a/_demos/mouse.go
+++ b/_demos/mouse.go
@@ -206,7 +206,7 @@ func main() {
 			switch ev.Buttons() {
 			case tcell.ButtonNone:
 				if ox >= 0 {
-					bg := tcell.Color((lchar - '0') * 2)
+					bg := tcell.Color((lchar - '0') * 2) | tcell.ColorValid
 					drawBox(s, ox, oy, x, y,
 						up.Background(bg),
 						lchar)

--- a/attr.go
+++ b/attr.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The TCell Authors
+// Copyright 2020 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -21,13 +21,12 @@ type AttrMask int
 // Attributes are not colors, but affect the display of text.  They can
 // be combined.
 const (
-	AttrBold AttrMask = 1 << (25 + iota)
+	AttrBold AttrMask = 1 << iota
 	AttrBlink
 	AttrReverse
 	AttrUnderline
 	AttrDim
 	AttrItalic
-	AttrNone AttrMask = 0 // Just normal text.
+	AttrInvalid              // Mark the style or attributes invalid
+	AttrNone    AttrMask = 0 // Just normal text.
 )
-
-const attrAll = AttrBold | AttrBlink | AttrReverse | AttrUnderline | AttrDim | AttrItalic

--- a/color_test.go
+++ b/color_test.go
@@ -42,22 +42,22 @@ func TestColorValues(t *testing.T) {
 func TestColorFitting(t *testing.T) {
 	pal := []Color{}
 	for i := 0; i < 255; i++ {
-		pal = append(pal, Color(i))
+		pal = append(pal, PaletteColor(i))
 	}
 
 	// Exact color fitting on ANSI colors
 	for i := 0; i < 7; i++ {
-		if FindColor(Color(i), pal[:8]) != Color(i) {
+		if FindColor(PaletteColor(i), pal[:8]) != PaletteColor(i) {
 			t.Errorf("Color ANSI fit fail at %d", i)
 		}
 	}
 	// Grey is closest to Silver
-	if FindColor(Color(8), pal[:8]) != Color(7) {
+	if FindColor(PaletteColor(8), pal[:8]) != PaletteColor(7) {
 		t.Errorf("Grey does not fit to silver")
 	}
 	// Color fitting of upper 8 colors.
 	for i := 9; i < 16; i++ {
-		if FindColor(Color(i), pal[:8]) != Color(i%8) {
+		if FindColor(PaletteColor(i), pal[:8]) != PaletteColor(i%8) {
 			t.Errorf("Color fit fail at %d", i)
 		}
 	}
@@ -76,15 +76,30 @@ func TestColorNameLookup(t *testing.T) {
 	var values = []struct {
 		name  string
 		color Color
+		rgb   bool
 	}{
-		{"#FF0000", ColorRed},
-		{"black", ColorBlack},
-		{"orange", ColorOrange},
+		{"#FF0000", ColorRed, true},
+		{"black", ColorBlack, false},
+		{"orange", ColorOrange, false},
+		{"door", ColorDefault, false},
 	}
 	for _, v := range values {
 		c := GetColor(v.name)
 		if c.Hex() != v.color.Hex() {
 			t.Errorf("Wrong color for %v: %v", v.name, c.Hex())
+		}
+		if v.rgb {
+			if c & ColorIsRGB == 0 {
+				t.Errorf("Color should have RGB")
+			}
+		} else {
+			if c & ColorIsRGB != 0 {
+				t.Errorf("Named color should not be RGB")
+			}
+		}
+
+		if c.TrueColor().Hex() != v.color.Hex() {
+			t.Errorf("TrueColor did not match")
 		}
 	}
 }

--- a/style.go
+++ b/style.go
@@ -32,101 +32,101 @@ package tcell
 // would be replaced with a palette number and palette index.
 //
 // To use Style, just declare a variable of its type.
-type Style int64
+type Style struct {
+	fg       Color
+	bg       Color
+	attrs    AttrMask
+}
 
 // StyleDefault represents a default style, based upon the context.
 // It is the zero value.
-const StyleDefault Style = 0
+var StyleDefault Style
 
-// styleFlags -- used internally for now.
-const (
-	styleBgSet = 1 << (iota + 57)
-	styleFgSet
-	stylePalette
-)
+// styleInvalid is just an arbitrary invalid style used internally.
+var styleInvalid = Style{attrs: AttrInvalid}
 
 // Foreground returns a new style based on s, with the foreground color set
 // as requested.  ColorDefault can be used to select the global default.
 func (s Style) Foreground(c Color) Style {
-	if c == ColorDefault {
-		return (s &^ (0x1ffffff00000000 | styleFgSet))
+	return Style{
+		fg:    c,
+		bg:    s.bg,
+		attrs: s.attrs,
 	}
-	return (s &^ Style(0x1ffffff00000000)) |
-		((Style(c) & 0x1ffffff) << 32) | styleFgSet
 }
 
 // Background returns a new style based on s, with the background color set
 // as requested.  ColorDefault can be used to select the global default.
 func (s Style) Background(c Color) Style {
-	if c == ColorDefault {
-		return (s &^ (0x1ffffff | styleBgSet))
+	return Style{
+		fg:    s.fg,
+		bg:    c,
+		attrs: s.attrs,
 	}
-	return (s &^ (0x1ffffff)) | (Style(c) & 0x1ffffff) | styleBgSet
 }
 
 // Decompose breaks a style up, returning the foreground, background,
 // and other attributes.
 func (s Style) Decompose() (fg Color, bg Color, attr AttrMask) {
-	if s&styleFgSet != 0 {
-		fg = Color(s>>32) & 0x1ffffff
-	} else {
-		fg = ColorDefault
-	}
-	if s&styleBgSet != 0 {
-		bg = Color(s & 0x1ffffff)
-	} else {
-		bg = ColorDefault
-	}
-	attr = AttrMask(s) & attrAll
-
-	return fg, bg, attr
+	return s.fg, s.bg, s.attrs
 }
 
-func (s Style) setAttrs(attrs Style, on bool) Style {
+func (s Style) setAttrs(attrs AttrMask, on bool) Style {
 	if on {
-		return s | attrs
+		return Style{
+			fg:    s.fg,
+			bg:    s.bg,
+			attrs: s.attrs | attrs,
+		}
 	}
-	return s &^ attrs
+	return Style{
+		fg:    s.fg,
+		bg:    s.bg,
+		attrs: s.attrs &^ attrs,
+	}
 }
 
 // Normal returns the style with all attributes disabled.
 func (s Style) Normal() Style {
-	return s &^ Style(attrAll)
+	return Style{
+		fg: s.fg,
+		bg: s.bg,
+	}
 }
 
 // Bold returns a new style based on s, with the bold attribute set
 // as requested.
 func (s Style) Bold(on bool) Style {
-	return s.setAttrs(Style(AttrBold), on)
+	return s.setAttrs(AttrBold, on)
 }
 
 // Blink returns a new style based on s, with the blink attribute set
 // as requested.
 func (s Style) Blink(on bool) Style {
-	return s.setAttrs(Style(AttrBlink), on)
+	return s.setAttrs(AttrBlink, on)
 }
 
 // Dim returns a new style based on s, with the dim attribute set
 // as requested.
 func (s Style) Dim(on bool) Style {
-	return s.setAttrs(Style(AttrDim), on)
+	return s.setAttrs(AttrDim, on)
 }
 
 // Italic returns a new style based on s, with the italic attribute set
 // as requested.
 func (s Style) Italic(on bool) Style {
-	return s.setAttrs(Style(AttrItalic), on)
+	return s.setAttrs(AttrItalic, on)
 }
 
 // Reverse returns a new style based on s, with the reverse attribute set
 // as requested.  (Reverse usually changes the foreground and background
 // colors.)
 func (s Style) Reverse(on bool) Style {
-	return s.setAttrs(Style(AttrReverse), on)
+	return s.setAttrs(AttrReverse, on)
 }
 
 // Underline returns a new style based on s, with the underline attribute set
 // as requested.
 func (s Style) Underline(on bool) Style {
-	return s.setAttrs(Style(AttrUnderline), on)
+	return s.setAttrs(AttrUnderline, on)
 }


### PR DESCRIPTION
This causes colors that are set that are low numbered to
be treated as themed colors -- basically honoring the palette
of the terminal.

The Style and Color implementations have changed quite a bit
to permit growth -- the colors are now 64-bits wide to permit
using the upper bits as flags, and to leave room for a future
alpha channel.

There is a new TrueColor() method on colors that obtains the
value as strict RGB value, and this will be used in lieu of
whatever terminal colors are provided -- giving the application
full control over the color space if they want, without
forcibly clobbering user preferences for terminals for the
vast majority of cases.