### PR TITLE
Turn off CSI-u before leaving alternate screen mode

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1227,6 +1227,7 @@ func (t *tScreen) disengage() {
 	t.TPuts(ti.AttrOff)
 	t.TPuts(ti.ExitKeypad)
 	t.TPuts(ti.EnableAutoMargin)
+	t.TPuts(t.disableCsiU)
 	if os.Getenv("TCELL_ALTSCREEN") != "disable" {
 		if t.restoreTitle != "" {
 			t.TPuts(t.restoreTitle)
@@ -1237,7 +1238,6 @@ func (t *tScreen) disengage() {
 	t.enableMouse(0)
 	t.enablePasting(false)
 	t.disableFocusReporting()
-	t.TPuts(t.disableCsiU)
 
 	_ = t.tty.Stop()
 }


### PR DESCRIPTION
Terminals are required to remember CSI-u mode separately for the main screen and the alternate screen, and maintain separate stacks of flags for each. This means that it is important to disable CSI-u mode *before* we leave the alternate screen; otherwise, it tries to pop the flags from the main screen stack, which does nothing because it is empty, but leaves the flags on the alternate screen stack forever, so they remain active for other, non-CSI-u aware applications.