### PR TITLE
Direct Drawing to TTY to enable sixel support

### DIFF
--- a/_demos/sixel.go
+++ b/_demos/sixel.go
@@ -1,0 +1,183 @@
+//go:build ignore
+// +build ignore
+
+// Copyright 2023 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// sixel displays a sixel and demonstrates how to use direct drawing
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"math"
+	"os"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/encoding"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/mattn/go-sixel"
+)
+
+type imageData struct {
+	width  int // width in pixels
+	height int // height in pixels
+	data   *bytes.Buffer
+}
+
+func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
+	for _, c := range str {
+		var comb []rune
+		w := runewidth.RuneWidth(c)
+		if w == 0 {
+			comb = []rune{c}
+			c = ' '
+			w = 1
+		}
+		s.SetContent(x, y, c, comb, style)
+		x += w
+	}
+}
+
+func displayHelloWorld(s tcell.Screen) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	emitStr(s, w/2-7, h/2, style, "Hello, World!")
+	emitStr(s, w/2-9, h/2+1, tcell.StyleDefault, "Press ESC to exit.")
+	emitStr(s, w/2-18, h/2+2, tcell.StyleDefault, "Press Enter to toggle sixel lock.")
+	s.Show()
+}
+
+func displaySixel(s tcell.Screen, img *imageData, lock bool) {
+	tty, ok := s.Tty()
+	if !ok {
+		s.Fini()
+		log.Fatal("not a terminal")
+	}
+	ws, err := tty.WindowSize()
+	if err != nil {
+		s.Fini()
+		log.Fatal(err)
+	}
+	// Get the dimensions of a single cell
+	cw, ch := ws.CellDimensions()
+	if cw == 0 || ch == 0 {
+		s.Fini()
+		log.Fatal("terminal does not support sixel graphics")
+		return
+	}
+
+	// Calculate the image dimensions in cells. We round up to prevent
+	// drawing on a partially filled cell
+	sixelWidth := int(math.Ceil(float64(img.width) / float64(cw)))
+	sixelHeight := int(math.Ceil(float64(img.height) / float64(ch)))
+
+	sixelX := ws.Width/2 - (sixelWidth / 2) // Center the image horizontally
+	sixelY := ws.Height/2 - sixelHeight - 2
+	if sixelY < 0 {
+		sixelY = 0
+	}
+	// Lock the region where we will draw the sixel, this prevents tcell
+	// from drawing over this area
+	s.LockRegion(sixelX, sixelY, sixelWidth, sixelHeight, lock)
+
+	// Get the terminfo for our current terminal
+	ti, err := tcell.LookupTerminfo(os.Getenv("TERM"))
+	if err != nil {
+		s.Fini()
+		log.Fatal(err)
+	}
+
+	emitStr(s, sixelX, sixelY, tcell.StyleDefault, "This text is behind")
+	emitStr(s, sixelX, sixelY+1, tcell.StyleDefault, "     the sixel")
+
+	// Move the cursor to our draw position
+	ti.TPuts(tty, ti.TGoto(sixelX, sixelY))
+	// Draw the sixel data
+	ti.TPuts(tty, img.data.String())
+
+	s.Show()
+}
+
+func loadImage(path string) (image.Image, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return png.Decode(f)
+}
+
+func main() {
+	encoding.Register()
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	raw, err := loadImage("./logos/tcell.png")
+	if err != nil {
+		s.Fini()
+		log.Println("couldn't load image. try running from the root directory")
+		log.Fatalf("        go run ./_demos/sixel.go")
+	}
+
+	img := &imageData{
+		width:  raw.Bounds().Dx(),
+		height: raw.Bounds().Dy(),
+		data:   bytes.NewBuffer(nil),
+	}
+	enc := sixel.NewEncoder(img.data)
+	if err := enc.Encode(raw); err != nil {
+		s.Fini()
+		log.Fatal(err)
+	}
+
+	lock := true
+	displayHelloWorld(s)
+	displaySixel(s, img, lock)
+
+	for {
+		switch ev := s.PollEvent().(type) {
+		case *tcell.EventResize:
+			s.Sync()
+			displayHelloWorld(s)
+			displaySixel(s, img, lock)
+		case *tcell.EventKey:
+			if ev.Key() == tcell.KeyEscape {
+				s.Fini()
+				os.Exit(0)
+			}
+			if ev.Key() == tcell.KeyEnter {
+				lock = !lock
+				displaySixel(s, img, lock)
+			}
+		}
+	}
+}

--- a/resize.go
+++ b/resize.go
@@ -20,15 +20,18 @@ import (
 
 // EventResize is sent when the window size changes.
 type EventResize struct {
-	t time.Time
-	w int
-	h int
+	t  time.Time
+	ws WindowSize
 }
 
 // NewEventResize creates an EventResize with the new updated window size,
 // which is given in character cells.
 func NewEventResize(width, height int) *EventResize {
-	return &EventResize{t: time.Now(), w: width, h: height}
+	ws := WindowSize{
+		Width:  width,
+		Height: height,
+	}
+	return &EventResize{t: time.Now(), ws: ws}
 }
 
 // When returns the time when the Event was created.
@@ -38,5 +41,26 @@ func (ev *EventResize) When() time.Time {
 
 // Size returns the new window size as width, height in character cells.
 func (ev *EventResize) Size() (int, int) {
-	return ev.w, ev.h
+	return ev.ws.Width, ev.ws.Height
+}
+
+// PixelSize returns the new window size as width, height in pixels. The size
+// will be 0,0 if the screen doesn't support this feature
+func (ev *EventResize) PixelSize() (int, int) {
+	return ev.ws.PixelWidth, ev.ws.PixelHeight
+}
+
+type WindowSize struct {
+	Width       int
+	Height      int
+	PixelWidth  int
+	PixelHeight int
+}
+
+// CellDimensions returns the dimensions of a single cell, in pixels
+func (ws WindowSize) CellDimensions() (int, int) {
+	if ws.PixelWidth == 0 || ws.PixelHeight == 0 {
+		return 0, 0
+	}
+	return (ws.PixelWidth / ws.Width), (ws.PixelHeight / ws.Height)
 }

--- a/screen.go
+++ b/screen.go
@@ -249,6 +249,10 @@ type Screen interface {
 	// does not support application-initiated resizing, whereas the legacy terminal does.
 	// Also, some emulators can support this but may have it disabled by default.
 	SetSize(int, int)
+
+	// LockRegion sets or unsets a lock on a region of cells. A lock on a
+	// cell prevents the cell from being redrawn.
+	LockRegion(x, y, width, height int, lock bool)
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal

--- a/screen.go
+++ b/screen.go
@@ -253,6 +253,11 @@ type Screen interface {
 	// LockRegion sets or unsets a lock on a region of cells. A lock on a
 	// cell prevents the cell from being redrawn.
 	LockRegion(x, y, width, height int, lock bool)
+
+	// Tty returns the underlying Tty. If the screen is not a terminal, the
+	// returned bool will be false
+	Tty() (Tty, bool)
+
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal

--- a/simulation.go
+++ b/simulation.go
@@ -562,3 +562,7 @@ func (s *simscreen) LockRegion(x, y, width, height int, lock bool) {
 		}
 	}
 }
+
+func (s *simscreen) Tty() (Tty, bool) {
+	return nil, false
+}

--- a/simulation.go
+++ b/simulation.go
@@ -547,3 +547,18 @@ func (s *simscreen) Suspend() error {
 func (s *simscreen) Resume() error {
 	return nil
 }
+
+func (s *simscreen) LockRegion(x, y, width, height int, lock bool) {
+	s.Lock()
+	defer s.Unlock()
+	for j := y; j < (y + height); j += 1 {
+		for i := x; i < (x + width); i += 1 {
+			switch lock {
+			case true:
+				s.back.LockCell(i, j)
+			case false:
+				s.back.UnlockCell(i, j)
+			}
+		}
+	}
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -1791,6 +1791,10 @@ func (t *tScreen) LockRegion(x, y, width, height int, lock bool) {
 	}
 }
 
+func (t *tScreen) Tty() (Tty, bool) {
+	return t.tty, true
+}
+
 // engage is used to place the terminal in raw mode and establish screen size, etc.
 // Think of this is as tcell "engaging" the clutch, as it's going to be driving the
 // terminal interface.

--- a/tscreen.go
+++ b/tscreen.go
@@ -1775,6 +1775,22 @@ func (t *tScreen) Resume() error {
 	return t.engage()
 }
 
+
+func (t *tScreen) LockRegion(x, y, width, height int, lock bool) {
+	t.Lock()
+	defer t.Unlock()
+	for j := y; j < (y + height); j += 1 {
+		for i := x; i < (x + width); i += 1 {
+			switch lock {
+			case true:
+				t.cells.LockCell(i, j)
+			case false:
+				t.cells.UnlockCell(i, j)
+			}
+		}
+	}
+}
+
 // engage is used to place the terminal in raw mode and establish screen size, etc.
 // Think of this is as tcell "engaging" the clutch, as it's going to be driving the
 // terminal interface.

--- a/tscreen.go
+++ b/tscreen.go
@@ -1051,19 +1051,22 @@ func (t *tScreen) Size() (int, int) {
 }
 
 func (t *tScreen) resize() {
-	if w, h, e := t.tty.WindowSize(); e == nil {
-		if w != t.w || h != t.h {
-			t.cx = -1
-			t.cy = -1
-
-			t.cells.Resize(w, h)
-			t.cells.Invalidate()
-			t.h = h
-			t.w = w
-			ev := NewEventResize(w, h)
-			_ = t.PostEvent(ev)
-		}
+	ws, err := t.tty.WindowSize()
+	if err != nil {
+		return
 	}
+	if ws.Width == t.w && ws.Height == t.h {
+		return
+	}
+	t.cx = -1
+	t.cy = -1
+
+	t.cells.Resize(ws.Width, ws.Height)
+	t.cells.Invalidate()
+	t.h = ws.Height
+	t.w = ws.Width
+	ev := &EventResize{t: time.Now(), ws: ws}
+	_ = t.PostEvent(ev)
 }
 
 func (t *tScreen) Colors() int {
@@ -1817,8 +1820,8 @@ func (t *tScreen) engage() error {
 		return err
 	}
 	t.running = true
-	if w, h, err := t.tty.WindowSize(); err == nil && w != 0 && h != 0 {
-		t.cells.Resize(w, h)
+	if ws, err := t.tty.WindowSize(); err == nil && ws.Width != 0 && ws.Height != 0 {
+		t.cells.Resize(ws.Width, ws.Height)
 	}
 	stopQ := make(chan struct{})
 	t.stopQ = stopQ

--- a/tty.go
+++ b/tty.go
@@ -50,7 +50,7 @@ type Tty interface {
 
 	// WindowSize is called to determine the terminal dimensions.  This might be determined
 	// by an ioctl or other means.
-	WindowSize() (width int, height int, err error)
+	WindowSize() (WindowSize, error)
 
 	io.ReadWriteCloser
 }

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -136,11 +137,14 @@ func (tty *devTty) Stop() error {
 	return nil
 }
 
-func (tty *devTty) WindowSize() (int, int, error) {
-	w, h, err := term.GetSize(tty.fd)
+func (tty *devTty) WindowSize() (WindowSize, error) {
+	size := WindowSize{}
+	ws, err := unix.IoctlGetWinsize(tty.fd, unix.TIOCGWINSZ)
 	if err != nil {
-		return 0, 0, err
+		return size, err
 	}
+	w := int(ws.Col)
+	h := int(ws.Row)
 	if w == 0 {
 		w, _ = strconv.Atoi(os.Getenv("COLUMNS"))
 	}
@@ -153,7 +157,11 @@ func (tty *devTty) WindowSize() (int, int, error) {
 	if h == 0 {
 		h = 25 // default
 	}
-	return w, h, nil
+	size.Width = w
+	size.Height = h
+	size.PixelWidth = int(ws.Xpixel)
+	size.PixelHeight = int(ws.Ypixel)
+	return size, nil
 }
 
 func (tty *devTty) NotifyResize(cb func()) {

--- a/wscreen.go
+++ b/wscreen.go
@@ -544,6 +544,21 @@ func (t *wScreen) Beep() error {
 	return nil
 }
 
+func (t *wScreen) LockRegion(x, y, width, height int, lock bool) {
+	t.Lock()
+	defer t.Unlock()
+	for j := y; j < (y + height); j += 1 {
+		for i := x; i < (x + width); i += 1 {
+			switch lock {
+			case true:
+				t.cells.LockCell(i, j)
+			case false:
+				t.cells.UnlockCell(i, j)
+			}
+		}
+	}
+}
+
 // WebKeyNames maps string names reported from HTML
 // (KeyboardEvent.key) to tcell accepted keys.
 var WebKeyNames = map[string]Key{

--- a/wscreen.go
+++ b/wscreen.go
@@ -559,6 +559,10 @@ func (t *wScreen) LockRegion(x, y, width, height int, lock bool) {
 	}
 }
 
+func (t *wScreen) Tty() (Tty, bool) {
+	return nil, false
+}
+
 // WebKeyNames maps string names reported from HTML
 // (KeyboardEvent.key) to tcell accepted keys.
 var WebKeyNames = map[string]Key{


### PR DESCRIPTION
Expose underlying TTY and locking mechanism to enable an implementer to directly write to the TTY (if the screen is a terminfo based screen). These two features allow for drawing of sixels on the screen, and locking the cells that are drawn on top of. The locking mechanism enables an implementer to lock tcell's access to drawing to a region of cells. Locks are not transferred during a resize.

Expose the pixel size of the window via EventResize and via a call to tty.WindowSize(). Both methods allow implementers access to the underlying window size in cells and pixels. A helper function is included on the WindowSize struct to calculate the pixel size of a single cell. Pixel sizes are required to calculate the cell size of an image so that an appropriate lock can be obtained.

Add a demo of displaying a sixel (the tcell logo). The demo must be run from the root directory in order for the path to the logo to resolve properly. I didn't add a dependency for go-sixel to the library since it's only needed for the demo: this will require users of the demo to perform a 'go get github.com/mattn/go-sixel' prior to running the demo.

Reference issue: #435 
Supercedes PR #436 