### PR TITLE
Support for new Suspend and Resume API.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -53,6 +53,10 @@ type cScreen struct {
 
 	finiOnce sync.Once
 
+	mouseEnabled bool
+	wg           sync.WaitGroup
+	stopQ        chan struct{}
+
 	sync.Mutex
 }
 
@@ -176,7 +180,7 @@ func (s *cScreen) Init() error {
 	// ConEmu handling of colors and scrolling when in terminal
 	// mode is extremely problematic at the best.  The color
 	// palette will scroll even though characters do not, when
-	// emiting stuff for the last character.  In the future we
+	// emitting stuff for the last character.  In the future we
 	// might change this to look at specific versions of ConEmu
 	// if they fix the bug.
 	if os.Getenv("ConEmuPID") != "" {
@@ -188,16 +192,6 @@ func (s *cScreen) Init() error {
 	case "enable":
 		s.truecolor = true
 	}
-
-	cf, _, e := procCreateEvent.Call(
-		uintptr(0),
-		uintptr(1),
-		uintptr(0),
-		uintptr(0))
-	if cf == uintptr(0) {
-		return e
-	}
-	s.cancelflag = syscall.Handle(cf)
 
 	s.Lock()
 
@@ -229,12 +223,9 @@ func (s *cScreen) Init() error {
 		s.setOutMode(0)
 	}
 
-	s.clearScreen(s.style)
-	s.hideCursor()
 	s.Unlock()
-	go s.scanInput()
 
-	return nil
+	return s.engage()
 }
 
 func (s *cScreen) CharacterSet() string {
@@ -243,19 +234,35 @@ func (s *cScreen) CharacterSet() string {
 }
 
 func (s *cScreen) EnableMouse(...MouseFlags) {
-	s.setInMode(modeResizeEn | modeMouseEn | modeExtndFlg)
+	s.Lock()
+	s.mouseEnabled = true
+	s.enableMouse(true)
+	s.Unlock()
 }
 
 func (s *cScreen) DisableMouse() {
-	s.setInMode(modeResizeEn | modeExtndFlg)
+	s.Lock()
+	s.mouseEnabled = false
+	s.enableMouse(false)
+	s.Unlock()
 }
+
+func (s *cScreen) enableMouse(on bool) {
+	if on {
+		s.setInMode(modeResizeEn | modeMouseEn | modeExtndFlg)
+	} else {
+		s.setInMode(modeResizeEn | modeExtndFlg)
+	}
+}
+
+// Windows lacks bracketed paste (for now)
 
 func (s *cScreen) EnablePaste() {}
 
 func (s *cScreen) DisablePaste() {}
 
 func (s *cScreen) Fini() {
-	s.finiOnce.Do(s.finish)
+	s.disengage()
 }
 
 func (s *cScreen) finish() {
@@ -271,8 +278,8 @@ func (s *cScreen) finish() {
 	s.setInMode(s.oimode)
 	s.setOutMode(s.oomode)
 	s.setBufferSize(int(s.oscreen.size.x), int(s.oscreen.size.y))
-	s.clearScreen(StyleDefault)
-	s.setCursorPos(0, 0)
+	s.clearScreen(StyleDefault, false)
+	s.setCursorPos(0, 0, false)
 	procSetConsoleTextAttribute.Call(
 		uintptr(s.out),
 		uintptr(s.mapStyle(StyleDefault)))
@@ -284,6 +291,68 @@ func (s *cScreen) finish() {
 	<-s.scandone
 	syscall.Close(s.in)
 	syscall.Close(s.out)
+}
+
+func (s *cScreen) disengage() {
+	s.Lock()
+	stopQ := s.stopQ
+	if stopQ == nil {
+		s.Unlock()
+		return
+	}
+	s.stopQ = nil
+	procSetEvent.Call(uintptr(s.cancelflag))
+	close(stopQ)
+	s.Unlock()
+
+	s.wg.Wait()
+
+	s.setInMode(s.oimode)
+	s.setOutMode(s.oomode)
+	s.setBufferSize(int(s.oscreen.size.x), int(s.oscreen.size.y))
+	s.clearScreen(StyleDefault, false)
+	s.setCursorPos(0, 0, false)
+	procSetConsoleTextAttribute.Call(
+		uintptr(s.out),
+		uintptr(s.mapStyle(StyleDefault)))
+}
+
+func (s *cScreen) engage() error {
+	s.Lock()
+	defer s.Unlock()
+	if s.stopQ != nil {
+		return errors.New("already engaged")
+	}
+	s.stopQ = make(chan struct{})
+	cf, _, e := procCreateEvent.Call(
+		uintptr(0),
+		uintptr(1),
+		uintptr(0),
+		uintptr(0))
+	if cf == uintptr(0) {
+		return e
+	}
+	s.cancelflag = syscall.Handle(cf)
+	s.enableMouse(s.mouseEnabled)
+
+	if s.vten {
+		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut)
+	} else {
+		s.setOutMode(0)
+	}
+
+	s.clearScreen(s.style, s.vten)
+	s.hideCursor()
+
+	s.cells.Invalidate()
+	s.hideCursor()
+	s.resize()
+	s.draw()
+	s.doCursor()
+
+	s.wg.Add(1)
+	go s.scanInput(s.stopQ)
+	return nil
 }
 
 func (s *cScreen) PostEventWait(ev Event) {
@@ -367,7 +436,7 @@ func (s *cScreen) doCursor() {
 	if x < 0 || y < 0 || x >= s.w || y >= s.h {
 		s.hideCursor()
 	} else {
-		s.setCursorPos(x, y)
+		s.setCursorPos(x, y, s.vten)
 		s.showCursor()
 	}
 }
@@ -691,10 +760,15 @@ func (s *cScreen) getConsoleInput() error {
 	return nil
 }
 
-func (s *cScreen) scanInput() {
+func (s *cScreen) scanInput(stopQ chan struct{}) {
+	defer s.wg.Done()
 	for {
+		select {
+		case <-stopQ:
+			return
+		default:
+		}
 		if e := s.getConsoleInput(); e != nil {
-			close(s.scandone)
 			return
 		}
 	}
@@ -843,7 +917,7 @@ func (s *cScreen) writeString(x, y int, style Style, ch []uint16) {
 	if len(ch) == 0 {
 		return
 	}
-	s.setCursorPos(x, y)
+	s.setCursorPos(x, y, s.vten)
 
 	if s.vten {
 		s.sendVtStyle(style)
@@ -859,7 +933,7 @@ func (s *cScreen) draw() {
 	// allocate a scratch line bit enough for no combining chars.
 	// if you have combining characters, you may pay for extra allocs.
 	if s.clear {
-		s.clearScreen(s.style)
+		s.clearScreen(s.style, s.vten)
 		s.clear = false
 		s.cells.Invalidate()
 	}
@@ -965,8 +1039,8 @@ func (s *cScreen) setCursorInfo(info *cursorInfo) {
 
 }
 
-func (s *cScreen) setCursorPos(x, y int) {
-	if s.vten {
+func (s *cScreen) setCursorPos(x, y int, vtEnable bool) {
+	if vtEnable {
 		// Note that the string is Y first.  Origin is 1,1.
 		s.emitVtString(fmt.Sprintf(vtCursorPos, y+1, x+1))
 	} else {
@@ -1028,15 +1102,15 @@ func (s *cScreen) Fill(r rune, style Style) {
 	s.Unlock()
 }
 
-func (s *cScreen) clearScreen(style Style) {
-	if s.vten {
+func (s *cScreen) clearScreen(style Style, vtEnable bool) {
+	if vtEnable {
 		s.sendVtStyle(style)
 		row := strings.Repeat(" ", s.w)
 		for y := 0; y < s.h; y++ {
-			s.setCursorPos(0, y)
+			s.setCursorPos(0, y, vtEnable)
 			s.emitVtString(row)
 		}
-		s.setCursorPos(0, 0)
+		s.setCursorPos(0, 0, vtEnable)
 
 	} else {
 		pos := coord{0, 0}
@@ -1184,4 +1258,13 @@ func (s *cScreen) Beep() error {
 		return err
 	}
 	return nil
+}
+
+func (s *cScreen) Suspend() error {
+	s.disengage()
+	return nil
+}
+
+func (s *cScreen) Resume() error {
+	return s.engage()
 }

--- a/nonblock_bsd.go
+++ b/nonblock_bsd.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package tcell
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// BSD systems use TIOC style ioctls.
+
+// nonBlocking changes VMIN to 0, and VTIME to 1.  This basically ensures that
+// we can wake up the input loop.  We only want to do this if we are going to interrupt
+// that loop.  Normally we use VMIN 1 and VTIME 0, which ensures we pick up bytes when
+// they come but don't spin burning cycles.
+func (t *tScreen) nonBlocking(on bool) {
+	fd := int(os.Stdin.Fd())
+	tio, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return
+	}
+	if on {
+		tio.Cc[unix.VMIN] = 0
+		tio.Cc[unix.VTIME] = 0
+	} else {
+		// block for any output
+		tio.Cc[unix.VTIME] = 0
+		tio.Cc[unix.VMIN] = 1
+	}
+
+	_ = syscall.SetNonblock(fd, on)
+	// We want to set this *right now*.
+	_ = unix.IoctlSetTermios(fd, unix.TIOCSETA, tio)
+}

--- a/nonblock_stub.go
+++ b/nonblock_stub.go
@@ -1,5 +1,3 @@
-// +build js plan9 windows
-
 // Copyright 2021 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,30 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build plan9 windows js
+
 package tcell
 
-// NB: We might someday wish to move Windows to this model.   However,
-// that would probably mean sacrificing some of the richer key reporting
-// that we can obtain with the console API present on Windows.
-
-func (t *tScreen) engage() error {
-	return ErrNoScreen
-}
-
-func (t *tScreen) disengage() {
-}
-
-func (t *tScreen) initialize() error {
-	return ErrNoScreen
-}
-
-func (t *tScreen) finalize() {
-}
-
-func (t *tScreen) getWinSize() (int, int, error) {
-	return 0, 0, ErrNoScreen
-}
-
-func (t *tScreen) Beep() error {
-	return ErrNoScreen
+func (t *tScreen) nonBlocking(on bool) error {
+	return nil
 }

--- a/screen.go
+++ b/screen.go
@@ -205,6 +205,14 @@ type Screen interface {
 	// runes) is always true.
 	HasKey(Key) bool
 
+	// Suspend pauses input and output processing.  It also restores the
+	// terminal settings to what they were when the application started.
+	// This can be used to, for example, run a sub-shell.
+	Suspend() error
+
+	// Resume resumes after Suspend().
+	Resume() error
+
 	// Beep attempts to sound an OS-dependent audible alert and returns an error
 	// when unsuccessful.
 	Beep() error

--- a/simulation.go
+++ b/simulation.go
@@ -520,3 +520,11 @@ func (s *simscreen) HasKey(Key) bool {
 func (s *simscreen) Beep() error {
 	return nil
 }
+
+func (s *simscreen) Suspend() error {
+	return nil
+}
+
+func (s *simscreen) Resume() error {
+	return nil
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -16,7 +16,6 @@ package tcell
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -91,7 +90,6 @@ type tScreen struct {
 	evch         chan Event
 	sigwinch     chan os.Signal
 	quit         chan struct{}
-	indoneq      chan struct{}
 	keyexist     map[Key]bool
 	keycodes     map[string]*tKeyCode
 	keychan      chan []byte
@@ -118,13 +116,20 @@ type tScreen struct {
 	enablePaste  string
 	disablePaste string
 	saved        *term.State
+	stopQ        chan struct{}
+	wg           sync.WaitGroup
+	mouseFlags   MouseFlags
+	pasteEnabled bool
 
 	sync.Mutex
 }
 
 func (t *tScreen) Init() error {
+	if e := t.initialize(); e != nil {
+		return e
+	}
+
 	t.evch = make(chan Event, 10)
-	t.indoneq = make(chan struct{})
 	t.keychan = make(chan []byte, 10)
 	t.keytimer = time.NewTimer(time.Millisecond * 50)
 	t.charset = "UTF-8"
@@ -147,10 +152,6 @@ func (t *tScreen) Init() error {
 	if i, _ := strconv.Atoi(os.Getenv("COLUMNS")); i != 0 {
 		w = i
 	}
-	if e := t.initialize(); e != nil {
-		return e
-	}
-
 	if t.ti.SetFgBgRGB != "" || t.ti.SetFgRGB != "" || t.ti.SetBgRGB != "" {
 		t.truecolor = true
 	}
@@ -184,8 +185,9 @@ func (t *tScreen) Init() error {
 	t.resize()
 	t.Unlock()
 
-	go t.mainLoop()
-	go t.inputLoop()
+	if err := t.engage(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -472,30 +474,7 @@ func (t *tScreen) Fini() {
 }
 
 func (t *tScreen) finish() {
-	t.Lock()
-	defer t.Unlock()
-
-	ti := t.ti
-	t.cells.Resize(0, 0)
-	t.TPuts(ti.ShowCursor)
-	t.TPuts(ti.AttrOff)
-	t.TPuts(ti.Clear)
-	t.TPuts(ti.ExitCA)
-	t.TPuts(ti.ExitKeypad)
-	t.TPuts(t.disablePaste)
-	t.DisableMouse()
-	t.curstyle = styleInvalid
-	t.clear = false
-	t.fini = true
-
-	select {
-	case <-t.quit:
-		// do nothing, already closed
-
-	default:
-		close(t.quit)
-	}
-
+	close(t.quit)
 	t.finalize()
 }
 
@@ -847,40 +826,60 @@ func (t *tScreen) EnableMouse(flags ...MouseFlags) {
 		f = MouseMotionEvents
 	}
 
+	t.Lock()
+	t.mouseFlags = f
+	t.enableMouse(f)
+	t.Unlock()
+}
+
+func (t *tScreen) enableMouse(f MouseFlags) {
 	// Rather than using terminfo to find mouse escape sequences, we rely on the fact that
 	// pretty much *every* terminal that supports mouse tracking follows the
 	// XTerm standards (the modern ones).
-
 	if len(t.mouse) != 0 {
-		var mm int
-		if f & MouseMotionEvents != 0 {
-			mm = 1003
-		} else if f & MouseDragEvents != 0 {
-			mm = 1002
-		} else if f & MouseButtonEvents != 0 {
-			mm = 1000
-		} else {
-			// No recognized tracking enabled.
-			return
+		// start by disabling all tracking.
+		t.TPuts("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
+		if f&MouseMotionEvents != 0 {
+			t.TPuts("\x1b[?1003h\x1b[?1006h")
+		} else if f&MouseDragEvents != 0 {
+			t.TPuts("\x1b[?1002h\x1b[?1006h")
+		} else if f&MouseButtonEvents != 0 {
+			t.TPuts("\x1b[?1000h\x1b[?1006h")
 		}
-
-		t.TPuts(fmt.Sprintf("\x1b[?%dh\x1b[?1006h", mm))
 	}
 }
 
 func (t *tScreen) DisableMouse() {
-	if len(t.mouse) != 0 {
-		// This turns off everything.
-		t.TPuts("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
-	}
+	t.Lock()
+	t.mouseFlags = 0
+	t.enableMouse(0)
+	t.Unlock()
 }
 
 func (t *tScreen) EnablePaste() {
-	t.TPuts(t.enablePaste)
+	t.Lock()
+	t.pasteEnabled = true
+	t.enablePasting(true)
+	t.Unlock()
 }
 
 func (t *tScreen) DisablePaste() {
-	t.TPuts(t.disablePaste)
+	t.Lock()
+	t.pasteEnabled = false
+	t.enablePasting(false)
+	t.Unlock()
+}
+
+func (t *tScreen) enablePasting(on bool) {
+	var s string
+	if on {
+		s = t.enablePaste
+	} else {
+		s = t.disablePaste
+	}
+	if s != "" {
+		t.TPuts(s)
+	}
 }
 
 func (t *tScreen) Size() (int, int) {
@@ -1434,12 +1433,14 @@ func (t *tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event
 	return res
 }
 
-func (t *tScreen) mainLoop() {
+func (t *tScreen) mainLoop(stopQ chan struct{}) {
+	defer t.wg.Done()
 	buf := &bytes.Buffer{}
 	for {
 		select {
+		case <-stopQ:
+			return
 		case <-t.quit:
-			close(t.indoneq)
 			return
 		case <-t.sigwinch:
 			t.Lock()
@@ -1487,19 +1488,26 @@ func (t *tScreen) mainLoop() {
 	}
 }
 
-func (t *tScreen) inputLoop() {
+func (t *tScreen) inputLoop(stopQ chan struct{}) {
 
+	defer t.wg.Done()
 	for {
+		select {
+		case <-stopQ:
+			return
+		default:
+		}
 		chunk := make([]byte, 128)
 		n, e := t.in.Read(chunk)
 		switch e {
-		case io.EOF:
 		case nil:
 		default:
 			_ = t.PostEvent(NewEventError(e))
 			return
 		}
-		t.keychan <- chunk[:n]
+		if n > 0 {
+			t.keychan <- chunk[:n]
+		}
 	}
 }
 
@@ -1571,3 +1579,13 @@ func (t *tScreen) HasKey(k Key) bool {
 }
 
 func (t *tScreen) Resize(int, int, int, int) {}
+
+
+func (t *tScreen) Suspend() error {
+	t.disengage()
+	return nil
+}
+
+func (t *tScreen) Resume() error {
+	return t.engage()
+}

--- a/tscreen_unix.go
+++ b/tscreen_unix.go
@@ -1,5 +1,3 @@
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris zos
-
 // Copyright 2021 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris zos
+
 package tcell
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -28,14 +29,27 @@ import (
 // Thing of this is as tcell "engaging" the clutch, as it's going to be driving the
 // terminal interface.
 func (t *tScreen) engage() error {
-
-	stdin := int(t.in.Fd())
-	if _, err := term.MakeRaw(stdin); err != nil {
+	t.Lock()
+	defer t.Unlock()
+	if t.stopQ != nil {
+		return errors.New("already engaged")
+	}
+	if _, err := term.MakeRaw(int(t.in.Fd())); err != nil {
 		return err
 	}
-	if w, h, err := term.GetSize(stdin); err == nil && w != 0 && h != 0 {
+	if w, h, err := term.GetSize(int(t.in.Fd())); err == nil && w != 0 && h != 0 {
 		t.cells.Resize(w, h)
 	}
+	stopQ := make(chan struct{})
+	t.stopQ = stopQ
+	t.nonBlocking(false)
+	t.enableMouse(t.mouseFlags)
+	t.enablePasting(t.pasteEnabled)
+	signal.Notify(t.sigwinch, syscall.SIGWINCH)
+
+	t.wg.Add(2)
+	go t.inputLoop(stopQ)
+	go t.mainLoop(stopQ)
 	return nil
 }
 
@@ -44,9 +58,36 @@ func (t *tScreen) engage() error {
 // can take over the terminal interface.  This restores the TTY mode that was
 // present when the application was first started.
 func (t *tScreen) disengage() {
-	if t.in != nil {
-		term.Restore(int(t.in.Fd()), t.saved)
-	}
+
+	t.Lock()
+	t.nonBlocking(true)
+	stopQ := t.stopQ
+	t.stopQ = nil
+	close(stopQ)
+	t.Unlock()
+
+	// wait for everything to shut down
+	t.wg.Wait()
+
+	signal.Stop(t.sigwinch)
+
+	// put back normal blocking mode
+	t.nonBlocking(false)
+
+	// shutdown the screen and disable special modes (e.g. mouse and bracketed paste)
+	ti := t.ti
+	t.cells.Resize(0, 0)
+	t.TPuts(ti.ShowCursor)
+	t.TPuts(ti.AttrOff)
+	t.TPuts(ti.Clear)
+	t.TPuts(ti.ExitCA)
+	t.TPuts(ti.ExitKeypad)
+	t.enableMouse(0)
+	t.enablePasting(false)
+
+	// restore the termios that we were started with
+	_ = term.Restore(int(t.in.Fd()), t.saved)
+
 }
 
 // initialize is used at application startup, and sets up the initial values
@@ -54,16 +95,10 @@ func (t *tScreen) disengage() {
 // so that it can be restored when the application terminates.
 func (t *tScreen) initialize() error {
 	var err error
-	fd := int(os.Stdin.Fd())
-	t.in = os.Stdin
 	t.out = os.Stdout
-	t.saved, err = term.GetState(fd)
+	t.in = os.Stdin
+	t.saved, err = term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
-		return err
-	}
-	signal.Notify(t.sigwinch, syscall.SIGWINCH)
-
-	if err := t.engage(); err != nil {
 		return err
 	}
 	return nil
@@ -72,10 +107,6 @@ func (t *tScreen) initialize() error {
 // finalize is used to at application shutdown, and restores the terminal
 // to it's initial state.  It should not be called more than once.
 func (t *tScreen) finalize() {
-
-	signal.Stop(t.sigwinch)
-
-	<-t.indoneq
 
 	t.disengage()
 }


### PR DESCRIPTION
fixes #194 Starting multiple screen sessions (lost key event)

You can test this by using the mouse demo, which now supports pressing
CTRL-Z.  This does not actually suspend the demo, but starts a subshell
which takes over.  After the subshell is exited, the demo takes control
of the screen back.  This can be done multiple times, and it is possible
to start multiple "nested" iterations of the demo this way.