### PR TITLE
Support Xterm modifier keys for dynamic terminfos

### DIFF
--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -314,6 +314,8 @@ func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	// but modern XTerm and emulators often have them.  Let's add them,
 	// if the shifted right and left arrows are defined.
 	if t.KeyShfRight == "\x1b[1;2C" && t.KeyShfLeft == "\x1b[1;2D" {
+		t.Modifiers = terminfo.ModifiersXTerm
+
 		t.KeyShfUp = "\x1b[1;2A"
 		t.KeyShfDown = "\x1b[1;2B"
 		t.KeyMetaUp = "\x1b[1;9A"


### PR DESCRIPTION
Previously, modified function keys in dyanmic terminals were not supported (like shift/control/alt + arrow keys).

Even though xterm-compatible terminals were dynamically discovered and their keys added to the terminfo struct, the Modifiers field was not supported and therefore the modified Xterm keys were not added to the keycodes map (prepareXtermModifiers was skipped).

This fixes the issue by setting the Modifiers field when we discover that the terminal is xterm-compatible.