### PR TITLE
fixes #666 cursor color

### DIFF
--- a/_demos/cursors.go
+++ b/_demos/cursors.go
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// beep makes a beep every second until you press ESC
 package main
 
 import (
@@ -52,6 +51,7 @@ func main() {
 	style := tcell.StyleDefault
 	go func() {
 		for {
+			s.Show()
 			ev := s.PollEvent()
 			switch ev := ev.(type) {
 			case *tcell.EventKey:
@@ -60,27 +60,26 @@ func main() {
 					switch ev.Rune() {
 					case '0':
 						s.SetContent(2, 2, '0', nil, style)
-						s.SetCursorStyle(tcell.CursorStyleDefault)
+						s.SetCursorStyle(tcell.CursorStyleDefault, tcell.ColorReset)
 					case '1':
 						s.SetContent(2, 2, '1', nil, style)
-						s.SetCursorStyle(tcell.CursorStyleBlinkingBlock)
+						s.SetCursorStyle(tcell.CursorStyleBlinkingBlock, tcell.ColorGreen)
 					case '2':
 						s.SetCell(2, 2, tcell.StyleDefault, '2')
-						s.SetCursorStyle(tcell.CursorStyleSteadyBlock)
+						s.SetCursorStyle(tcell.CursorStyleSteadyBlock, tcell.ColorBlue)
 					case '3':
 						s.SetCell(2, 2, tcell.StyleDefault, '3')
-						s.SetCursorStyle(tcell.CursorStyleBlinkingUnderline)
+						s.SetCursorStyle(tcell.CursorStyleBlinkingUnderline, tcell.ColorRed)
 					case '4':
 						s.SetCell(2, 2, tcell.StyleDefault, '4')
-						s.SetCursorStyle(tcell.CursorStyleSteadyUnderline)
+						s.SetCursorStyle(tcell.CursorStyleSteadyUnderline, tcell.ColorOrange)
 					case '5':
 						s.SetCell(2, 2, tcell.StyleDefault, '5')
-						s.SetCursorStyle(tcell.CursorStyleBlinkingBar)
+						s.SetCursorStyle(tcell.CursorStyleBlinkingBar, tcell.ColorYellow)
 					case '6':
 						s.SetCell(2, 2, tcell.StyleDefault, '6')
-						s.SetCursorStyle(tcell.CursorStyleSteadyBar)
+						s.SetCursorStyle(tcell.CursorStyleSteadyBar, tcell.ColorPink)
 					}
-					s.Show()
 
 				case tcell.KeyEscape, tcell.KeyEnter, tcell.KeyCtrlC:
 					close(quit)

--- a/screen.go
+++ b/screen.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The TCell Authors
+// Copyright 2024 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -79,8 +79,9 @@ type Screen interface {
 
 	// SetCursorStyle is used to set the cursor style.  If the style
 	// is not supported (or cursor styles are not supported at all),
-	// then this will have no effect.
-	SetCursorStyle(CursorStyle)
+	// then this will have no effect.  Color will be changed if supplied,
+	// and the terminal supports doing so.
+	SetCursorStyle(CursorStyle, ...Color)
 
 	// Size returns the screen size as width, height.  This changes in
 	// response to a call to Clear or Flush.
@@ -312,7 +313,7 @@ type screenImpl interface {
 	SetStyle(style Style)
 	ShowCursor(x int, y int)
 	HideCursor()
-	SetCursorStyle(CursorStyle)
+	SetCursor(CursorStyle, Color)
 	Size() (width, height int)
 	EnableMouse(...MouseFlags)
 	DisableMouse()
@@ -462,5 +463,13 @@ func (b *baseScreen) PostEvent(ev Event) error {
 		return nil
 	default:
 		return ErrEventQFull
+	}
+}
+
+func (b *baseScreen) SetCursorStyle(cs CursorStyle, ccs ...Color) {
+	if len(ccs) > 0 {
+		b.SetCursor(cs, ccs[0])
+	} else {
+		b.SetCursor(cs, ColorNone)
 	}
 }

--- a/simulation.go
+++ b/simulation.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The TCell Authors
+// Copyright 2024 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -239,7 +239,7 @@ func (s *simscreen) hideCursor() {
 	s.cursorvis = false
 }
 
-func (s *simscreen) SetCursorStyle(CursorStyle) {}
+func (s *simscreen) SetCursor(CursorStyle, Color) {}
 
 func (s *simscreen) Show() {
 	s.Lock()

--- a/terminfo/terminfo.go
+++ b/terminfo/terminfo.go
@@ -227,6 +227,9 @@ type Terminfo struct {
 	CursorSteadyUnderline   string
 	CursorBlinkingBar       string
 	CursorSteadyBar         string
+	CursorColor             string // nothing uses it yet
+	CursorColorRGB          string // Cs (but not really because Cs uses X11 color string)
+	CursorColorReset        string // Cr
 	EnterUrl                string
 	ExitUrl                 string
 	SetWindowSize           string

--- a/webfiles/tcell.js
+++ b/webfiles/tcell.js
@@ -21,6 +21,7 @@ const beepAudio = new Audio("beep.wav");
 var cx = -1;
 var cy = -1;
 var cursorClass = "cursor-blinking-block";
+var cursorColor = "";
 
 var content; // {data: row[height], dirty: bool}
 // row = {data: element[width], previous: span}
@@ -185,12 +186,18 @@ function displayCursor() {
       content.data[cy].data[cx] = span;
     }
 
+    if (cursorColor != "") {
+      term.style.setProperty("--cursor-color", cursorColor);
+    } else {
+      term.style.setProperty("--cursor-color", "lightgrey");
+    }
+
     content.data[cy].data[cx].classList.add(cursorClass);
   }
 }
 
-function setCursorStyle(newClass) {
-  if (newClass == cursorClass) {
+function setCursorStyle(newClass, newColor) {
+  if (newClass == cursorClass && newColor == cursorColor) {
     return;
   }
 
@@ -207,6 +214,7 @@ function setCursorStyle(newClass) {
   }
 
   cursorClass = newClass;
+  cursorColor = newColor;
 }
 
 function beep() {

--- a/webfiles/termstyle.css
+++ b/webfiles/termstyle.css
@@ -17,6 +17,7 @@
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
+  --cursor-color: lightgrey;
 }
 
 /* Style attributes */
@@ -64,26 +65,26 @@
 /* Cursor styles */
 
 .cursor-steady-block {
-  background-color: lightgrey !important;
+  background-color: var(--cursor-color) !important;
 }
 .cursor-blinking-block {
   animation: blinking-block 1s step-start infinite !important;
 }
 @keyframes blinking-block {
   50% {
-    background-color: lightgrey;
+    background-color: var(--cursor-color);
   }
 }
 
 .cursor-steady-underline {
-  text-decoration: underline lightgrey !important;
+  text-decoration: underline var(--cursor-color) !important;
 }
 .cursor-blinking-underline {
   animation: blinking-underline 1s step-start infinite !important;
 }
 @keyframes blinking-underline {
   50% {
-    text-decoration: underline lightgrey;
+    text-decoration: underline var(--cursor-color);
   }
 }
 
@@ -93,7 +94,7 @@
 .cursor-steady-bar:before {
   content: " ";
   width: 2px;
-  background-color: lightgrey !important;
+  background-color: var(--cursor-color) !important;
   display: inline-block;
 }
 .cursor-blinking-bar {
@@ -102,7 +103,7 @@
 .cursor-blinking-bar:before {
   content: " ";
   width: 2px;
-  background-color: lightgrey !important;
+  background-color: var(--cursor-color) !important;
   display: inline-block;
   animation: blinker 1s step-start infinite;
 }

--- a/wscreen.go
+++ b/wscreen.go
@@ -19,11 +19,13 @@ package tcell
 
 import (
 	"errors"
-	"github.com/gdamore/tcell/v2/terminfo"
+	"fmt"
 	"strings"
 	"sync"
 	"syscall/js"
 	"unicode/utf8"
+
+	"github.com/gdamore/tcell/v2/terminfo"
 )
 
 func NewTerminfoScreen() (Screen, error) {
@@ -158,9 +160,12 @@ func (t *wScreen) ShowCursor(x, y int) {
 	t.Unlock()
 }
 
-func (t *wScreen) SetCursorStyle(cs CursorStyle) {
+func (t *wScreen) SetCursor(cs CursorStyle, cc Color) {
+	if !cc.Valid() {
+		cc = ColorLightGray
+	}
 	t.Lock()
-	js.Global().Call("setCursorStyle", curStyleClasses[cs])
+	js.Global().Call("setCursorStyle", curStyleClasses[cs], fmt.Sprintf("#%06x", cc.Hex()))
 	t.Unlock()
 }
 


### PR DESCRIPTION
This adds a new optional parameter to screen.SetCursorStyle, which is a color.  The cursors demo is enhanced to show this.

This ability is supported on screen types, provided the underlying terminal supports the capability.