### PR TITLE
Don't set modifiers for AltGr on Windows

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -599,12 +599,17 @@ func geti16(v []byte) int16 {
 func mod2mask(cks uint32) ModMask {
 	mm := ModNone
 	// Left or right control
-	if (cks & (0x0008 | 0x0004)) != 0 {
-		mm |= ModCtrl
-	}
+	ctrl := (cks & (0x0008 | 0x0004)) != 0
 	// Left or right alt
-	if (cks & (0x0002 | 0x0001)) != 0 {
-		mm |= ModAlt
+	alt := (cks & (0x0002 | 0x0001)) != 0
+	// Filter out ctrl+alt (it means AltGr)
+	if !(ctrl && alt) {
+		if ctrl {
+			mm |= ModCtrl
+		}
+		if alt {
+			mm |= ModAlt
+		}
 	}
 	// Any shift
 	if (cks & 0x0010) != 0 {


### PR DESCRIPTION
AltGr is the same as ctrl+alt, and we don't want those to be set when you press a key using AltGr.

This fixes https://github.com/jesseduffield/lazygit/issues/2839; there, we register keybindings for `[` and `]` without modifiers, but they can't be used with a German keyboard layout, where `[` is typed using AltGr+8. The code that dispatches the keybindings checks that the modifiers are the same; it expects none, but sees ctrl and alt.

Yes, this means it's not possible to register a keybinding for ctrl+[ and have it work for non-US keyboards. But that's no different from, say, `!` on a US keyboard; you can't have a keybinding for shift+! either. (And you don't want to have shift reported as a modifier when typing `!`.)