### PR TITLE
Fix deadlock on screen.Fini

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1693,7 +1693,11 @@ func (t *tScreen) inputLoop(stopQ chan struct{}) {
 			return
 		}
 		if n > 0 {
-			t.keychan <- chunk[:n]
+			select {
+			case t.keychan <- chunk[:n]:
+			case <-t.quit:
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
I've run into this deadlock a few times in my private fork and so I figured I would contribute the fix back.

`Fini` hangs forever with the right sequence of events: if there's still data to be processed but `mainLoop` is done, then `inputLoop` hangs forever and so the screen's close wait group `Wait` never returns.

```
1 @ 0x10495de08 0x104928b4c 0x104928778 0x1050b1fb8 0x104994214
#	0x1050b1fb7	github.com/ernestrc/tcell/v2.(*tScreen).inputLoop+0x137	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tscreen.go:1757


1 @ 0x10495de08 0x104970154 0x1050b41cc 0x104994214
#	0x1050b41cb	github.com/ernestrc/tcell/v2.(*devTty).Start.func1+0xeb	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tty_unix.go:94

1 @ 0x10495de08 0x1049711b8 0x104971195 0x10498f4dc 0x1049a50bc 0x1050b34b0 0x1050b37ac 0x1050ba674 0x1049a3204 0x1049a3124 0x1050aa52c 0x10536a370 0x10536a349 0x10536a345 0x10536a341 0x10537c9e4 0x10537ba9c 0x104e333b0 0x10537b7dc 0x10495d99c 0x104994214
#	0x10498f4db	sync.runtime_Semacquire+0x2b				/opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/sema.go:62
#	0x1049a50bb	sync.(*WaitGroup).Wait+0x7b				/opt/homebrew/Cellar/go/1.21.5/libexec/src/sync/waitgroup.go:116
#	0x1050b34af	github.com/ernestrc/tcell/v2.(*tScreen).disengage+0xcf	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tscreen.go:1917
#	0x1050b37ab	github.com/ernestrc/tcell/v2.(*tScreen).finalize+0x2b	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tscreen.go:1947
#	0x1050ba673	github.com/ernestrc/tcell/v2.(*tScreen).finish+0x53	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tscreen.go:587
#	0x1049a3203	sync.(*Once).doSlow+0xb3				/opt/homebrew/Cellar/go/1.21.5/libexec/src/sync/once.go:74
#	0x1049a3123	sync.(*Once).Do+0x43					/opt/homebrew/Cellar/go/1.21.5/libexec/src/sync/once.go:65
#	0x1050aa52b	github.com/ernestrc/tcell/v2.(*tScreen).Fini+0x5b	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/tscreen.go:582
#	0x10536a36f	github.com/ernestrc/tcell/v2/termbox.Close+0x7f		/Users/ernestrc/go/pkg/mod/github.com/ernestrc/tcell/v2@v2.7.0-erc/termbox/compat.go:43
#	0x10536a348	unstable.build/go-tui/term.Close+0x58			/Users/ernestrc/src/go-tui/term/term.go:135
#	0x10536a344	unstable.build/go-tui.Close+0x54			/Users/ernestrc/src/go-tui/tui.go:98
#	0x10536a340	unstable.build/go-tui/ide.(*IDE).Close+0x50		/Users/ernestrc/src/go-tui/ide/ide.go:215
#	0x10537c9e3	main.run+0x983						/Users/ernestrc/src/go-tui/cmd/six/main.go:296
#	0x10537ba9b	main.main.func1+0x2b					/Users/ernestrc/src/go-tui/cmd/six/main.go:178
#	0x104e333af	github.com/ernestrc/blue/debug.CapturePanic+0xef	/Users/ernestrc/go/pkg/mod/github.com/ernestrc/blue@v1.40.0/debug/recover.go:56
#	0x10537b7db	main.main+0xbb						/Users/ernestrc/src/go-tui/cmd/six/main.go:177
#	0x10495d99b	runtime.main+0x2bb					/opt/homebrew/Cellar/go/1.21.5/libexec/src/runtime/proc.go:267
```