### PR TITLE
Add Horizontal, Vertical const type Orientation (fixes #543)

### DIFF
--- a/views/constants.go
+++ b/views/constants.go
@@ -53,7 +53,7 @@ type Orientation int
 
 const (
 	// Horizontal indicates left to right orientation.
-	Horizontal = iota
+	Horizontal Orientation = iota
 
 	// Vertical indicates top to bottom orientation.
 	Vertical


### PR DESCRIPTION
Added the proper type `views.Orientation` for `views.Horizontal` and `views.Vertical` constants.