### PR TITLE
Add tmux-wormhole to the list of tcell-dependent apps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,7 @@ Version 1.x remains available using the import `github.com/gdamore/tcell`.
 * https://github.com/tmountain/uchess[uchess] - A UCI chess client for your terminal
 * https://github.com/a-h/min[min] - A Gemini browser
 * https://github.com/noborus/ov - Terminal pager
+* https://github.com/gcla/tmux-wormhole - A tmux plugin to transfer files with magic wormhole
 
 == Pure Go Terminfo Database
 


### PR DESCRIPTION
I published this yesterday on github. It's a tmux plugin that scrapes
the active tmux pane for a magic wormhole code, then downloads and
optionally opens the file tied to the code. I wrote this to make it
easier to get pcaps from termshark into Wireshark. This plugin uses
gowid which itself depends wholly on tcell to manipulate the
terminal. Link: https://github.com/gcla/tmux-wormhole