### PR TITLE
enhanced mouse tracking mode (1006) is set improperly when exiting tcell

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -948,7 +948,7 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 		if f&MouseMotionEvents != 0 {
 			t.TPuts("\x1b[?1003h")
 		}
-		if f != 0 {
+		if f&(MouseButtonEvents|MouseDragEvents|MouseMotionEvents) != 0 {
 			t.TPuts("\x1b[?1006h")
 		}
 	}

--- a/tscreen.go
+++ b/tscreen.go
@@ -948,8 +948,9 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 		if f&MouseMotionEvents != 0 {
 			t.TPuts("\x1b[?1003h")
 		}
-
-		t.TPuts("\x1b[?1006h")
+		if f != 0 {
+			t.TPuts("\x1b[?1006h")
+		}
 	}
 
 }


### PR DESCRIPTION
Fixed to properly reset enhanced mouse tracking mode (1006) when calling `enableMouse(0)`.

related #477

Behavior before modification:

If I quit the `tcell` application with the mouse enabled and then start `vim`, the cursor doesn't move when I click the mouse.

The symptom was confirmed by `_demos/mouse.go` in the linux environment on Chromebook and Windows. 