### PR TITLE
Fix dynamic terminfo when an alias is used

### DIFF
--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -190,9 +190,6 @@ func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	t := &terminfo.Terminfo{}
 	// If this is an alias record, then just emit the alias
 	t.Name = tc.name
-	if t.Name != name {
-		return t, "", nil
-	}
 	t.Aliases = tc.aliases
 	t.Colors = tc.getnum("colors")
 	t.Columns = tc.getnum("cols")

--- a/terminfo/dynamic/dynamic.go
+++ b/terminfo/dynamic/dynamic.go
@@ -185,9 +185,7 @@ func (tc *termcap) setupterm(name string) error {
 func LoadTerminfo(name string) (*terminfo.Terminfo, string, error) {
 	var tc termcap
 	if err := tc.setupterm(name); err != nil {
-		if err != nil {
-			return nil, "", err
-		}
+		return nil, "", err
 	}
 	t := &terminfo.Terminfo{}
 	// If this is an alias record, then just emit the alias


### PR DESCRIPTION
Currently, the dynamic terminfo loader will return an empty struct if it
encounters that an alias was used. An alias does not mean the output of
`infocmp` was incorrect. Set the name to the primary name from `infocmp`
and continue processing as necessary.

For users who have a terminal not in the internal terminfo database who
also may be using an alias TERM (for whatever reason...), the result is
that no error is given to the application, and the terminfo struct
returns empty strings at runtime...notably the application can't enter
the alternate screen and the app is immediately unusable.
