### PR TITLE
Add italic code to alacritty terminfo

### DIFF
--- a/terminfo/a/alacritty/term.go
+++ b/terminfo/a/alacritty/term.go
@@ -21,6 +21,7 @@ func init() {
 		AttrOff:         "\x1b(B\x1b[m",
 		Underline:       "\x1b[4m",
 		Bold:            "\x1b[1m",
+		Italic:          "\x1b[3m",
 		Dim:             "\x1b[2m",
 		Blink:           "\x1b[5m",
 		Reverse:         "\x1b[7m",


### PR DESCRIPTION
For tcell programs on alacritty to be able to display italics.

Source: <https://github.com/alacritty/alacritty/blob/master/extra/alacritty.info#L56>