### PR TITLE
fix wide char rendering on Windows

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -50,6 +50,10 @@ func (cb *CellBuffer) SetContent(x int, y int,
 	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
 		c := &cb.cells[(y*cb.w)+x]
 
+		for i := 1; i < c.width; i++ {
+			cb.SetDirty(x+i, y, true)
+		}
+
 		c.currComb = append([]rune{}, combc...)
 
 		if c.currMain != mainc {
@@ -178,13 +182,14 @@ func (cb *CellBuffer) Fill(r rune, style Style) {
 	}
 }
 
-var runeConfig *runewidth.Condition;
+var runeConfig *runewidth.Condition
+
 func init() {
 	// The defaults for the runewidth package are poorly chosen for terminal
 	// applications.  We however will honor the setting in the environment if
 	// it is set.
 	if os.Getenv("RUNEWIDTH_EASTASIAN") == "" {
-		runewidth.DefaultCondition.EastAsianWidth = false;
+		runewidth.DefaultCondition.EastAsianWidth = false
 	}
 
 	// For performance reasons, we create a lookup table.  However some users


### PR DESCRIPTION
ref: https://github.com/jesseduffield/lazygit/issues/1383, https://github.com/jesseduffield/gocui/pull/28#discussion_r1089974893

Fix the afterimage that remains when a cell with wide characters drawn on Windows is overwritten with half-width characters.

run this demo: https://github.com/Ryooooooga/tcell/blob/d29805811f6c0c8ac2846aa8a362437b25e29daf/_demos/hello_world.go

<table>
<tr>
	<th>
	<th>Windows
	<th>mac
	<th>Ubuntu (WSL)
<tr>
	<th>before
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754085-43a91a37-cdef-4fde-a7a7-e6013cb83d3b.PNG">
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754138-8862086e-9323-4dd7-932c-0dcf7f3ab83b.png">
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754167-fff70976-8fea-407e-90d0-9023489a6544.PNG">
<tr>
	<th>after
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754235-09374d6a-a09c-4e7c-b9bd-868b9c4d9ec2.PNG">
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754197-19d130f9-eb23-4e46-a0fe-47914f25e191.png">
	<td>
<img src="https://user-images.githubusercontent.com/10097437/215754258-e7b1c25b-ac76-4c2b-a1d6-e389eb67b9a6.PNG">
</table>