### PR TITLE
Screen: add End()

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -265,6 +265,13 @@ func (s *cScreen) Fini() {
 	s.disengage()
 }
 
+func (s *cScreen) End() {
+	s.showCursor()
+	procSetConsoleTextAttribute.Call(
+		uintptr(s.out), uintptr(s.mapStyle(StyleDefault)),
+	)
+}
+
 func (s *cScreen) finish() {
 	s.Lock()
 	s.style = StyleDefault

--- a/screen.go
+++ b/screen.go
@@ -24,6 +24,10 @@ type Screen interface {
 	// Fini finalizes the screen also releasing resources.
 	Fini()
 
+	// End sets default style and shows the cursor, without clearing the
+	// screen.
+	End()
+
 	// Clear erases the screen.  The contents of any screen buffers
 	// will also be cleared.  This has the logical effect of
 	// filling the screen with spaces, using the global default style.

--- a/simulation.go
+++ b/simulation.go
@@ -151,6 +151,8 @@ func (s *simscreen) Fini() {
 	s.front = nil
 }
 
+func (s *simscreen) End() {}
+
 func (s *simscreen) SetStyle(style Style) {
 	s.Lock()
 	s.style = style

--- a/tscreen.go
+++ b/tscreen.go
@@ -473,6 +473,8 @@ func (t *tScreen) Fini() {
 	t.finiOnce.Do(t.finish)
 }
 
+func (t *tScreen) End() {}
+
 func (t *tScreen) finish() {
 	close(t.quit)
 	t.finalize()


### PR DESCRIPTION
End() is similar to Fini(), except it only sets default styles and shows the
cursor, without clearing the screen. This is similar to the behavior with Less,
when used with the `-X` option or `LESS=X` environment variable:

https://serverfault.com/questions/785949

Fixes #262