### PR TITLE
fixes #808 Add tmux to the base set of terminals.

### DIFF
--- a/terminfo/base/base.go
+++ b/terminfo/base/base.go
@@ -25,6 +25,7 @@ import (
 	// The following imports just register themselves --
 	// these are the terminal types we aggregate in this package.
 	_ "github.com/gdamore/tcell/v2/terminfo/a/ansi"
+	_ "github.com/gdamore/tcell/v2/terminfo/t/tmux"
 	_ "github.com/gdamore/tcell/v2/terminfo/v/vt100"
 	_ "github.com/gdamore/tcell/v2/terminfo/v/vt102"
 	_ "github.com/gdamore/tcell/v2/terminfo/v/vt220"


### PR DESCRIPTION
Tmux is pretty much everywhere, and the incremental addition of adding it is trivial, compared to the friction that results when it is not already included.