### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webasm.yml
+++ b/.github/workflows/webasm.yml
@@ -1,4 +1,6 @@
 name: webasm
+permissions:
+  contents: read
 on: [push]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/gdamore/tcell/security/code-scanning/4](https://github.com/gdamore/tcell/security/code-scanning/4)

To fix this issue, you should add an explicit `permissions` block either at the workflow level (top-level, applying to all jobs) or specifically for the affected job. Since this workflow only contains a single job (`build`), you can place the block at the workflow root, for clarity and scalability. The recommended minimal permission when jobs only need to read code/content is `contents: read`, which prevents GITHUB_TOKEN from being used to write to the repository. This should be added immediately after the `name:` key and before the `on:` trigger to apply globally, or inside the job definition if more granular control is needed.

No new methods, imports, or functionality changes are needed—just a YAML block addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
