### PR TITLE
fixes PollEvent() hung after Fini() on windows

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -370,7 +370,7 @@ func (s *cScreen) PostEvent(ev Event) error {
 
 func (s *cScreen) PollEvent() Event {
 	select {
-	case <-s.quit:
+	case <-s.stopQ:
 		return nil
 	case ev := <-s.evch:
 		return ev


### PR DESCRIPTION
It seems too many unused codes are left in console_win.go, which makes this obvious problem hard to be aware of while coding.