### PR TITLE
fixes #716 Improve missing terminal error message.

### DIFF
--- a/terms_dynamic.go
+++ b/terms_dynamic.go
@@ -27,9 +27,14 @@ import (
 	// will be automatically included anyway.
 	"github.com/gdamore/tcell/v2/terminfo"
 	"github.com/gdamore/tcell/v2/terminfo/dynamic"
+
+	"fmt"
 )
 
 func loadDynamicTerminfo(term string) (*terminfo.Terminfo, error) {
+	if term == "" {
+		return nil, fmt.Errorf("%w: term not set", ErrTermNotFound)
+	}
 	ti, _, e := dynamic.LoadTerminfo(term)
 	if e != nil {
 		return nil, e


### PR DESCRIPTION
When running in debug mode in VS Code under Linux the Application.Run() method returns an *os/exec.ExitError . This is very confusing and makes tracking down the root cause difficult.

The issue is caused by the default debug environment in VS Code not launching in a terminal.

The error message can be improved by returning an ErrTermNotFound in the case of an empty $TERM environment variable. Hopefully a better error message will lead users to identify the lack of a terminal as the root cause of the problem.