### PR TITLE
Add screen.SetTitle

### DIFF
--- a/_demos/set_clipboard.go
+++ b/_demos/set_clipboard.go
@@ -1,0 +1,88 @@
+// +build ignore
+
+// Copyright 2020 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/encoding"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
+	for _, c := range str {
+		var comb []rune
+		w := runewidth.RuneWidth(c)
+		if w == 0 {
+			comb = []rune{c}
+			c = ' '
+			w = 1
+		}
+		s.SetContent(x, y, c, comb, style)
+		x += w
+	}
+}
+
+func displayHelloWorld(s tcell.Screen) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	emitStr(s, w/2-14, h/2, style, "Press Enter to set clipboard")
+	emitStr(s, w/2-9, h/2+1, tcell.StyleDefault, "Press ESC to exit.")
+	s.Show()
+}
+
+// This program just prints "Hello, World!".  Press ESC to exit.
+func main() {
+	encoding.Register()
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	displayHelloWorld(s)
+
+	for {
+		switch ev := s.PollEvent().(type) {
+		case *tcell.EventResize:
+			s.Sync()
+			displayHelloWorld(s)
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEnter:
+				s.SetClipboard("enjoy your new clipboard content")
+			case tcell.KeyEscape:
+				s.Fini()
+				os.Exit(0)
+			}
+		}
+	}
+}

--- a/_demos/set_title.go
+++ b/_demos/set_title.go
@@ -1,0 +1,88 @@
+// +build ignore
+
+// Copyright 2020 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/encoding"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
+	for _, c := range str {
+		var comb []rune
+		w := runewidth.RuneWidth(c)
+		if w == 0 {
+			comb = []rune{c}
+			c = ' '
+			w = 1
+		}
+		s.SetContent(x, y, c, comb, style)
+		x += w
+	}
+}
+
+func displayHelloWorld(s tcell.Screen) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	emitStr(s, w/2-12, h/2, style, "Press Enter to set title")
+	emitStr(s, w/2-9, h/2+1, tcell.StyleDefault, "Press ESC to exit.")
+	s.Show()
+}
+
+// This program just prints "Hello, World!".  Press ESC to exit.
+func main() {
+	encoding.Register()
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	displayHelloWorld(s)
+
+	for {
+		switch ev := s.PollEvent().(type) {
+		case *tcell.EventResize:
+			s.Sync()
+			displayHelloWorld(s)
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEnter:
+				s.SetTitle("enjoy your new title")
+			case tcell.KeyEscape:
+				s.Fini()
+				os.Exit(0)
+			}
+		}
+	}
+}

--- a/console_win.go
+++ b/console_win.go
@@ -1135,6 +1135,10 @@ func (s *cScreen) SetClipboard(content string) bool {
 	return false
 }
 
+func (s *cScreen) SetTitle(title string) bool {
+	return false
+}
+
 func (s *cScreen) resize() {
 	info := consoleInfo{}
 	s.getConsoleInfo(&info)

--- a/console_win.go
+++ b/console_win.go
@@ -1131,6 +1131,10 @@ func (s *cScreen) SetSize(w, h int) {
 	s.resize()
 }
 
+func (s *cScreen) SetClipboard(content string) bool {
+	return false
+}
+
 func (s *cScreen) resize() {
 	info := consoleInfo{}
 	s.getConsoleInfo(&info)

--- a/screen.go
+++ b/screen.go
@@ -248,6 +248,8 @@ type Screen interface {
 	// does not support application-initiated resizing, whereas the legacy terminal does.
 	// Also, some emulators can support this but may have it disabled by default.
 	SetSize(int, int)
+
+	SetClipboard(string) bool
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal

--- a/screen.go
+++ b/screen.go
@@ -250,6 +250,8 @@ type Screen interface {
 	SetSize(int, int)
 
 	SetClipboard(string) bool
+
+	SetTitle(string) bool
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal

--- a/simulation.go
+++ b/simulation.go
@@ -478,6 +478,10 @@ func (s *simscreen) SetSize(w, h int) {
 	s.Unlock()
 }
 
+func (s *simscreen) SetClipboard(content string) bool {
+	return false
+}
+
 func (s *simscreen) GetContents() ([]SimCell, int, int) {
 	s.Lock()
 	cells, w, h := s.front, s.physw, s.physh

--- a/simulation.go
+++ b/simulation.go
@@ -482,6 +482,10 @@ func (s *simscreen) SetClipboard(content string) bool {
 	return false
 }
 
+func (s *simscreen) SetTitle(title string) bool {
+	return false
+}
+
 func (s *simscreen) GetContents() ([]SimCell, int, int) {
 	s.Lock()
 	cells, w, h := s.front, s.physw, s.physh

--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -220,6 +220,9 @@ func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	t.CursorBack1 = tc.getstr("cub1")
 	t.CursorUp1 = tc.getstr("cuu1")
 	t.SetClipboard = tc.getstr("Ms")
+	if tc.getstr("tsl") != "" && tc.getstr("fsl") != "" {
+		t.SetTitle = tc.getstr("tsl") + "%p1%s" + tc.getstr("fsl")
+	}
 	t.KeyF1 = tc.getstr("kf1")
 	t.KeyF2 = tc.getstr("kf2")
 	t.KeyF3 = tc.getstr("kf3")

--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -117,7 +117,7 @@ func unescape(s string) string {
 }
 
 func (tc *termcap) setupterm(name string) error {
-	cmd := exec.Command("infocmp", "-1", name)
+	cmd := exec.Command("infocmp", "-x", "-1", name)
 	output := &bytes.Buffer{}
 	cmd.Stdout = output
 
@@ -219,6 +219,7 @@ func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	t.SetCursor = tc.getstr("cup")
 	t.CursorBack1 = tc.getstr("cub1")
 	t.CursorUp1 = tc.getstr("cuu1")
+	t.SetClipboard = tc.getstr("Ms")
 	t.KeyF1 = tc.getstr("kf1")
 	t.KeyF2 = tc.getstr("kf2")
 	t.KeyF3 = tc.getstr("kf3")

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -230,6 +230,7 @@ type Terminfo struct {
 	EnterUrl                string
 	ExitUrl                 string
 	SetWindowSize           string
+	SetClipboard            string
 }
 
 const (

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -231,6 +231,7 @@ type Terminfo struct {
 	ExitUrl                 string
 	SetWindowSize           string
 	SetClipboard            string
+	SetTitle                string
 }
 
 const (

--- a/tscreen.go
+++ b/tscreen.go
@@ -1788,6 +1788,15 @@ func (t *tScreen) SetClipboard(content string) bool {
 	return true
 }
 
+func (t *tScreen) SetTitle(title string) bool {
+	ti := t.ti
+	if ti.SetTitle == "" {
+		return false
+	}
+	t.TPuts(ti.TParm(ti.SetTitle, title))
+	return true
+}
+
 func (t *tScreen) Resize(int, int, int, int) {}
 
 func (t *tScreen) Suspend() error {

--- a/tscreen.go
+++ b/tscreen.go
@@ -16,6 +16,7 @@ package tcell
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"io"
 	"os"
@@ -1775,6 +1776,16 @@ func (t *tScreen) SetSize(w, h int) {
 	}
 	t.cells.Invalidate()
 	t.resize()
+}
+
+func (t *tScreen) SetClipboard(content string) bool {
+	ti := t.ti
+	if ti.SetClipboard == "" {
+		return false
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+	t.TPuts(ti.TParm(ti.SetClipboard, "c", encoded))
+	return true
 }
 
 func (t *tScreen) Resize(int, int, int, int) {}


### PR DESCRIPTION
Fixes #4

I tested this using the following additional change to always prefer dynamic loading of terminfo data:
```diff
diff --git a/tscreen.go b/tscreen.go
index 980f00b..537e21b 100644
--- a/tscreen.go
+++ b/tscreen.go
@@ -50,13 +50,14 @@ func NewTerminfoScreen() (Screen, error) {
 // LookupTerminfo attempts to find a definition for the named $TERM falling
 // back to attempting to parse the output from infocmp.
 func LookupTerminfo(name string) (ti *terminfo.Terminfo, e error) {
-	ti, e = terminfo.LookupTerminfo(name)
-	if e != nil {
-		ti, e = loadDynamicTerminfo(name)
+	ti, e = loadDynamicTerminfo(name)
+	if e == nil {
+		terminfo.AddTerminfo(ti)
+	} else {
+		ti, e = terminfo.LookupTerminfo(name)
 		if e != nil {
 			return nil, e
 		}
-		terminfo.AddTerminfo(ti)
 	}
 
 	return
```

This PR is based on top of #562, will rebase once required.