### PR TITLE
Add Bios-Marcel/memoryalike to the readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,7 @@ The new work in progress is available using master and `github.com/gdamore/tcell
 * https://github.com/ezeoleaf/tblogs[tblogs] - A terminal based development blogs reader
 * https://github.com/lallassu/spinc[spinc] - An irssi inspired terminal chat application for Cisco Spark/WebEx
 * https://github.com/lallassu/gorss[gorss] - A RSS/Atom feed reader for your terminal
+* https://github.com/Bios-Marcel/memoryalike[memoryalike] - A game where you have to memorize runes hat hit their respective keys
 
 == Pure Go Terminfo Database
 


### PR DESCRIPTION
I added a link to https://github.com/Bios-Marcel/memoryalike.
It's a small terminal game written with tcell as it's sole dependency.