### PR TITLE
fixes #120 Support for bracketed paste mode

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -249,6 +249,10 @@ func (s *cScreen) DisableMouse() {
 	s.setInMode(modeResizeEn | modeExtndFlg)
 }
 
+func (s *cScreen) EnablePaste() {}
+
+func (s *cScreen) DisablePaste() {}
+
 func (s *cScreen) Fini() {
 	s.finiOnce.Do(s.finish)
 }

--- a/key.go
+++ b/key.go
@@ -375,6 +375,12 @@ const (
 	KeyF64
 )
 
+const (
+	// These key codes are used internally, and will never appear to applications.
+	keyPasteStart Key = iota + 16384
+	keyPasteEnd
+)
+
 // These are the control keys.  Note that they overlap with other keys,
 // perhaps.  For example, KeyCtrlH is the same as KeyBackspace.
 const (

--- a/paste.go
+++ b/paste.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	"time"
+)
+
+// EventPaste is used to mark the start and end of a bracketed paste.
+// An event with .Start() true will be sent to mark the start.
+// Then a number of keys will be sent to indicate that the content
+// is pasted in.  At the end, an event with .Start() false will be sent.
+type EventPaste struct {
+	start bool
+	t     time.Time
+}
+
+// When returns the time when this EventMouse was created.
+func (ev *EventPaste) When() time.Time {
+	return ev.t
+}
+
+// Start returns true if this is the start of a paste.
+func (ev *EventPaste) Start() bool {
+	return ev.start
+}
+
+// End returns true if this is the end of a paste.
+func (ev *EventPaste) End() bool {
+	return !ev.start
+}
+
+// NewEventPaste returns a new EventPaste.
+func NewEventPaste(start bool) *EventPaste {
+	return &EventPaste{t: time.Now(), start: start}
+}

--- a/screen.go
+++ b/screen.go
@@ -104,6 +104,12 @@ type Screen interface {
 	// DisableMouse disables the mouse.
 	DisableMouse()
 
+	// EnablePaste enables bracketed paste mode, if supported.
+	EnablePaste()
+
+	// DisablePaste() disables bracketed paste mode.
+	DisablePaste()
+
 	// HasMouse returns true if the terminal (apparently) supports a
 	// mouse.  Note that the a return value of true doesn't guarantee that
 	// a mouse/pointing device is present; a false return definitely

--- a/simulation.go
+++ b/simulation.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The TCell Authors
+// Copyright 2020 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -97,6 +97,7 @@ type simscreen struct {
 	cursory   int
 	cursorvis bool
 	mouse     bool
+	paste     bool
 	charset   string
 	encoder   transform.Transformer
 	decoder   transform.Transformer
@@ -319,6 +320,14 @@ func (s *simscreen) EnableMouse() {
 
 func (s *simscreen) DisableMouse() {
 	s.mouse = false
+}
+
+func (s *simscreen) EnablePaste() {
+	s.paste = true
+}
+
+func (s *simscreen) DisablePaste() {
+	s.paste = false
 }
 
 func (s *simscreen) Size() (int, int) {

--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The TCell Authors
+// Copyright 2020 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -374,6 +374,24 @@ func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	if t.KeyShfHome == "\x1b[7$" && t.KeyShfEnd == "\x1b[8$" {
 		t.KeyCtrlHome = "\x1b[7^"
 		t.KeyCtrlEnd = "\x1b[8^"
+	}
+
+	// Technically the RGB flag that is provided for xterm-direct is not
+	// quite right.  The problem is that the -direct flag that was introduced
+	// with ncurses 6.1 requires a parsing for the parameters that we lack.
+	// For this case we'll just assume it's XTerm compatible.  Someday this
+	// may be incorrect, but right now it is correct, and nobody uses it
+	// anyway.
+	if tc.getflag("Tc") {
+		// This presumes XTerm 24-bit true color.
+		t.TrueColor = true
+	} else if tc.getflag("RGB") {
+		// This is for xterm-direct, which uses a different scheme entirely.
+		// (ncurses went a very different direction from everyone else, and
+		// so it's unlikely anything is using this definition.)
+		t.TrueColor = true
+		t.SetBg = "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m"
+		t.SetFg = "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"
 	}
 
 	// If the kmous entry is present, then we need to record the

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -213,6 +213,10 @@ type Terminfo struct {
 	KeyAltShfEnd    string
 	KeyMetaShfHome  string
 	KeyMetaShfEnd   string
+	EnablePaste     string // bracketed paste mode
+	DisablePaste    string
+	PasteStart      string
+	PasteEnd        string
 	Modifiers       int
 	TrueColor       bool // true if the terminal supports direct color
 }


### PR DESCRIPTION
This adds Bracketed Paste support for terminals that have mouse
support and support it.  The bracketing events are EventPaste,
with methods to note Start() or End() of the paste.  Content
comes in as normal rune events.  Programs must opt-in to this by
calling screen.EnablePaste().