### PR TITLE
fix warning 'Restore cache failed'

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,14 +10,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: 1.18
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -15,9 +18,6 @@ jobs:
 
     - name: Go version
       run: go version
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: 1.18
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...


### PR DESCRIPTION
When running GitHub workflow actions, there are [warnings](https://github.com/gdamore/tcell/actions/runs/8276175862) printed out:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/tcell/tcell.
Supported file pattern: go.sum
```

This PR fixes this issue.