### PR TITLE
Add “foot-extra” as a terminfo alias for “foot”

### DIFF
--- a/terminfo/f/foot/foot.go
+++ b/terminfo/f/foot/foot.go
@@ -9,6 +9,7 @@ func init() {
 	// foot terminal emulator
 	terminfo.AddTerminfo(&terminfo.Terminfo{
 		Name:         "foot",
+		Aliases:      []string{"foot-extra"},
 		Columns:      80,
 		Lines:        24,
 		Colors:       256,


### PR DESCRIPTION
There are two “regular”[^1] terminfos for [foot](https://codeberg.org/dnkl/foot). One stripped down version included with ncurses, and another one shipped with foot itself, that contains a number on non-standard capabilities (mainly used by tmux).

Foot’s “own” terminfo is _usually_ packaged as “foot-extra”.

[^1]: there’s actually four; foot also has a “direct” variant (similar to xterm-direct): foot-direct, and foot-extra-direct.