### PR TITLE
Name return values for `Screen.Size`

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -76,7 +76,7 @@ type Screen interface {
 
 	// Size returns the screen size as width, height.  This changes in
 	// response to a call to Clear or Flush.
-	Size() (int, int)
+	Size() (width, height int)
 
 	// ChannelEvents is an infinite loop that waits for an event and
 	// channels it into the user provided channel ch.  Closing the


### PR DESCRIPTION
This adds names to the return values of the `Size` function to add
context. This also changes the return declarations to use the shortcut
when both named return values are the same type, by only specifying the
type once.

***

This is a pretty small change, and only for documentation purposes. I believe that it's easier to read the function declaration than the function's documentation to determine the context of the return values. For me, personally, I look at the function declaration before the comments when reading the docs on pkg.go.dev.

[Source](https://tour.golang.org/basics/7):
>These names should be used to document the meaning of the return values.