### PR TITLE
switch back to ca mode after suspend/resume

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -168,11 +168,6 @@ func (t *tScreen) Init() error {
 		t.colors[Color(i)|ColorValid] = Color(i) | ColorValid
 	}
 
-	t.TPuts(ti.EnterCA)
-	t.TPuts(ti.HideCursor)
-	t.TPuts(ti.EnableAcs)
-	t.TPuts(ti.Clear)
-
 	t.quit = make(chan struct{})
 
 	t.Lock()

--- a/tscreen_unix.go
+++ b/tscreen_unix.go
@@ -47,6 +47,12 @@ func (t *tScreen) engage() error {
 	t.enablePasting(t.pasteEnabled)
 	signal.Notify(t.sigwinch, syscall.SIGWINCH)
 
+	ti := t.ti
+	t.TPuts(ti.EnterCA)
+	t.TPuts(ti.HideCursor)
+	t.TPuts(ti.EnableAcs)
+	t.TPuts(ti.Clear)
+
 	t.wg.Add(2)
 	go t.inputLoop(stopQ)
 	go t.mainLoop(stopQ)

--- a/tscreen_unix.go
+++ b/tscreen_unix.go
@@ -49,6 +49,7 @@ func (t *tScreen) engage() error {
 
 	ti := t.ti
 	t.TPuts(ti.EnterCA)
+	t.TPuts(ti.EnterKeypad)
 	t.TPuts(ti.HideCursor)
 	t.TPuts(ti.EnableAcs)
 	t.TPuts(ti.Clear)


### PR DESCRIPTION
Suspend call currently exits ca mode. So after the first suspend/resume
the program does not use the alternate screen anymore. Therefore Resume
needs to enter ca mode again.