### PR TITLE
Speed up SetContent by checking length of combining characters before reflect.DeepEqual

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -16,7 +16,7 @@ package tcell
 
 // AttrMask represents a mask of text attributes, apart from color.
 // Note that support for attributes may vary widely across terminals.
-type AttrMask int
+type AttrMask int64
 
 // Attributes are not colors, but affect the display of text.  They can
 // be combined, in some cases, but not others. (E.g. you can have Dim Italic,

--- a/attr.go
+++ b/attr.go
@@ -16,7 +16,7 @@ package tcell
 
 // AttrMask represents a mask of text attributes, apart from color.
 // Note that support for attributes may vary widely across terminals.
-type AttrMask int64
+type AttrMask int
 
 // Attributes are not colors, but affect the display of text.  They can
 // be combined, in some cases, but not others. (E.g. you can have Dim Italic,

--- a/cell.go
+++ b/cell.go
@@ -58,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || !(len(combc) > 0 && len(combc) == len(c.currComb) && reflect.DeepEqual(combc, c.currComb))) {
+		if (c.width > 0) && (mainc != c.currMain || len(combc) != len(c.currComb) || (len(combc) > 0 && !reflect.DeepEqual(combc, c.currComb))) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -58,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || (len(combc) > 0 && len(combc) == len(c.currComb) && !reflect.DeepEqual(combc, c.currComb))) {
+		if (c.width > 0) && (mainc != c.currMain || !(len(combc) > 0 && len(combc) == len(c.currComb) && reflect.DeepEqual(combc, c.currComb))) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -16,6 +16,7 @@ package tcell
 
 import (
 	"os"
+	"reflect"
 
 	runewidth "github.com/mattn/go-runewidth"
 )
@@ -57,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain) {
+		if (c.width > 0) && (mainc != c.currMain || !reflect.DeepEqual(combc, c.currComb)) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -16,7 +16,6 @@ package tcell
 
 import (
 	"os"
-	"reflect"
 
 	runewidth "github.com/mattn/go-runewidth"
 )
@@ -58,7 +57,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || !reflect.DeepEqual(combc, c.currComb)) {
+		if (c.width > 0) && (mainc != c.currMain) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -58,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || len(combc) != len(c.currComb) || !(len(combc) > 0 && reflect.DeepEqual(combc, c.currComb))) {
+		if (c.width > 0) && (mainc != c.currMain || len(combc) != len(c.currComb) || (len(combc) > 0 && !reflect.DeepEqual(combc, c.currComb))) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -58,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || !reflect.DeepEqual(combc, c.currComb)) {
+		if (c.width > 0) && (mainc != c.currMain || (len(combc) > 0 && len(combc) == len(c.currComb) && !reflect.DeepEqual(combc, c.currComb))) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}

--- a/cell.go
+++ b/cell.go
@@ -58,7 +58,7 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if (c.width > 0) && (mainc != c.currMain || len(combc) != len(c.currComb) || (len(combc) > 0 && !reflect.DeepEqual(combc, c.currComb))) {
+		if (c.width > 0) && (mainc != c.currMain || len(combc) != len(c.currComb) || !(len(combc) > 0 && reflect.DeepEqual(combc, c.currComb))) {
 			for i := 0; i < c.width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}


### PR DESCRIPTION
Adding these length checks before the `reflect.DeepEqual` speeds up SetContent when not drawing Unicode combining characters

With `xset r rate 300 255` (key repeating 255 times per second), I recorded myself scrolling through 2000 files in my file manager project where I'm using [tview](https://github.com/rivo/tview) with and without (left) this change:

https://github.com/user-attachments/assets/9a4f8f83-7a8d-4b5f-b368-8687c53e1ad3

(6x sped up)

![image](https://github.com/user-attachments/assets/0d97e488-7496-4ef3-9772-c26752889965)

I believe the performance difference is a lot less dramatic for most projects, since in this old version of my file manager the screen was always unnecessarily being cleared with [Box.DrawForSubclass()](https://github.com/rivo/tview/blob/b0a7293b81308ab0e44c2757f8922683a3d659df/box.go#L386) in tview