### PR TITLE
Implement missing methods in cScreen

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -1349,5 +1349,5 @@ func (s *cScreen) LockRegion(x, y, width, height int, lock bool) {
 }
 
 func (s *cScreen) Tty() (Tty, bool) {
-	return nil, true
+	return nil, false
 }

--- a/console_win.go
+++ b/console_win.go
@@ -1332,3 +1332,22 @@ func (s *cScreen) Suspend() error {
 func (s *cScreen) Resume() error {
 	return s.engage()
 }
+
+func (s *cScreen) LockRegion(x, y, width, height int, lock bool) {
+	s.Lock()
+	defer s.Unlock()
+	for j := y; j < (y + height); j += 1 {
+		for i := x; i < (x + width); i += 1 {
+			switch lock {
+			case true:
+				s.cells.LockCell(i, j)
+			case false:
+				s.cells.UnlockCell(i, j)
+			}
+		}
+	}
+}
+
+func (s *cScreen) Tty() (Tty, bool) {
+	return nil, true
+}


### PR DESCRIPTION
I encountered the following errors when trying to build a Windows binary of [fzf](https://github.com/junegunn/fzf).

```
* cannot use &cScreen{} (value of type *cScreen) as Screen value in return statement: *cScreen does not implement Screen (missing method LockRegion)
* cannot use &cScreen{} (value of type *cScreen) as Screen value in return statement: *cScreen does not implement Screen (missing method Tty)
```

So I just tried to fill in the missing methods by referencing other implementations, but I'm not sure of the correctness as I'm not familiar with the code.

Would it be possible to return a proper value from Tty(), so we can use the "pass-through" mechanism also on Windows? i.e. https://github.com/gdamore/tcell/blob/8a50441ee1fd29b18a4a7d51e98423a17ec8ef4c/_demos/sixel.go#L110-L113

/cc @rockorager 