### PR TITLE
Change to /dev/tty because term.GetState fails

### DIFF
--- a/tscreen_unix.go
+++ b/tscreen_unix.go
@@ -96,10 +96,14 @@ func (t *tScreen) disengage() {
 func (t *tScreen) initialize() error {
 	var err error
 	t.out = os.Stdout
-	t.in = os.Stdin
-	t.saved, err = term.GetState(int(os.Stdin.Fd()))
+	t.in, err = os.OpenFile("/dev/tty", os.O_RDONLY, 0)
 	if err != nil {
 		return err
+	}
+
+	t.saved, err = term.GetState(int(t.in.Fd()))
+	if err == nil {
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
This is a fix for #432.
The file descriptor of "os.Stdin"
may cause term.GetState to be an error.