### PR TITLE
Fix endless loop

### DIFF
--- a/simulation.go
+++ b/simulation.go
@@ -404,6 +404,7 @@ outer:
 			}
 			ev := NewEventKey(Key(b[0]), 0, mod)
 			s.PostEvent(ev)
+			b = b[1:]
 			continue
 		}
 


### PR DESCRIPTION
InjectKeyBytes would go into an endless loop for single bytes smaller than a blank.