### PR TITLE
Add Screen.ChannelEvents v2

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -343,6 +343,26 @@ func (s *cScreen) PostEvent(ev Event) error {
 	}
 }
 
+func (s *cScreen) ChannelEvents(ch chan<- Event, quit <-chan struct{}) {
+	defer close(ch)
+	for {
+		select {
+		case <-quit:
+			return
+		case <-s.stopQ:
+			return
+		case ev := <-s.evch:
+			select {
+			case <-quit:
+				return
+			case <-s.stopQ:
+				return
+			case ch <- ev:
+			}
+		}
+	}
+}
+
 func (s *cScreen) PollEvent() Event {
 	select {
 	case <-s.stopQ:

--- a/screen.go
+++ b/screen.go
@@ -79,9 +79,14 @@ type Screen interface {
 	Size() (int, int)
 
 	// ChannelEvents is an infinite loop that waits for an event and
-	// channels it into the user provided channel. When Fini() is called
-	// or quit is closed, the function returns. This function should be
-	// used as a goroutine.
+	// channels it into the user provided channel ch.  Closing the
+	// quit channel and calling the Fini method are cancellation
+	// signals.  When a cancellation signal is received the method
+	// returns after closing ch.
+	//
+	// This method should be used as a goroutine.
+	//
+	// NOTE: PollEvent should not be called while this method is running.
 	ChannelEvents(ch chan<- Event, quit <-chan struct{})
 
 	// PollEvent waits for events to arrive.  Main application loops

--- a/screen.go
+++ b/screen.go
@@ -78,6 +78,12 @@ type Screen interface {
 	// response to a call to Clear or Flush.
 	Size() (int, int)
 
+	// ChannelEvents is an infinite loop that waits for an event and
+	// channels it into the user provided channel. When Fini() is called
+	// or quit is closed, the function returns. This function should be
+	// used as a goroutine.
+	ChannelEvents(ch chan<- Event, quit <-chan struct{})
+
 	// PollEvent waits for events to arrive.  Main application loops
 	// must spin on this to prevent the application from stalling.
 	// Furthermore, this will return nil if the Screen is finalized.

--- a/simulation.go
+++ b/simulation.go
@@ -351,6 +351,26 @@ func (s *simscreen) Colors() int {
 	return 256
 }
 
+func (s *simscreen) ChannelEvents(ch chan<- Event, quit <-chan struct{}) {
+	defer close(ch)
+	for {
+		select {
+		case <-quit:
+			return
+		case <-s.quit:
+			return
+		case ev := <-s.evch:
+			select {
+			case <-quit:
+				return
+			case <-s.quit:
+				return
+			case ch <- ev:
+			}
+		}
+	}
+}
+
 func (s *simscreen) PollEvent() Event {
 	select {
 	case <-s.quit:

--- a/tscreen.go
+++ b/tscreen.go
@@ -638,7 +638,7 @@ func (t *tScreen) drawCell(x, y int) int {
 			t.TPuts(ti.TGoto(x-1, y))
 			t.TPuts(ti.InsertChar)
 			t.cy = y
-			t.cx = x-1
+			t.cx = x - 1
 			t.cells.SetDirty(x-1, y, true)
 			_ = t.drawCell(x-1, y)
 			t.TPuts(t.ti.TGoto(0, 0))
@@ -939,6 +939,26 @@ func (t *tScreen) Colors() int {
 // always be a small number. (<= 256)
 func (t *tScreen) nColors() int {
 	return t.ti.Colors
+}
+
+func (t *tScreen) ChannelEvents(ch chan<- Event, quit <-chan struct{}) {
+	defer close(ch)
+	for {
+		select {
+		case <-quit:
+			return
+		case <-t.quit:
+			return
+		case ev := <-t.evch:
+			select {
+			case <-quit:
+				return
+			case <-t.quit:
+				return
+			case ch <- ev:
+			}
+		}
+	}
 }
 
 func (t *tScreen) PollEvent() Event {


### PR DESCRIPTION
This PR proposes an alternative API for getting Events. Version 2. The following method is added:

```go
type Screen interface {
	...
	// ChannelEvents is an infinite loop that waits for an event and
	// channels it into the user provided channel. When Fini() is called
	// or quit is closed, the function returns. This function should be
	// used as a goroutine.
	ChannelEvents(ch chan<- Event, quit <-chan struct{})
	...
}
```

Previous version: #461.