### PR TITLE
Enhanced Windows VT mode, and ALTSCREEN support

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -182,7 +182,6 @@ func (s *cScreen) Init() error {
 	s.eventQ = make(chan Event, 10)
 	s.quit = make(chan struct{})
 	s.scandone = make(chan struct{})
-
 	in, e := syscall.Open("CONIN$", syscall.O_RDWR, 0)
 	if e != nil {
 		return e
@@ -227,9 +226,10 @@ func (s *cScreen) Init() error {
 	s.fini = false
 	s.setInMode(modeResizeEn | modeExtendFlg)
 
-	// 24-bit color is opt-in for now, because we can't figure out
-	// to make it work consistently.
-	if s.truecolor {
+	// If a user needs to force old style console, they may do so
+	// by setting TCELL_VTMODE to disable.  This is an undocumented safety net for now.
+	// It may be removed in the future.  (This mostly exists because of ConEmu.)
+	if os.Getenv("TCELL_VTMODE") != "disable" {
 		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut | modeUnderline)
 		var om uint32
 		s.getOutMode(&om)

--- a/console_win.go
+++ b/console_win.go
@@ -336,19 +336,20 @@ func (s *cScreen) disengage() {
 	if s.vten {
 		s.emitVtString(vtCursorStyles[CursorStyleDefault])
 		s.emitVtString(vtEnableAm)
+		if !s.disableAlt {
+			s.emitVtString(vtExitCA)
+		}
+	} else if !s.disableAlt {
+		s.clearScreen(StyleDefault, s.vten)
 	}
 	s.setInMode(s.oimode)
 	s.setOutMode(s.oomode)
 	s.setBufferSize(int(s.oscreen.size.x), int(s.oscreen.size.y))
-	s.clearScreen(StyleDefault, false)
 	s.setCursorPos(0, 0, false)
 	s.setCursorInfo(&s.ocursor)
 	_, _, _ = procSetConsoleTextAttribute.Call(
 		uintptr(s.out),
 		uintptr(s.mapStyle(StyleDefault)))
-	if s.vten && !s.disableAlt {
-		s.emitVtString(vtExitCA)
-	}
 }
 
 func (s *cScreen) engage() error {

--- a/console_win.go
+++ b/console_win.go
@@ -159,6 +159,8 @@ const (
 	vtCursorSteadyUnderline   = "\x1b[4 q"
 	vtCursorBlinkingBar       = "\x1b[5 q"
 	vtCursorSteadyBar         = "\x1b[6 q"
+	vtDisableAm               = "\x1b[?7l"
+	vtEnableAm                = "\x1b[?7h"
 )
 
 var vtCursorStyles = map[CursorStyle]string{
@@ -324,6 +326,7 @@ func (s *cScreen) disengage() {
 
 	if s.vten {
 		s.emitVtString(vtCursorStyles[CursorStyleDefault])
+		s.emitVtString(vtEnableAm)
 	}
 	s.setInMode(s.oimode)
 	s.setOutMode(s.oomode)
@@ -357,6 +360,7 @@ func (s *cScreen) engage() error {
 
 	if s.vten {
 		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut | modeUnderline)
+		s.emitVtString(vtDisableAm)
 	} else {
 		s.setOutMode(0)
 	}

--- a/tscreen.go
+++ b/tscreen.go
@@ -1822,7 +1822,14 @@ func (t *tScreen) engage() error {
 	}
 
 	ti := t.ti
-	t.TPuts(ti.EnterCA)
+	if os.Getenv("TCELL_ALTSCREEN") != "disable" {
+		// Technically this may not be right, but every terminal we know about
+		// (even Wyse 60) uses this to enter the alternate screen buffer, and
+		// possibly save and restore the window title and/or icon.
+		// (In theory there could be terminals that don't support X,Y cursor
+		// positions without a setup command, but we don't support them.)
+		t.TPuts(ti.EnterCA)
+	}
 	t.TPuts(ti.EnterKeypad)
 	t.TPuts(ti.HideCursor)
 	t.TPuts(ti.EnableAcs)
@@ -1865,10 +1872,12 @@ func (t *tScreen) disengage() {
 	}
 	t.TPuts(ti.ResetFgBg)
 	t.TPuts(ti.AttrOff)
-	t.TPuts(ti.Clear)
-	t.TPuts(ti.ExitCA)
 	t.TPuts(ti.ExitKeypad)
 	t.TPuts(ti.EnableAutoMargin)
+	if os.Getenv("TCELL_ALTSCREEN") != "disable" {
+		t.TPuts(ti.Clear) // only needed if ExitCA is empty
+		t.TPuts(ti.ExitCA)
+	}
 	t.enableMouse(0)
 	t.enablePasting(false)
 	t.disableFocusReporting()


### PR DESCRIPTION
This enables the use of VT mode on Windows by default everywhere except ConEmu (because ConEmu is too broken).  The attempt to use (or not use) the vt mode can be controlled by the TCELL_VTMODE environment variable (set it to "enable" or "disable" -- default is enabled unless ConEmu is detected.)

This also uses the alternate screen buffer on Windows by default, with fixes to avoid clearing the non-alternate screen.

It also adds TCELL_ALTSCREEN as an override.  This can be set to "disable" (on either Windows or POSIX), in which case we won't use the alternate screen.  We also don't clear the screen on exit (or disengage) in that case, and the cursor may be at an indeterminate location.  Applications may utilize this to arrange for Tcell to draw the screen, then drop to some other application (e.g. using GNU readline or something) while leaving the part drawn by tcell present.  This is highly experimental, and I'm not formally documenting it yet because its likely brittle and may change in the future.  It also doesn't work with every terminal type.