### PR TITLE
Add cview. Deprecate unsupported tview.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ Version 1.x remains available using the import `github.com/gdamore/tcell`.
 * https://github.com/gdamore/gomatrix[gomatrix] - converted from Termbox
 * https://github.com/zyedidia/micro/[micro] - lightweight text editor with syntax-highlighting and themes
 * https://github.com/viktomas/godu[godu] - simple golang utility helping to discover large files/folders.
-* https://github.com/rivo/tview[tview] - rich interactive widgets for terminal UIs
+* https://gitlab.com/tslocum/cview[cview] / https://github.com/rivo/tview[tview] (_deprecated_) - rich interactive widgets for terminal UIs
 * https://github.com/marcusolsson/tui-go[tui-go] - UI library for terminal apps (_deprecated_)
 * https://github.com/rgm3/gomandelbrot[gomandelbrot] - Mandelbrot!
 * https://github.com/senorprogrammer/wtf[WTF]- Personal information dashboard for your terminal


### PR DESCRIPTION
The `tview` project has been unsupported (though not archived) for some time (according to the author). The `cview` project is, however, alive and well and frequently adding new features as well as supporting old ones. I believe it is worth nothing this on the main page given these facts.