### PR TITLE
Add gruid-tcell to the list of examples in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,7 @@ Version 1.x remains available using the import `github.com/gdamore/tcell`.
 * https://github.com/a-h/min[min] - A Gemini browser
 * https://github.com/noborus/ov[ov] - Terminal pager
 * https://github.com/gcla/tmux-wormhole[tmux-wormhole] - A tmux plugin to transfer files with magic wormhole
+* https://github.com/anaseto/gruid-tcell[gruid-tcell] - A tcell driver for the grid based UI and game framework gruid.
 
 == Pure Go Terminfo Database
 


### PR DESCRIPTION
gruid-tcell is a tcell-based driver for the grid-based UI and game
framework gruid. I would be glad to see it added on the examples.

Thanks for making tcell!