### PR TITLE
Fixed typo in example link description

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ The new work in progress is available using master and `github.com/gdamore/tcell
 * https://github.com/ezeoleaf/tblogs[tblogs] - A terminal based development blogs reader
 * https://github.com/lallassu/spinc[spinc] - An irssi inspired terminal chat application for Cisco Spark/WebEx
 * https://github.com/lallassu/gorss[gorss] - A RSS/Atom feed reader for your terminal
-* https://github.com/Bios-Marcel/memoryalike[memoryalike] - A game where you have to memorize runes hat hit their respective keys
+* https://github.com/Bios-Marcel/memoryalike[memoryalike] - A game where you have to memorize runes and hit their respective keys
 
 == Pure Go Terminfo Database
 


### PR DESCRIPTION
There was a typo in my previous PR, I didn't notice, sorry