### PR TITLE
Add go 1.15 and power support ppc64le to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
+  - 1.15.x
   - master
+
+arch:
+   - amd64
+   - ppc64le
 
 before_install:
   - go get -t -v ./...


### PR DESCRIPTION
Added go 1.15 latest and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.