### PR TITLE
fixes #561 Add clipboard support.

### DIFF
--- a/_demos/clipboard.go
+++ b/_demos/clipboard.go
@@ -1,0 +1,115 @@
+//go:build ignore
+// +build ignore
+
+// Copyright 2024 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"unicode/utf8"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/encoding"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
+	for _, c := range str {
+		var comb []rune
+		w := runewidth.RuneWidth(c)
+		if w == 0 {
+			comb = []rune{c}
+			c = ' '
+			w = 1
+		}
+		s.SetContent(x, y, c, comb, style)
+		x += w
+	}
+}
+
+var clipboard []byte
+
+func displayHelloWorld(s tcell.Screen) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	emitStr(s, w/2-14, h/2, style, "Press 1 to set clipboard")
+	emitStr(s, w/2-14, h/2+1, style, "Press 2 to get clipboard")
+
+	msg := ""
+	if utf8.Valid(clipboard) {
+		cp := string(clipboard)
+		if len(cp) >= w-25 {
+			cp = cp[:21] + " ..."
+		}
+		msg = fmt.Sprintf("Clipboard (%d bytes): %s", len(clipboard), cp)
+	} else if clipboard != nil {
+		msg = fmt.Sprintf("Clipboard (%d bytes) Not Valid UTF-8", len(clipboard))
+	} else {
+		msg = "No clipboard data"
+	}
+	emitStr(s, (w-len(msg))/2, h/2+3, tcell.StyleDefault, msg)
+	emitStr(s, w/2-9, h/2+5, tcell.StyleDefault, "Press ESC to exit.")
+	s.Show()
+}
+
+// This program just prints "Hello, World!".  Press ESC to exit.
+func main() {
+	encoding.Register()
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	displayHelloWorld(s)
+
+	for {
+		switch ev := s.PollEvent().(type) {
+		case *tcell.EventResize:
+			s.Sync()
+			displayHelloWorld(s)
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyRune:
+				switch ev.Rune() {
+				case '1':
+					s.SetClipboard([]byte("Enjoy your new clipboard content!"))
+				case '2':
+					s.GetClipboard()
+				}
+			case tcell.KeyEscape:
+				s.Fini()
+				os.Exit(0)
+			}
+		case *tcell.EventClipboard:
+			clipboard = ev.Data()
+			displayHelloWorld(s)
+		}
+	}
+}

--- a/console_win.go
+++ b/console_win.go
@@ -1312,6 +1312,12 @@ func (s *cScreen) HasMouse() bool {
 	return true
 }
 
+func (s *cScreen) SetClipboard(_ []byte) {
+}
+
+func (s *cScreen) GetClipboard() {
+}
+
 func (s *cScreen) Resize(int, int, int, int) {}
 
 func (s *cScreen) HasKey(k Key) bool {

--- a/paste.go
+++ b/paste.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The TCell Authors
+// Copyright 2024 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -19,12 +19,14 @@ import (
 )
 
 // EventPaste is used to mark the start and end of a bracketed paste.
-// An event with .Start() true will be sent to mark the start.
-// Then a number of keys will be sent to indicate that the content
-// is pasted in.  At the end, an event with .Start() false will be sent.
+//
+// An event with .Start() true will be sent to mark the start of a bracketed paste,
+// followed by a number of keys (string data) for the content, ending with the
+// an event with .End() true.
 type EventPaste struct {
 	start bool
 	t     time.Time
+	data  []byte
 }
 
 // When returns the time when this EventPaste was created.
@@ -45,4 +47,26 @@ func (ev *EventPaste) End() bool {
 // NewEventPaste returns a new EventPaste.
 func NewEventPaste(start bool) *EventPaste {
 	return &EventPaste{t: time.Now(), start: start}
+}
+
+// NewEventClipboard returns a new NewEventClipboard with a data payload
+func NewEventClipboard(data []byte) *EventClipboard {
+	return &EventClipboard{t: time.Now(), data: data}
+}
+
+// EventClipboard represents data from the clipboard,
+// in response to a GetClipboard request.
+type EventClipboard struct {
+	t    time.Time
+	data []byte
+}
+
+// Data returns the attached binary data.
+func (ev *EventClipboard) Data() []byte {
+	return ev.data
+}
+
+// When returns the time when this event was created.
+func (ev *EventClipboard) When() time.Time {
+	return ev.t
 }

--- a/screen.go
+++ b/screen.go
@@ -272,6 +272,17 @@ type Screen interface {
 	// Tcell may attempt to save and restore the window title on entry and exit, but
 	// the results may vary.  Use of unicode characters may not be supported.
 	SetTitle(string)
+
+	// SetClipboard is used to post arbitrary data to the system clipboard.
+	// This need not be UTF-8 string data.  It's up to the recipient to decode the
+	// data meaningfully.  Terminals may prevent this for security reasons.
+	SetClipboard([]byte)
+
+	// GetClipboard is used to request the clipboard contents.  It may be ignored.
+	// If the terminal is willing, it will be post the clipboard contents using an
+	// EventPaste with the clipboard content as the Data() field.  Terminals may
+	// prevent this for security reasons.
+	GetClipboard()
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal
@@ -343,6 +354,8 @@ type screenImpl interface {
 	SetSize(int, int)
 	SetTitle(string)
 	Tty() (Tty, bool)
+	SetClipboard([]byte)
+	GetClipboard()
 
 	// Following methods are not part of the Screen api, but are used for interaction with
 	// the common layer code.

--- a/simulation.go
+++ b/simulation.go
@@ -61,8 +61,11 @@ type SimulationScreen interface {
 	// GetCursor returns the cursor details.
 	GetCursor() (x int, y int, visible bool)
 
-	// GetTitle gets the set title
+	// GetTitle gets the previously set title.
 	GetTitle() string
+
+	// GetClipboardData gets the actual data for the clipboard.
+	GetClipboardData() []byte
 }
 
 // SimCell represents a simulated screen cell.  The purpose of this
@@ -102,6 +105,7 @@ type simscreen struct {
 	fillstyle Style
 	fallback  map[rune]string
 	title     string
+	clipboard []byte
 
 	Screen
 	sync.Mutex
@@ -506,4 +510,19 @@ func (s *simscreen) SetTitle(title string) {
 
 func (s *simscreen) GetTitle() string {
 	return s.title
+}
+
+func (s *simscreen) SetClipboard(data []byte) {
+	s.clipboard = data
+}
+
+func (s *simscreen) GetClipboard() {
+	if s.clipboard != nil {
+		ev := NewEventClipboard(s.clipboard)
+		s.postEvent(ev)
+	}
+}
+
+func (s *simscreen) GetClipboardData() []byte {
+	return s.clipboard
 }


### PR DESCRIPTION
This is not supported for Windows or WebAssembly yet. It's possible for applications to post to the clipboard using Screen.SetClipboard (any data), and they can retrieve the clipboard (if permitted) using GetClipboard.  The terminal may well reject either of these.

Retrieval will arrive as a new EventClipboard, if it can.  (There is no good way to make this synchronous.)

This work was inspired by a PR submitted by Consolatis (#562), and has some work based on it, but it was also substantially improved and now includes both sides of the clipboard access pattern.