### PR TITLE
fixes #462 Console resizing

### DIFF
--- a/_demos/setsize.go
+++ b/_demos/setsize.go
@@ -1,0 +1,101 @@
+//go:build ignore
+// +build ignore
+
+// Copyright 2022 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/encoding"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
+	for _, c := range str {
+		var comb []rune
+		w := runewidth.RuneWidth(c)
+		if w == 0 {
+			comb = []rune{c}
+			c = ' '
+			w = 1
+		}
+		s.SetContent(x, y, c, comb, style)
+		x += w
+	}
+}
+
+func displayDemo(s tcell.Screen) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	sizeStr := fmt.Sprintf("%d x %d", w, h)
+	helpStr := "Use cursors to resize, ESC to exit."
+	emitStr(s, (w-len(sizeStr))/2, h/2, style, sizeStr)
+	emitStr(s, (w-len(helpStr))/2, h/2+1, tcell.StyleDefault, helpStr)
+	s.Show()
+}
+
+// This program just prints "Hello, World!".  Press ESC to exit.
+func main() {
+	encoding.Register()
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	displayDemo(s)
+
+	for {
+		switch ev := s.PollEvent().(type) {
+		case *tcell.EventResize:
+			s.Sync()
+			displayDemo(s)
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEscape:
+				s.Fini()
+				os.Exit(0)
+			case tcell.KeyRight:
+				w, h := s.Size()
+				s.SetSize(w+1, h)
+			case tcell.KeyLeft:
+				w, h := s.Size()
+				s.SetSize(w-1, h)
+			case tcell.KeyUp:
+				w, h := s.Size()
+				s.SetSize(w, h-1)
+			case tcell.KeyDown:
+				w, h := s.Size()
+				s.SetSize(w, h+1)
+			}
+		}
+	}
+}

--- a/screen.go
+++ b/screen.go
@@ -239,6 +239,15 @@ type Screen interface {
 	// Beep attempts to sound an OS-dependent audible alert and returns an error
 	// when unsuccessful.
 	Beep() error
+
+	// SetSize attempts to resize the window.  It also invalidates the cells and
+	// calls the resize function.  Note that if the window size is changed, it will
+	// not be restored upon application exit.
+	//
+	// Many terminals cannot support this.  Perversely, the "modern" Windows Terminal
+	// does not support application-initiated resizing, whereas the legacy terminal does.
+	// Also, some emulators can support this but may have it disabled by default.
+	SetSize(int, int)
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal

--- a/simulation.go
+++ b/simulation.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The TCell Authors
+// Copyright 2022 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -48,13 +48,6 @@ type SimulationScreen interface {
 
 	// InjectMouse injects a mouse event.
 	InjectMouse(x, y int, buttons ButtonMask, mod ModMask)
-
-	// SetSize resizes the underlying physical screen.  It also causes
-	// a resize event to be injected during the next Show() or Sync().
-	// A new physical contents array will be allocated (with data from
-	// the old copied), so any prior value obtained with GetContents
-	// won't be used anymore
-	SetSize(width, height int)
 
 	// GetContents returns screen contents as an array of
 	// cells, along with the physical width & height.   Note that the

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -229,6 +229,7 @@ type Terminfo struct {
 	CursorSteadyBar         string
 	EnterUrl                string
 	ExitUrl                 string
+	SetWindowSize           string
 }
 
 const (

--- a/tscreen.go
+++ b/tscreen.go
@@ -150,6 +150,7 @@ type tScreen struct {
 	disablePaste string
 	enterUrl     string
 	exitUrl      string
+	setWinSize   string
 	cursorStyles map[CursorStyle]string
 	cursorStyle  CursorStyle
 	saved        *term.State
@@ -347,6 +348,12 @@ func (t *tScreen) prepareExtendedOSC() {
 	} else if t.ti.Mouse != "" {
 		t.enterUrl = "\x1b]8;;%p1%s\x1b\\"
 		t.exitUrl = "\x1b]8;;\x1b\\"
+	}
+
+	if t.ti.SetWindowSize != "" {
+		t.setWinSize = t.ti.SetWindowSize
+	} else if t.ti.Mouse != "" {
+		t.setWinSize = "\x1b[8;%p1%p2%d;%dt"
 	}
 }
 
@@ -1743,6 +1750,14 @@ func (t *tScreen) HasKey(k Key) bool {
 		return true
 	}
 	return t.keyexist[k]
+}
+
+func (t *tScreen) SetSize(w, h int) {
+	if t.setWinSize != "" {
+		t.TPuts(t.ti.TParm(t.setWinSize, w, h))
+	}
+	t.cells.Invalidate()
+	t.resize()
 }
 
 func (t *tScreen) Resize(int, int, int, int) {}


### PR DESCRIPTION
This supports both terminfo (Linux, macOS) terminals, and
the legacy Windows console.  Perversely, the "modern" Windows
terminal doesn't support application initiated resizing yet.