### PR TITLE
Don't count mouse WheelDown/Up as buttondn

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1346,7 +1346,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 			y = val - 1
 
 			motion = (btn & 32) != 0
-			scroll = (btn & 0x43) == 0x40 || (btn & 0x43) == 0x41
+			scroll = (btn & 0x42) == 0x40
 			btn &^= 32
 			if b[i] == 'm' {
 				// mouse release, clear all buttons

--- a/tscreen.go
+++ b/tscreen.go
@@ -1271,6 +1271,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 	dig := false
 	neg := false
 	motion := false
+	scroll := false
 	i := 0
 	val := 0
 
@@ -1345,6 +1346,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 			y = val - 1
 
 			motion = (btn & 32) != 0
+			scroll = (btn & 0x43) == 0x40 || (btn & 0x43) == 0x41
 			btn &^= 32
 			if b[i] == 'm' {
 				// mouse release, clear all buttons
@@ -1363,7 +1365,7 @@ func (t *tScreen) parseSgrMouse(buf *bytes.Buffer, evs *[]Event) (bool, bool) {
 					btn |= 3
 					btn &^= 0x40
 				}
-			} else {
+			} else if !scroll {
 				t.buttondn = true
 			}
 			// consume the event bytes


### PR DESCRIPTION
If a mouse event is a scroll, either up or down, don't set the `buttondn` boolean to true, thereby ensuring buttons are cleared on subsequent mouse movements.

This resolves the issue where scrolling up/down and then moving the mouse causes further `MouseWheel` events.

See issue for more details:
closes #600