### PR TITLE
Interfaces to expose internal APIs for SIXEL

### DIFF
--- a/interceptors.go
+++ b/interceptors.go
@@ -7,16 +7,18 @@ type interceptors struct {
 	afterFunc  DrawInterceptFunc
 }
 
-func (icepts interceptors) before(s Screen, sync bool) {
+func (icepts interceptors) before(s Screen, sync bool) bool {
 	if icepts.beforeFunc != nil {
-		icepts.beforeFunc(s, sync)
+		return icepts.beforeFunc(s, sync)
 	}
+	return false
 }
 
-func (icepts interceptors) after(s Screen, sync bool) {
+func (icepts interceptors) after(s Screen, sync bool) bool {
 	if icepts.afterFunc != nil {
-		icepts.afterFunc(s, sync)
+		return icepts.afterFunc(s, sync)
 	}
+	return false
 }
 
 // AddDrawIntercept wraps the existing draw intercept function with the given
@@ -36,9 +38,10 @@ func wrapDrawInterceptFunc(oldFn, newFn DrawInterceptFunc) DrawInterceptFunc {
 		return newFn
 	}
 
-	return func(s Screen, sync bool) {
-		newFn(s, sync)
-		oldFn(s, sync)
+	return func(s Screen, sync bool) bool {
+		a := newFn(s, sync)
+		b := oldFn(s, sync)
+		return a || b
 	}
 }
 

--- a/interceptors.go
+++ b/interceptors.go
@@ -1,0 +1,48 @@
+package tcell
+
+// interceptors implements the DrawInterceptAdder interface. It provides
+// somewhere to store the callbacks.
+type interceptors struct {
+	beforeFunc DrawInterceptFunc
+	afterFunc  DrawInterceptFunc
+}
+
+func (icepts interceptors) before(s Screen, sync bool) {
+	if icepts.beforeFunc != nil {
+		icepts.beforeFunc(s, sync)
+	}
+}
+
+func (icepts interceptors) after(s Screen, sync bool) {
+	if icepts.afterFunc != nil {
+		icepts.afterFunc(s, sync)
+	}
+}
+
+// AddDrawIntercept wraps the existing draw intercept function with the given
+// one.
+func (icepts *interceptors) AddDrawIntercept(fn DrawInterceptFunc) {
+	icepts.beforeFunc = wrapDrawInterceptFunc(icepts.beforeFunc, fn)
+}
+
+// AddDrawInterceptAfter adds the draw interceptor after everything is drawn.
+func (icepts *interceptors) AddDrawInterceptAfter(fn DrawInterceptFunc) {
+	icepts.afterFunc = wrapDrawInterceptFunc(icepts.afterFunc, fn)
+}
+
+func wrapDrawInterceptFunc(oldFn, newFn DrawInterceptFunc) DrawInterceptFunc {
+	// directly use the new function if we don't have an old one.
+	if oldFn == nil {
+		return newFn
+	}
+
+	return func(s Screen, sync bool) {
+		newFn(s, sync)
+		oldFn(s, sync)
+	}
+}
+
+type noopMutex struct{}
+
+func (noopMutex) Lock()   {}
+func (noopMutex) Unlock() {}

--- a/screen.go
+++ b/screen.go
@@ -243,17 +243,19 @@ const (
 
 // DrawInterceptFunc is the callback to intercept a draw. It is called when the
 // lock is acquired. Sync is true if the whole screen is about to be cleared, or
-// for after interceptors, after clearing.
+// for after interceptors, after clearing. If the callback returns true on
+// before, then the screen is cleared after the callback is done. If it's an
+// after, then the screen will be cleared on the next draw.
 //
 // The interceptor function must use the given screen instead of referencing the
 // existing screen from outside. This is done to prevent deadlocks.
-type DrawInterceptFunc func(s Screen, sync bool)
+type DrawInterceptFunc func(s Screen, sync bool) (clear bool)
 
 // DrawInterceptAdder is an interface that Screen can implement to add a draw
-// itnerceptor function. This interface could be used to draw custom SIXEL
+// interceptor function. This interface could be used to draw custom SIXEL
 // images as well as other raw terminal things.
 //
-// Implementations must call these functions before any state changes, or in teh
+// Implementations must call these functions before any state changes, or in the
 // case of After, after all state changes. For example, draw interceptors should
 // be called before the cursor is hidden, and the after interceptors should be
 // called after the cursor is shown and everything is drawn into the buffer (but

--- a/tscreen.go
+++ b/tscreen.go
@@ -825,7 +825,11 @@ func (t tScreen) draw() {
 
 	// call the interceptors with a clean buffer and call the after interceptors
 	// when we're done
-	t.interceptors.before(t, clearing)
+	interceptClear := t.interceptors.before(t, clearing)
+
+	if !clearing {
+		clearing = interceptClear
+	}
 
 	// clobber cursor position, because we're gonna change it all
 	t.cx = -1
@@ -855,7 +859,7 @@ func (t tScreen) draw() {
 	t.showCursor()
 
 	// call the interceptor before flushing the buffer
-	t.interceptors.after(t, clearing)
+	t.clear = t.interceptors.after(t, clearing)
 
 	_, _ = t.buf.WriteTo(t.out)
 }

--- a/tscreen.go
+++ b/tscreen.go
@@ -197,7 +197,7 @@ func (t tScreen) Init() error {
 	t.cells.Resize(w, h)
 	t.cursorx = -1
 	t.cursory = -1
-	t.resize()
+	t.resize(true)
 	t.Unlock()
 
 	if err := t.engage(); err != nil {
@@ -784,8 +784,9 @@ func (t tScreen) TPuts(s string) {
 func (t tScreen) Show() {
 	t.Lock()
 	if !t.fini {
-		t.resize()
+		t.resize(false)
 		t.draw()
+		t.dispatchResizeEvent()
 	}
 	t.Unlock()
 }
@@ -1526,8 +1527,9 @@ func (t tScreen) mainLoop(stopQ chan struct{}) {
 			t.Lock()
 			t.cx = -1
 			t.cy = -1
-			t.resize()
+			t.resize(false)
 			t.draw()
+			t.dispatchResizeEvent()
 			t.Unlock()
 			continue
 		case <-t.keytimer.C:
@@ -1595,10 +1597,11 @@ func (t tScreen) Sync() {
 	t.cx = -1
 	t.cy = -1
 	if !t.fini {
-		t.resize()
+		t.resize(false)
 		t.clear = true
 		t.cells.Invalidate()
 		t.draw()
+		t.dispatchResizeEvent()
 	}
 	t.Unlock()
 }

--- a/tscreen.go
+++ b/tscreen.go
@@ -50,7 +50,10 @@ func NewTerminfoScreen() (Screen, error) {
 		}
 		terminfo.AddTerminfo(ti)
 	}
-	t := &tScreen{ti: ti}
+	t := tScreen{
+		tState: &tState{ti: ti},
+		Locker: &sync.Mutex{},
+	}
 
 	t.keyexist = make(map[Key]bool)
 	t.keycodes = make(map[string]*tKeyCode)
@@ -59,7 +62,7 @@ func NewTerminfoScreen() (Screen, error) {
 	}
 	t.prepareKeys()
 	t.buildAcsMap()
-	t.sigwinch = make(chan os.Signal, 10)
+	t.sigwinch = make(chan os.Signal, 2)
 	t.fallback = make(map[rune]string)
 	for k, v := range RuneFallbacks {
 		t.fallback[k] = v
@@ -76,9 +79,15 @@ type tKeyCode struct {
 
 // tScreen represents a screen backed by a terminfo implementation.
 type tScreen struct {
+	*tState
+	sync.Locker
+}
+
+// tState represents a screen's internal states.
+type tState struct {
+	tScreenSize
+
 	ti           *terminfo.Terminfo
-	h            int
-	w            int
 	fini         bool
 	cells        CellBuffer
 	in           *os.File
@@ -120,11 +129,17 @@ type tScreen struct {
 	wg           sync.WaitGroup
 	mouseFlags   MouseFlags
 	pasteEnabled bool
-
-	sync.Mutex
+	interceptors interceptors
 }
 
-func (t *tScreen) Init() error {
+type tScreenSize struct {
+	h   int
+	w   int
+	xpx int
+	ypx int
+}
+
+func (t tScreen) Init() error {
 	if e := t.initialize(); e != nil {
 		return e
 	}
@@ -192,7 +207,7 @@ func (t *tScreen) Init() error {
 	return nil
 }
 
-func (t *tScreen) prepareKeyMod(key Key, mod ModMask, val string) {
+func (t tScreen) prepareKeyMod(key Key, mod ModMask, val string) {
 	if val != "" {
 		// Do not override codes that already exist
 		if _, exist := t.keycodes[val]; !exist {
@@ -202,7 +217,7 @@ func (t *tScreen) prepareKeyMod(key Key, mod ModMask, val string) {
 	}
 }
 
-func (t *tScreen) prepareKeyModReplace(key Key, replace Key, mod ModMask, val string) {
+func (t tScreen) prepareKeyModReplace(key Key, replace Key, mod ModMask, val string) {
 	if val != "" {
 		// Do not override codes that already exist
 		if old, exist := t.keycodes[val]; !exist || old.key == replace {
@@ -212,7 +227,7 @@ func (t *tScreen) prepareKeyModReplace(key Key, replace Key, mod ModMask, val st
 	}
 }
 
-func (t *tScreen) prepareKeyModXTerm(key Key, val string) {
+func (t tScreen) prepareKeyModXTerm(key Key, val string) {
 
 	if strings.HasPrefix(val, "\x1b[") && strings.HasSuffix(val, "~") {
 
@@ -257,7 +272,7 @@ func (t *tScreen) prepareKeyModXTerm(key Key, val string) {
 	}
 }
 
-func (t *tScreen) prepareXtermModifiers() {
+func (t tScreen) prepareXtermModifiers() {
 	if t.ti.Modifiers != terminfo.ModifiersXTerm {
 		return
 	}
@@ -285,7 +300,7 @@ func (t *tScreen) prepareXtermModifiers() {
 	t.prepareKeyModXTerm(KeyF12, t.ti.KeyF12)
 }
 
-func (t *tScreen) prepareBracketedPaste() {
+func (t tScreen) prepareBracketedPaste() {
 	// Another workaround for lack of reporting in terminfo.
 	// We assume if the terminal has a mouse entry, that it
 	// offers bracketed paste.  But we allow specific overrides
@@ -303,11 +318,11 @@ func (t *tScreen) prepareBracketedPaste() {
 	}
 }
 
-func (t *tScreen) prepareKey(key Key, val string) {
+func (t tScreen) prepareKey(key Key, val string) {
 	t.prepareKeyMod(key, ModNone, val)
 }
 
-func (t *tScreen) prepareKeys() {
+func (t tScreen) prepareKeys() {
 	ti := t.ti
 	t.prepareKey(KeyBackspace, ti.KeyBackspace)
 	t.prepareKey(KeyF1, ti.KeyF1)
@@ -469,16 +484,16 @@ outer:
 	}
 }
 
-func (t *tScreen) Fini() {
+func (t tScreen) Fini() {
 	t.finiOnce.Do(t.finish)
 }
 
-func (t *tScreen) finish() {
+func (t tScreen) finish() {
 	close(t.quit)
 	t.finalize()
 }
 
-func (t *tScreen) SetStyle(style Style) {
+func (t tScreen) SetStyle(style Style) {
 	t.Lock()
 	if !t.fini {
 		t.style = style
@@ -486,11 +501,11 @@ func (t *tScreen) SetStyle(style Style) {
 	t.Unlock()
 }
 
-func (t *tScreen) Clear() {
+func (t tScreen) Clear() {
 	t.Fill(' ', t.style)
 }
 
-func (t *tScreen) Fill(r rune, style Style) {
+func (t tScreen) Fill(r rune, style Style) {
 	t.Lock()
 	if !t.fini {
 		t.cells.Fill(r, style)
@@ -498,7 +513,7 @@ func (t *tScreen) Fill(r rune, style Style) {
 	t.Unlock()
 }
 
-func (t *tScreen) SetContent(x, y int, mainc rune, combc []rune, style Style) {
+func (t tScreen) SetContent(x, y int, mainc rune, combc []rune, style Style) {
 	t.Lock()
 	if !t.fini {
 		t.cells.SetContent(x, y, mainc, combc, style)
@@ -506,14 +521,14 @@ func (t *tScreen) SetContent(x, y int, mainc rune, combc []rune, style Style) {
 	t.Unlock()
 }
 
-func (t *tScreen) GetContent(x, y int) (rune, []rune, Style, int) {
+func (t tScreen) GetContent(x, y int) (rune, []rune, Style, int) {
 	t.Lock()
 	mainc, combc, style, width := t.cells.GetContent(x, y)
 	t.Unlock()
 	return mainc, combc, style, width
 }
 
-func (t *tScreen) SetCell(x, y int, style Style, ch ...rune) {
+func (t tScreen) SetCell(x, y int, style Style, ch ...rune) {
 	if len(ch) > 0 {
 		t.SetContent(x, y, ch[0], ch[1:], style)
 	} else {
@@ -521,7 +536,7 @@ func (t *tScreen) SetCell(x, y int, style Style, ch ...rune) {
 	}
 }
 
-func (t *tScreen) encodeRune(r rune, buf []byte) []byte {
+func (t tScreen) encodeRune(r rune, buf []byte) []byte {
 
 	nb := make([]byte, 6)
 	ob := make([]byte, 6)
@@ -551,7 +566,7 @@ func (t *tScreen) encodeRune(r rune, buf []byte) []byte {
 	return buf
 }
 
-func (t *tScreen) sendFgBg(fg Color, bg Color) {
+func (t tScreen) sendFgBg(fg Color, bg Color) {
 	ti := t.ti
 	if ti.Colors == 0 {
 		return
@@ -615,7 +630,7 @@ func (t *tScreen) sendFgBg(fg Color, bg Color) {
 	}
 }
 
-func (t *tScreen) drawCell(x, y int) int {
+func (t tScreen) drawCell(x, y int) int {
 
 	ti := t.ti
 
@@ -701,18 +716,18 @@ func (t *tScreen) drawCell(x, y int) int {
 	return width
 }
 
-func (t *tScreen) ShowCursor(x, y int) {
+func (t tScreen) ShowCursor(x, y int) {
 	t.Lock()
 	t.cursorx = x
 	t.cursory = y
 	t.Unlock()
 }
 
-func (t *tScreen) HideCursor() {
+func (t tScreen) HideCursor() {
 	t.ShowCursor(-1, -1)
 }
 
-func (t *tScreen) showCursor() {
+func (t tScreen) showCursor() {
 
 	x, y := t.cursorx, t.cursory
 	w, h := t.cells.Size()
@@ -726,13 +741,31 @@ func (t *tScreen) showCursor() {
 	t.cy = y
 }
 
+var _ DirectDrawer = (*tScreen)(nil)
+
+// DrawDirectly draws the given bytes directly into the screen buffer or the
+// screen file descriptor. If the screen is buffered, then the bytes will be
+// drawn on flush.
+func (t tScreen) DrawDirectly(b []byte) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.showCursor()
+
+	if t.buffering {
+		_, _ = t.buf.Write(b)
+	} else {
+		_, _ = t.out.Write(b)
+	}
+}
+
 // writeString sends a string to the terminal. The string is sent as-is and
 // this function does not expand inline padding indications (of the form
 // $<[delay]> where [delay] is msec). In order to have these expanded, use
 // TPuts. If the screen is "buffering", the string is collected in a buffer,
 // with the intention that the entire buffer be sent to the terminal in one
 // write operation at some point later.
-func (t *tScreen) writeString(s string) {
+func (t tScreen) writeString(s string) {
 	if t.buffering {
 		_, _ = io.WriteString(&t.buf, s)
 	} else {
@@ -740,7 +773,7 @@ func (t *tScreen) writeString(s string) {
 	}
 }
 
-func (t *tScreen) TPuts(s string) {
+func (t tScreen) TPuts(s string) {
 	if t.buffering {
 		t.ti.TPuts(&t.buf, s)
 	} else {
@@ -748,7 +781,7 @@ func (t *tScreen) TPuts(s string) {
 	}
 }
 
-func (t *tScreen) Show() {
+func (t tScreen) Show() {
 	t.Lock()
 	if !t.fini {
 		t.resize()
@@ -757,14 +790,14 @@ func (t *tScreen) Show() {
 	t.Unlock()
 }
 
-func (t *tScreen) clearScreen() {
+func (t tScreen) clearScreen() {
 	fg, bg, _ := t.style.Decompose()
 	t.sendFgBg(fg, bg)
 	t.TPuts(t.ti.Clear)
 	t.clear = false
 }
 
-func (t *tScreen) hideCursor() {
+func (t tScreen) hideCursor() {
 	// does not update cursor position
 	if t.ti.HideCursor != "" {
 		t.TPuts(t.ti.HideCursor)
@@ -776,34 +809,42 @@ func (t *tScreen) hideCursor() {
 	}
 }
 
-func (t *tScreen) draw() {
-	// clobber cursor position, because we're gonna change it all
-	t.cx = -1
-	t.cy = -1
-
+func (t tScreen) draw() {
 	t.buf.Reset()
 	t.buffering = true
 	defer func() {
 		t.buffering = false
 	}()
 
+	clearing := t.clear
+
+	// t is passed by value, so we can directly mutate this; there is nothing
+	// after this that uses the mutex.
+	t.Locker = noopMutex{}
+
+	// call the interceptors with a clean buffer and call the after interceptors
+	// when we're done
+	t.interceptors.before(t, clearing)
+
+	// clobber cursor position, because we're gonna change it all
+	t.cx = -1
+	t.cy = -1
+
 	// hide the cursor while we move stuff around
 	t.hideCursor()
 
-	if t.clear {
+	if clearing {
 		t.clearScreen()
 	}
 
 	for y := 0; y < t.h; y++ {
 		for x := 0; x < t.w; x++ {
 			width := t.drawCell(x, y)
-			if width > 1 {
-				if x+1 < t.w {
-					// this is necessary so that if we ever
-					// go back to drawing that cell, we
-					// actually will *draw* it.
-					t.cells.SetDirty(x+1, y, true)
-				}
+			if width > 1 && x+1 < t.w {
+				// this is necessary so that if we ever
+				// go back to drawing that cell, we
+				// actually will *draw* it.
+				t.cells.SetDirty(x+1, y, true)
 			}
 			x += width - 1
 		}
@@ -812,10 +853,35 @@ func (t *tScreen) draw() {
 	// restore the cursor
 	t.showCursor()
 
+	// call the interceptor before flushing the buffer
+	t.interceptors.after(t, clearing)
+
 	_, _ = t.buf.WriteTo(t.out)
 }
 
-func (t *tScreen) EnableMouse(flags ...MouseFlags) {
+var _ CellBufferViewer = (*tScreen)(nil)
+
+func (t tScreen) ViewCellBuffer(f func(*CellBuffer)) {
+	t.Lock()
+	f(&t.cells)
+	t.Unlock()
+}
+
+var _ DirectDrawer = (*tScreen)(nil)
+
+func (t tScreen) AddDrawIntercept(fn DrawInterceptFunc) {
+	t.Lock()
+	t.interceptors.AddDrawIntercept(fn)
+	t.Unlock()
+}
+
+func (t tScreen) AddDrawInterceptAfter(fn DrawInterceptFunc) {
+	t.Lock()
+	t.interceptors.AddDrawInterceptAfter(fn)
+	t.Unlock()
+}
+
+func (t tScreen) EnableMouse(flags ...MouseFlags) {
 	var f MouseFlags
 	flagsPresent := false
 	for _, flag := range flags {
@@ -832,7 +898,7 @@ func (t *tScreen) EnableMouse(flags ...MouseFlags) {
 	t.Unlock()
 }
 
-func (t *tScreen) enableMouse(f MouseFlags) {
+func (t tScreen) enableMouse(f MouseFlags) {
 	// Rather than using terminfo to find mouse escape sequences, we rely on the fact that
 	// pretty much *every* terminal that supports mouse tracking follows the
 	// XTerm standards (the modern ones).
@@ -849,28 +915,28 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 	}
 }
 
-func (t *tScreen) DisableMouse() {
+func (t tScreen) DisableMouse() {
 	t.Lock()
 	t.mouseFlags = 0
 	t.enableMouse(0)
 	t.Unlock()
 }
 
-func (t *tScreen) EnablePaste() {
+func (t tScreen) EnablePaste() {
 	t.Lock()
 	t.pasteEnabled = true
 	t.enablePasting(true)
 	t.Unlock()
 }
 
-func (t *tScreen) DisablePaste() {
+func (t tScreen) DisablePaste() {
 	t.Lock()
 	t.pasteEnabled = false
 	t.enablePasting(false)
 	t.Unlock()
 }
 
-func (t *tScreen) enablePasting(on bool) {
+func (t tScreen) enablePasting(on bool) {
 	var s string
 	if on {
 		s = t.enablePaste
@@ -882,30 +948,44 @@ func (t *tScreen) enablePasting(on bool) {
 	}
 }
 
-func (t *tScreen) Size() (int, int) {
+func (t tScreen) Size() (int, int) {
 	t.Lock()
-	w, h := t.w, t.h
-	t.Unlock()
-	return w, h
+	defer t.Unlock()
+
+	return t.w, t.h
 }
 
-func (t *tScreen) resize() {
-	if w, h, e := t.getWinSize(); e == nil {
-		if w != t.w || h != t.h {
-			t.cx = -1
-			t.cy = -1
+// PixelSize returns the pixel size of the terminal. It returns (0, 0) if the
+// information is not available.
+func (t tScreen) PixelSize() (int, int) {
+	t.Lock()
+	defer t.Unlock()
 
-			t.cells.Resize(w, h)
-			t.cells.Invalidate()
-			t.h = h
-			t.w = w
-			ev := NewEventResize(w, h)
-			_ = t.PostEvent(ev)
-		}
+	return t.xpx, t.ypx
+}
+
+func (t tScreen) resize(dispatch bool) {
+	if !t.updateScreenSize() {
+		return
+	}
+
+	t.cx = -1
+	t.cy = -1
+
+	t.cells.Resize(t.w, t.h)
+	t.cells.Invalidate()
+
+	if dispatch {
+		t.dispatchResizeEvent()
 	}
 }
 
-func (t *tScreen) Colors() int {
+func (t tScreen) dispatchResizeEvent() {
+	ev := NewEventResize(t.w, t.h)
+	_ = t.PostEvent(ev)
+}
+
+func (t tScreen) Colors() int {
 	// this doesn't change, no need for lock
 	if t.truecolor {
 		return 1 << 24
@@ -916,11 +996,11 @@ func (t *tScreen) Colors() int {
 // nColors returns the size of the built-in palette.
 // This is distinct from Colors(), as it will generally
 // always be a small number. (<= 256)
-func (t *tScreen) nColors() int {
+func (t tScreen) nColors() int {
 	return t.ti.Colors
 }
 
-func (t *tScreen) PollEvent() Event {
+func (t tScreen) PollEvent() Event {
 	select {
 	case <-t.quit:
 		return nil
@@ -980,7 +1060,7 @@ var vtACSNames = map[byte]rune{
 // alternate character encodings.  To do this, we use the standard VT100 ACS
 // maps.  This is only done if the terminal lacks support for Unicode; we
 // always prefer to emit Unicode glyphs when we are able.
-func (t *tScreen) buildAcsMap() {
+func (t tScreen) buildAcsMap() {
 	acsstr := t.ti.AltChars
 	t.acs = make(map[rune]string)
 	for len(acsstr) > 2 {
@@ -993,11 +1073,11 @@ func (t *tScreen) buildAcsMap() {
 	}
 }
 
-func (t *tScreen) PostEventWait(ev Event) {
+func (t tScreen) PostEventWait(ev Event) {
 	t.evch <- ev
 }
 
-func (t *tScreen) PostEvent(ev Event) error {
+func (t tScreen) PostEvent(ev Event) error {
 	select {
 	case t.evch <- ev:
 		return nil
@@ -1006,7 +1086,7 @@ func (t *tScreen) PostEvent(ev Event) error {
 	}
 }
 
-func (t *tScreen) clip(x, y int) (int, int) {
+func (t tScreen) clip(x, y int) (int, int) {
 	w, h := t.cells.Size()
 	if x < 0 {
 		x = 0
@@ -1026,7 +1106,7 @@ func (t *tScreen) clip(x, y int) (int, int) {
 // buildMouseEvent returns an event based on the supplied coordinates and button
 // state. Note that the screen's mouse button state is updated based on the
 // input to this function (i.e. it mutates the receiver).
-func (t *tScreen) buildMouseEvent(x, y, btn int) *EventMouse {
+func (t tScreen) buildMouseEvent(x, y, btn int) *EventMouse {
 
 	// XTerm mouse events only report at most one button at a time,
 	// which may include a wheel button.  Wheel motion events are
@@ -1090,7 +1170,7 @@ func (t *tScreen) buildMouseEvent(x, y, btn int) *EventMouse {
 // be removed from the buffer.  It returns true, false if the buffer might
 // contain such an event, but more bytes are necessary (partial match), and
 // false, false if the content is definitely *not* an SGR mouse record.
-func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
+func (t tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1209,7 +1289,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 // parseXtermMouse is like parseSgrMouse, but it parses a legacy
 // X11 mouse record.
-func (t *tScreen) parseXtermMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
+func (t tScreen) parseXtermMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 
 	b := buf.Bytes()
 
@@ -1258,7 +1338,7 @@ func (t *tScreen) parseXtermMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) 
 	return true, false
 }
 
-func (t *tScreen) parseFunctionKey(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
+func (t tScreen) parseFunctionKey(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	partial := false
 	for e, k := range t.keycodes {
@@ -1297,7 +1377,7 @@ func (t *tScreen) parseFunctionKey(buf *bytes.Buffer, evs *[]Event) (bool, bool)
 	return partial, false
 }
 
-func (t *tScreen) parseRune(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
+func (t tScreen) parseRune(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	b := buf.Bytes()
 	if b[0] >= ' ' && b[0] <= 0x7F {
 		// printable ASCII easy to deal with -- no encodings
@@ -1344,7 +1424,7 @@ func (t *tScreen) parseRune(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	return true, false
 }
 
-func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
+func (t tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 	evs := t.collectEventsFromInput(buf, expire)
 
 	for _, ev := range evs {
@@ -1355,7 +1435,7 @@ func (t *tScreen) scanInput(buf *bytes.Buffer, expire bool) {
 // Return an array of Events extracted from the supplied buffer. This is done
 // while holding the screen's lock - the events can then be queued for
 // application processing with the lock released.
-func (t *tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event {
+func (t tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event {
 
 	res := make([]Event, 0, 20)
 
@@ -1433,7 +1513,7 @@ func (t *tScreen) collectEventsFromInput(buf *bytes.Buffer, expire bool) []Event
 	return res
 }
 
-func (t *tScreen) mainLoop(stopQ chan struct{}) {
+func (t tScreen) mainLoop(stopQ chan struct{}) {
 	defer t.wg.Done()
 	buf := &bytes.Buffer{}
 	for {
@@ -1447,7 +1527,6 @@ func (t *tScreen) mainLoop(stopQ chan struct{}) {
 			t.cx = -1
 			t.cy = -1
 			t.resize()
-			t.cells.Invalidate()
 			t.draw()
 			t.Unlock()
 			continue
@@ -1488,7 +1567,7 @@ func (t *tScreen) mainLoop(stopQ chan struct{}) {
 	}
 }
 
-func (t *tScreen) inputLoop(stopQ chan struct{}) {
+func (t tScreen) inputLoop(stopQ chan struct{}) {
 
 	defer t.wg.Done()
 	for {
@@ -1511,7 +1590,7 @@ func (t *tScreen) inputLoop(stopQ chan struct{}) {
 	}
 }
 
-func (t *tScreen) Sync() {
+func (t tScreen) Sync() {
 	t.Lock()
 	t.cx = -1
 	t.cy = -1
@@ -1524,23 +1603,23 @@ func (t *tScreen) Sync() {
 	t.Unlock()
 }
 
-func (t *tScreen) CharacterSet() string {
+func (t tScreen) CharacterSet() string {
 	return t.charset
 }
 
-func (t *tScreen) RegisterRuneFallback(orig rune, fallback string) {
+func (t tScreen) RegisterRuneFallback(orig rune, fallback string) {
 	t.Lock()
 	t.fallback[orig] = fallback
 	t.Unlock()
 }
 
-func (t *tScreen) UnregisterRuneFallback(orig rune) {
+func (t tScreen) UnregisterRuneFallback(orig rune) {
 	t.Lock()
 	delete(t.fallback, orig)
 	t.Unlock()
 }
 
-func (t *tScreen) CanDisplay(r rune, checkFallbacks bool) bool {
+func (t tScreen) CanDisplay(r rune, checkFallbacks bool) bool {
 
 	if enc := t.encoder; enc != nil {
 		nb := make([]byte, 6)
@@ -1567,25 +1646,24 @@ func (t *tScreen) CanDisplay(r rune, checkFallbacks bool) bool {
 	return false
 }
 
-func (t *tScreen) HasMouse() bool {
+func (t tScreen) HasMouse() bool {
 	return len(t.mouse) != 0
 }
 
-func (t *tScreen) HasKey(k Key) bool {
+func (t tScreen) HasKey(k Key) bool {
 	if k == KeyRune {
 		return true
 	}
 	return t.keyexist[k]
 }
 
-func (t *tScreen) Resize(int, int, int, int) {}
+func (t tScreen) Resize(int, int, int, int) {}
 
-
-func (t *tScreen) Suspend() error {
+func (t tScreen) Suspend() error {
 	t.disengage()
 	return nil
 }
 
-func (t *tScreen) Resume() error {
+func (t tScreen) Resume() error {
 	return t.engage()
 }

--- a/tscreen_stub.go
+++ b/tscreen_stub.go
@@ -20,24 +20,24 @@ package tcell
 // that would probably mean sacrificing some of the richer key reporting
 // that we can obtain with the console API present on Windows.
 
-func (t *tScreen) engage() error {
+func (t tScreen) engage() error {
 	return ErrNoScreen
 }
 
-func (t *tScreen) disengage() {
+func (t tScreen) disengage() {
 }
 
-func (t *tScreen) initialize() error {
+func (t tScreen) initialize() error {
 	return ErrNoScreen
 }
 
-func (t *tScreen) finalize() {
+func (t tScreen) finalize() {
 }
 
-func (t *tScreen) getWinSize() (int, int, error) {
-	return 0, 0, ErrNoScreen
+func (t tScreen) updateScreenSize() bool {
+	return false
 }
 
-func (t *tScreen) Beep() error {
+func (t tScreen) Beep() error {
 	return ErrNoScreen
 }


### PR DESCRIPTION
This pull request adds several interfaces to optionally expose screen implementations for SIXEL graphics and such. It does not break any existing API or behavior. The Windows implementation of the screen is untouched and therefore will not support any of these new interfaces.
	
	Author: diamondburned <datutbrus@gmail.com>
	Date:   Fri Feb 26 23:24:24 2021 -0800
	
	    Add interceptor and pixel APIs for raw terminal support
	    
	    This commit adds several interfaces to allow raw terminal support, such
	    as for SIXEL graphics.
	    
	    DrawInterceptor was added for extensions to intercept each draw event
	    to synchronize its state with the screen's and redraw things it needs to
	    while occupying the screen lock to prevent data race with the user.
	    
	    PixelSizer was added to expose the screen's size in pixels from
	    TIOCGWINSZ. This is needed to properly resize and position SIXEL images
	    on the terminal.
	    
	    CellBufferViewer was added for low-level efficient damage tracking for
	    draw interceptors to synchronize the screen state.

	Author: diamondburned <datutbrus@gmail.com>
	Date:   Thu Mar 4 17:19:36 2021 -0800
	
	    Dispatch ResizeEvent after drawing
	    
	    This commit changes the Unix screen to dispatch events only after
	    drawing. This helps draw interceptors update its states in time before
	    the user gets the event.

### Proof-of-concept

As of the time this pull request was made, [a tcell SIXEL library](https://github.com/diamondburned/tcell-sixel) was written as a proof-of-concept that such an API could be used for not just static SIXEL images but also animations:

![gif demo](https://raw.githubusercontent.com/diamondburned/tcell-sixel/6el/sixel-demo.gif)