### PR TITLE
fixes #764 Adding tcell as a dependency delays startup time

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -246,11 +246,4 @@ func init() {
 	if os.Getenv("RUNEWIDTH_EASTASIAN") == "" {
 		runewidth.DefaultCondition.EastAsianWidth = false
 	}
-
-	// For performance reasons, we create a lookup table.  However, some users
-	// might be more memory conscious.  If that's you, set the TCELL_MINIMIZE
-	// environment variable.
-	if os.Getenv("TCELL_MINIMIZE") == "" {
-		runewidth.CreateLUT()
-	}
 }


### PR DESCRIPTION
We no longer bother to create the lookup table for runewidth. I had expected this to make a significant difference, but I'm finding that it does not, but it does make the startup time even for applications that only import and never create a screen, considerably worse.  Dozens of milliseconds, even up to half a second.

Applications that need this (persumably some heavy Emoji or EastAsian users) can solve for themselves by importing the runewidth package (same version) and calling the CreateLUT method.