### PR TITLE
hyperlinks: fix id escape format

### DIFF
--- a/style.go
+++ b/style.go
@@ -171,6 +171,6 @@ func (s Style) UrlId(id string) Style {
 		bg:    s.bg,
 		attrs: s.attrs,
 		url:   s.url,
-		urlId: "id:" + id,
+		urlId: "id=" + id,
 	}
 }

--- a/terminfo/terminfo_test.go
+++ b/terminfo/terminfo_test.go
@@ -139,8 +139,8 @@ func TestStringParameter(t *testing.T) {
 	if s != "\x1b]8;;https://example.org/test\x1b\\" {
 		t.Errorf("Result string failed: %s", s)
 	}
-	s = ti.TParm(ti.EnterUrl, "https://example.org/test", "id:1234")
-	if s != "\x1b]8;id:1234;https://example.org/test\x1b\\" {
+	s = ti.TParm(ti.EnterUrl, "https://example.org/test", "id=1234")
+	if s != "\x1b]8;id=1234;https://example.org/test\x1b\\" {
 		t.Errorf("Result string failed: %s", s)
 	}
 }


### PR DESCRIPTION
Commit 43efca775e73 added support for url IDs within OSC8 escape sequences, however the formatting of the param is incorrect.

Use `id=` instead of `id:`

Fixes: 43efca775e73 ("hyperlinks: add support for optional id parameter")