### PR TITLE
Attempted fix of a regression I introduced - breaking mouse support!

### DIFF
--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -260,8 +260,17 @@ func (st stack) PopInt() (int, stack) {
 		if e.isInt {
 			return e.i, st
 		} else if e.isStr {
-			i, _ := strconv.Atoi(e.s)
-			return i, st
+			// If the string that was pushed was the representation
+			// of a number e.g. '123', then return the number. If the
+			// conversion doesn't work, assume the string pushed was
+			// intended to return, as an int, the ascii representation
+			// of the (one and only) character.
+			i, err := strconv.Atoi(e.s)
+			if err == nil {
+				return i, st
+			} else if len(e.s) >= 1 {
+				return int(e.s[0]), st
+			}
 		}
 	}
 	return 0, st
@@ -461,7 +470,7 @@ func (t *Terminfo) TParm(s string, p ...int) string {
 		case '\'': // push(char)
 			ch, _ = pb.NextCh()
 			pb.NextCh() // must be ' but we don't check
-			stk = stk.PushInt(int(ch))
+			stk = stk.Push(string(ch))
 
 		case '{': // push(int)
 			ai = 0


### PR DESCRIPTION
@tslocum reported that the commit at 2d6d7fbe broke mouse support in
cview (https://github.com/gdamore/tcell/pull/384#issuecomment-698422464). The
purpose of the original commit was to fix a terminfo background color
code parsing problem that I spotted using TERM=xterm-16color:

$ infocmp xterm-16color | grep setab
	setab=\E[%?%p1%{8}%<%t%p1%'('%+%e%p1%{92}%+%;%dm,

The middle sections says "if p1<8 then push(p1+'(') ". '(' is ascii
40. The sequence '%d' will then pop from the stack and interpreting the
result as an integer.

My change above was to have tcell assume the sequence between two single
quotes was a single ASCII character e.g. '(' and push that to the
terminfo stack as an integer with the ASCII value of the character
e.g. push(40:int). I didn't find any counterexamples in my local
terminfo database that didn't line up with that assumption; but I did
break mouse support because tcell generates its own rules to enable
mouse support, if not specified in the terminfo DB - both when
generating its own Golang-style internal DB, and in the dynamic terminfo
generator that uses infocmp:

"%?%p1%{1}%=%t%'h'%Pa%e%'l'%Pa%;\x1b[?1000%ga%c\x1b[?1002%ga%c\x1b[?1003%ga%c\x1b[?1006%ga%c"

This rule will push 'h' or 'l', depending on whether mouse mode is to be
enabled or disabled, and then sets the variable named a to the result,
interpreted as a string. The result is that when mouse mode is enabled,
tcell needs to emit \x1b[?1000h - where the 'h' comes from variable a
i.e. it needs to be able to push a quoted argument as a string and not
be forced into an int.

This alternative fix preserves the fact the quoted argument is a string
and maintains that on the stack. However, if the integer Pop() function
is called when the top element of the stack is a string, tcell will now

- return the string converted to an int, if it converts e.g. in the case
  '123' is pushed to the stack as a string and popped as an int, the value
  is 123
- otherwise return the ASCII value of the first character of the string
  e.g. if '(' is pushed then popped as an int, the value returned is 40.

To be compatible with this logic, if a terminfo rule needs to push an
integer whose value is >= ascii('0')==48 and <= ascii('9')==57, it will
need to use the form e.g. {53} and not '5' because the form '5' will be
pushed as "5":string and if popped as an int will return the value 5 and
not 53.