### PR TITLE
Add LookupTerminfo stub for wasm

### DIFF
--- a/wscreen.go
+++ b/wscreen.go
@@ -19,6 +19,7 @@ package tcell
 
 import (
 	"errors"
+	"github.com/gdamore/tcell/v2/terminfo"
 	"strings"
 	"sync"
 	"syscall/js"
@@ -675,4 +676,8 @@ var curStyleClasses = map[CursorStyle]string{
 	CursorStyleSteadyUnderline:   "cursor-steady-underline",
 	CursorStyleBlinkingBar:       "cursor-blinking-bar",
 	CursorStyleSteadyBar:         "cursor-steady-bar",
+}
+
+func LookupTerminfo(name string) (ti *terminfo.Terminfo, e error) {
+	return nil, errors.New("LookupTermInfo not supported")
 }


### PR DESCRIPTION
This is a workaround for #617.

A better solution would probably be to return a hard-coded Terminfo that matches the Wasm terminal's capabilities, but an unimplemented stub is enough to make [tview](https://github.com/rivo/tview) applications build and run in a browser.