### PR TITLE
fixes #546 terminfo tput escape sequence errors

### DIFF
--- a/terminfo/terminfo_test.go
+++ b/terminfo/terminfo_test.go
@@ -63,6 +63,57 @@ func TestTerminfoExpansion(t *testing.T) {
 	if ti.TParm(ti.SetFg, 200) != "\x1b[38;5;200m" {
 		t.Error("SetFg(200) failed")
 	}
+
+	type testCase struct {
+		expect string
+		format string
+		params []interface{}
+	}
+
+	cases := []testCase{
+		{expect: "0a", format: "%p1%02x", params: []interface{}{10}},
+		{expect: "0A", format: "%p1%02X", params: []interface{}{10}},
+		{expect: "A", format: "%p1%c", params: []interface{}{65}},
+		{expect: "A", format: "%'A'%c", params: []interface{}{}},
+		{expect: "65", format: "%'A'%d", params: []interface{}{}},
+		{expect: "7", format: "%i%p1%p2%+%d", params: []interface{}{2, 3}},
+		{expect: "abc", format: "%p1%s", params: []interface{}{"abc"}},
+		{expect: "1%d", format: "1%%d", params: []interface{}{}},
+		{expect: "abc", format: "%p1%s%", params: []interface{}{"abc"}}, // unterminated %
+		{expect: "  abc", format: "%p1%5s", params: []interface{}{"abc"}},
+		{expect: "abc  ", format: "%p1%:-5s", params: []interface{}{"abc"}},
+		{expect: "15", format: "%{3}%p1%*%d", params: []interface{}{5}},
+		{expect: " A", format: "%p1%2c", params: []interface{}{65}},
+		{expect: "4", format: "%p1%l%d", params: []interface{}{"four"}},
+		{expect: "0", format: "%pA%d", params: []interface{}{}}, // missing/invalid parameter
+		{expect: "5", format: "%p1%p2%/%d", params: []interface{}{15, 3}},
+		{expect: "0", format: "%p1%p2%/%d", params: []interface{}{3, 15}},
+		{expect: "0", format: "%p1%p2%/%d", params: []interface{}{3, 0}},
+		{expect: "3", format: "%p1%p2%m%d", params: []interface{}{15, 4}},
+		{expect: "0", format: "%p1%p2%m%d", params: []interface{}{3, 0}},
+		{expect: "2", format: "%p1%Pa%{4}%{3}%ga%d", params: []interface{}{2}},
+		{expect: "2", format: "%p1%PA%{4}%{3}%gA%d", params: []interface{}{2}},
+		{expect: "0", format: "%p1%PA%{4}%{3}%ga%d", params: []interface{}{2}},
+		{expect: "0", format: "%p1%Pz%{4}%{3}%gZ%d", params: []interface{}{2}},
+		{expect: "0", format: "%d", params: []interface{}{}}, // underflow
+		{expect: "", format: "%s", params: []interface{}{}},  // underflow
+		{expect: "1", format: "%p1%p2%=%d", params: []interface{}{3, 3}},
+		{expect: "0", format: "%p1%p2%=%d", params: []interface{}{3, 4}},
+		{expect: "1", format: "%p1%p2%=%!%d", params: []interface{}{3, 4}},
+		{expect: "1", format: "%p1%p2%>%d", params: []interface{}{4, 3}},
+		{expect: "3", format: "%p1%p2%|%d", params: []interface{}{1, 2}},
+		{expect: "2", format: "%p1%p2%&%d", params: []interface{}{2, 3}},
+		{expect: "1", format: "%p1%p2%^%d", params: []interface{}{2, 3}},
+		{expect: "f", format: "%p1%~%{255}%&%x", params: []interface{}{0xf0}},
+		{expect: "%Z", format: "%Z", params: []interface{}{2, 3}}, // unknown sequence
+	}
+
+	for i := range cases {
+		if res := ti.TParm(cases[i].format, cases[i].params...); res != cases[i].expect {
+			t.Errorf("Format case %d failed: Format %q got %q", i, cases[i].format, res)
+		}
+	}
+	t.Logf("Tested %d cases", len(cases))
 }
 
 func TestTerminfoDelay(t *testing.T) {


### PR DESCRIPTION
These fix errors discovered while implementing the same logic
in dcell.  While here, the conditional support was simplified
using a similar approach as used in dcell, and test cases were
added.