### PR TITLE
Send AttrOff when clearing the screen

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -858,6 +858,7 @@ func (t *tScreen) Show() {
 }
 
 func (t *tScreen) clearScreen() {
+	t.TPuts(t.ti.AttrOff)
 	fg, bg, _ := t.style.Decompose()
 	t.sendFgBg(fg, bg)
 	t.TPuts(t.ti.Clear)


### PR DESCRIPTION
In tcell v2.4, the following calls would reset the screen
to its default color:

1. SetContent() to change the bg color to maroon.
2. Clear()
3. Show()

In tcell v2.5, the behavior changed to clear the screen
to the last-used style passed to SetContent.

This happens because commit 62f5502f set the dirty flag
to false for all cells, on the assumption that sending
ti.Clear would clear the cells anyway. Unlike the drawCell
calls triggered by the dirty flag, however, clearScreen
does not send AttrOff. This causes the screen to clear
to the last-used background color.

Issue: https://github.com/gdamore/tcell/issues/522