### PR TITLE
Add aretext to the list of examples in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,7 @@ Version 1.x remains available using the import `github.com/gdamore/tcell`.
 * https://github.com/noborus/ov[ov] - Terminal pager
 * https://github.com/gcla/tmux-wormhole[tmux-wormhole] - A tmux plugin to transfer files with magic wormhole
 * https://github.com/anaseto/gruid-tcell[gruid-tcell] - A tcell driver for the grid based UI and game framework gruid.
+* https://github.com/aretext/aretext[aretext] - Minimalist text editor with vim key bindings.
 
 == Pure Go Terminfo Database
 


### PR DESCRIPTION
Aretext is a minimalist text editor with vim key bindings.

Thanks for all your work on tcell!  This project would not have been possible without it.