### PR TITLE
Add go-tetris

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A brief, and still somewhat rough, [tutorial](TUTORIAL.md) is available.
 - [gbb](https://github.com/sdemingo/gbb) - A classical bulletin board app for tildes or public unix servers
 - [lil](https://github.com/andrievsky/lil) - A simple and flexible interface for any service by implementing only list and get operations
 - [hero.go](https://github.com/barisbll/hero.go) - 2d monster shooter ([video](https://user-images.githubusercontent.com/40062673/277157369-240d7606-b471-4aa1-8c54-4379a513122b.mp4))
+- [go-tetris](https://github.com/aaronriekenberg/go-tetris) - simple tetris game for native terminal and WASM using github actions+pages
 
 ## Pure Go Terminfo Database
 


### PR DESCRIPTION
Add go-tetris -  a simple tetris game built with tcell.

Works as a native terminal app, have used in Linux and MacOS.

Also works as WASM app. The project is setup to deploy to github pages with github actions build on every commit.

Thanks!