### PR TITLE
Start of base screen refactoring.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-// Copyright 2022 The TCell Authors
+// Copyright 2023 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -175,7 +175,7 @@ var vtCursorStyles = map[CursorStyle]string{
 // with the current process.  The Screen makes use of the Windows Console
 // API to display content and read events.
 func NewConsoleScreen() (Screen, error) {
-	return &cScreen{}, nil
+	return &baseScreen{screenImpl: &cScreen{}}, nil
 }
 
 func (s *cScreen) Init() error {
@@ -894,14 +894,6 @@ func (s *cScreen) mapStyle(style Style) uint16 {
 	return attr
 }
 
-func (s *cScreen) SetCell(x, y int, style Style, ch ...rune) {
-	if len(ch) > 0 {
-		s.SetContent(x, y, ch[0], ch[1:], style)
-	} else {
-		s.SetContent(x, y, ' ', nil, style)
-	}
-}
-
 func (s *cScreen) SetContent(x, y int, primary rune, combining []rune, style Style) {
 	s.Lock()
 	if !s.fini {
@@ -1152,10 +1144,6 @@ func (s *cScreen) resize() {
 		uintptr(1),
 		uintptr(unsafe.Pointer(&r)))
 	_ = s.PostEvent(NewEventResize(w, h))
-}
-
-func (s *cScreen) Clear() {
-	s.Fill(' ', s.style)
 }
 
 func (s *cScreen) Fill(r rune, style Style) {

--- a/tscreen.go
+++ b/tscreen.go
@@ -94,7 +94,7 @@ func NewTerminfoScreenFromTtyTerminfo(tty Tty, ti *terminfo.Terminfo) (s Screen,
 		t.fallback[k] = v
 	}
 
-	return t, nil
+	return &baseScreen{screenImpl: t}, nil
 }
 
 // NewTerminfoScreenFromTty returns a Screen using a custom Tty implementation.
@@ -595,10 +595,6 @@ func (t *tScreen) SetStyle(style Style) {
 	t.Unlock()
 }
 
-func (t *tScreen) Clear() {
-	t.Fill(' ', t.style)
-}
-
 func (t *tScreen) Fill(r rune, style Style) {
 	t.Lock()
 	if !t.fini {
@@ -620,14 +616,6 @@ func (t *tScreen) GetContent(x, y int) (rune, []rune, Style, int) {
 	mainc, combc, style, width := t.cells.GetContent(x, y)
 	t.Unlock()
 	return mainc, combc, style, width
-}
-
-func (t *tScreen) SetCell(x, y int, style Style, ch ...rune) {
-	if len(ch) > 0 {
-		t.SetContent(x, y, ch[0], ch[1:], style)
-	} else {
-		t.SetContent(x, y, ' ', nil, style)
-	}
 }
 
 func (t *tScreen) encodeRune(r rune, buf []byte) []byte {

--- a/wscreen.go
+++ b/wscreen.go
@@ -30,7 +30,7 @@ func NewTerminfoScreen() (Screen, error) {
 	t := &wScreen{}
 	t.fallback = make(map[rune]string)
 
-	return t, nil
+	return &baseScreen{screenImpl: t}, nil
 }
 
 type wScreen struct {
@@ -79,10 +79,6 @@ func (t *wScreen) SetStyle(style Style) {
 	t.Unlock()
 }
 
-func (t *wScreen) Clear() {
-	t.Fill(' ', t.style)
-}
-
 func (t *wScreen) Fill(r rune, style Style) {
 	t.Lock()
 	t.cells.Fill(r, style)
@@ -100,14 +96,6 @@ func (t *wScreen) GetContent(x, y int) (rune, []rune, Style, int) {
 	mainc, combc, style, width := t.cells.GetContent(x, y)
 	t.Unlock()
 	return mainc, combc, style, width
-}
-
-func (t *wScreen) SetCell(x, y int, style Style, ch ...rune) {
-	if len(ch) > 0 {
-		t.SetContent(x, y, ch[0], ch[1:], style)
-	} else {
-		t.SetContent(x, y, ' ', nil, style)
-	}
 }
 
 // paletteColor gives a more natural palette color actually matching


### PR DESCRIPTION
A lot of functionality is duplicated across screen implementations, and adding convenience methods is onerous because one needs to touch each implementation with what is mostly copy-paste coding.

This represents the start of refactoring to eliminate redundant code from each implemenation and provide for it in a common layer.