### PR TITLE
feat: Add improved string accessors for cell content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ If you're lazy, and want them all anyway, see the `encoding` sub-directory.
 
 ## Wide & Combining Characters
 
-The `SetContent()` API takes a primary rune, and an optional list of combining runes.
-If any of the runes is a wide (East Asian, Emoji, etc.) rune occupying two cells,
-then the library will skip output from the following cell. Care must be
-taken in the application to avoid explicitly attempting to set content in the
-next cell, otherwise the results are undefined. (Normally the wide character
-is displayed, and the other character is not; do not depend on that behavior.)
+The `Put()` API takes a string, which should be legal UTF-8, and displays
+the first grapheme (which may composed of multiple runes). It returns the
+actual width displayed, which can be used to advance the column positiion
+for the next display grapheme.  Alternatively, `PutStr()` or `PutStrStyled()`
+can be used to display a single line of text (which will be clipped at the
+edge of the screen).
+
+If a second character is displayed immediately in the cell adjacent to a
+wide character (offset by one instead of by two), then the results are undefined.
 
 ## Colors
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -107,28 +107,39 @@ s.SetStyle(defStyle)
 s.Clear()
 ```
 
-Text may be drawn on the screen using `SetContent`.
+Text may be drawn on the screen using `Put`, `PutStr`, or `PutStrStyled`.
 
 ```go
-s.SetContent(0, 0, 'H', nil, defStyle)
-s.SetContent(1, 0, 'i', nil, defStyle)
-s.SetContent(2, 0, '!', nil, defStyle)
+s.Put(0, 0, 'H', defStyle)
+s.Put(1, 0, 'i', defStyle)
+s.Put(2, 0, '!', defStyle)
 ```
 
-To draw text more easily, define a render function.
+which is equivalent to
+
+```go
+s.PutStrStyled(0, 0, "Hi!", defStyle)
+````
+
+To draw text more easily with wrapping, define a render function.
 
 ```go
 func drawText(s tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, text string) {
 	row := y1
 	col := x1
-	for _, r := range []rune(text) {
-		s.SetContent(col, row, r, nil, style)
-		col++
+	var width int
+	for text != "" {
+		text, width = s.Put(col, row, text, style)
+		col += width
 		if col >= x2 {
 			row++
 			col = x1
 		}
 		if row > y2 {
+			break
+		}
+		if width == 0 {
+			// incomplete grapheme at end of string
 			break
 		}
 	}
@@ -178,14 +189,19 @@ import (
 func drawText(s tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, text string) {
 	row := y1
 	col := x1
-	for _, r := range []rune(text) {
-		s.SetContent(col, row, r, nil, style)
-		col++
+	var width int
+	for text != "" {
+		text, width = s.Put(col, row, text, style)
+		col += width
 		if col >= x2 {
 			row++
 			col = x1
 		}
 		if row > y2 {
+			break
+		}
+		if width == 0 {
+			// incomplete grapheme at end of string
 			break
 		}
 	}
@@ -202,26 +218,26 @@ func drawBox(s tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, text string)
 	// Fill background
 	for row := y1; row <= y2; row++ {
 		for col := x1; col <= x2; col++ {
-			s.SetContent(col, row, ' ', nil, style)
+			s.Put(col, row, " ", style)
 		}
 	}
 
 	// Draw borders
 	for col := x1; col <= x2; col++ {
-		s.SetContent(col, y1, tcell.RuneHLine, nil, style)
-		s.SetContent(col, y2, tcell.RuneHLine, nil, style)
+		s.Put(col, y1, string(tcell.RuneHLine), style)
+		s.Put(col, y2, string(tcell.RuneHLine), style)
 	}
 	for row := y1 + 1; row < y2; row++ {
-		s.SetContent(x1, row, tcell.RuneVLine, nil, style)
-		s.SetContent(x2, row, tcell.RuneVLine, nil, style)
+		s.Put(x1, row, string(tcell.RuneVLine), style)
+		s.Put(x2, row, string(tcell.RuneVLine), style)
 	}
 
 	// Only draw corners if necessary
 	if y1 != y2 && x1 != x2 {
-		s.SetContent(x1, y1, tcell.RuneULCorner, nil, style)
-		s.SetContent(x2, y1, tcell.RuneURCorner, nil, style)
-		s.SetContent(x1, y2, tcell.RuneLLCorner, nil, style)
-		s.SetContent(x2, y2, tcell.RuneLRCorner, nil, style)
+		s.Put(x1, y1, string(tcell.RuneULCorner), style)
+		s.Put(x2, y1, string(tcell.RuneURCorner), style)
+		s.Put(x1, y2, string(tcell.RuneLLCorner), style)
+		s.Put(x2, y2, string(tcell.RuneLRCorner), style)
 	}
 
 	drawText(s, x1+1, y1+1, x2-1, y2-1, style, text)
@@ -310,4 +326,3 @@ func main() {
 	}
 }
 ```
-

--- a/_demos/boxes.go
+++ b/_demos/boxes.go
@@ -35,14 +35,14 @@ func makebox(s tcell.Screen) {
 		return
 	}
 
-	glyphs := []rune{'@', '#', '&', '*', '=', '%', 'Z', 'A'}
+	glyphs := []string{"@", "#", "&", "*", "=", "%", "Z", "A"}
 
 	lx := rand.Int() % w
 	ly := rand.Int() % h
 	lw := rand.Int() % (w - lx)
 	lh := rand.Int() % (h - ly)
 	st := tcell.StyleDefault
-	gl := ' '
+	gl := " "
 	if s.Colors() > 256 {
 		rgb := tcell.NewHexColor(int32(rand.Int() & 0xffffff))
 		st = st.Background(rgb)
@@ -55,7 +55,7 @@ func makebox(s tcell.Screen) {
 
 	for row := 0; row < lh; row++ {
 		for col := 0; col < lw; col++ {
-			s.SetCell(lx+col, ly+row, st, gl)
+			s.PutStrStyled(lx+col, ly+row, gl, st)
 		}
 	}
 	s.Show()

--- a/_demos/clipboard.go
+++ b/_demos/clipboard.go
@@ -23,23 +23,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
-
-func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
-	for _, c := range str {
-		var comb []rune
-		w := uniseg.StringWidth(string(c))
-		if w == 0 {
-			comb = []rune{c}
-			c = ' '
-			w = 1
-		}
-		s.SetContent(x, y, c, comb, style)
-		x += w
-	}
-}
 
 var clipboard []byte
 
@@ -47,8 +31,8 @@ func displayHelloWorld(s tcell.Screen) {
 	w, h := s.Size()
 	s.Clear()
 	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
-	emitStr(s, w/2-14, h/2, style, "Press 1 to set clipboard")
-	emitStr(s, w/2-14, h/2+1, style, "Press 2 to get clipboard")
+	s.PutStrStyled(w/2-14, h/2, "Press 1 to set clipboard", style)
+	s.PutStrStyled(w/2-14, h/2+1, "Press 2 to get clipboard", style)
 
 	msg := ""
 	if utf8.Valid(clipboard) {
@@ -62,14 +46,13 @@ func displayHelloWorld(s tcell.Screen) {
 	} else {
 		msg = "No clipboard data"
 	}
-	emitStr(s, (w-len(msg))/2, h/2+3, tcell.StyleDefault, msg)
-	emitStr(s, w/2-9, h/2+5, tcell.StyleDefault, "Press ESC to exit.")
+	s.PutStr((w-len(msg))/2, h/2+3, msg)
+	s.PutStr(w/2-9, h/2+5, "Press ESC to exit.")
 	s.Show()
 }
 
 // This program just prints "Hello, World!".  Press ESC to exit.
 func main() {
-	encoding.Register()
 
 	s, e := tcell.NewScreen()
 	if e != nil {

--- a/_demos/colors.go
+++ b/_demos/colors.go
@@ -1,7 +1,7 @@
 //go:build ignore
 // +build ignore
 
-// Copyright 2019 The TCell Authors
+// Copyright 2025 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -47,14 +47,14 @@ func makebox(s tcell.Screen) {
 		return
 	}
 
-	glyphs := []rune{'@', '#', '&', '*', '=', '%', 'Z', 'A'}
+	glyphs := []string{"@", "#", "&", "*", "=", "%", "Z", "A"}
 
 	lh := h / 2
 	lw := w / 2
 	lx := w / 4
 	ly := h / 4
 	st := tcell.StyleDefault
-	gl := ' '
+	gl := " "
 
 	if s.Colors() == 0 {
 		st = st.Reverse(rand.Int()%2 == 0)
@@ -81,7 +81,7 @@ func makebox(s tcell.Screen) {
 	}
 	for row := 0; row < lh; row++ {
 		for col := 0; col < lw; col++ {
-			s.SetCell(lx+col, ly+row, st, gl)
+			s.Put(lx+col, ly+row, gl, st)
 		}
 	}
 	s.Show()

--- a/_demos/cursors.go
+++ b/_demos/cursors.go
@@ -19,8 +19,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/gdamore/tcell/v2"
 	"os"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 func main() {
@@ -39,16 +40,12 @@ func main() {
 	s.Clear()
 
 	text := "This demonstrates cursor styles.  Press 0 through 6 to change the style."
-	x := 1
-	for _, r := range text {
-		s.SetCell(x, 1, tcell.StyleDefault, r)
-		x++
-	}
-	s.SetCell(2, 2, tcell.StyleDefault, '0')
+	s.PutStr(1, 1, text)
+
+	s.Put(2, 2, "0", tcell.StyleDefault)
 	s.SetCursorStyle(tcell.CursorStyleDefault)
 	s.ShowCursor(3, 2)
 	quit := make(chan struct{})
-	style := tcell.StyleDefault
 	go func() {
 		for {
 			s.Show()
@@ -59,25 +56,25 @@ func main() {
 				case tcell.KeyRune:
 					switch ev.Rune() {
 					case '0':
-						s.SetContent(2, 2, '0', nil, style)
+						s.Put(2, 2, "0", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleDefault, tcell.ColorReset)
 					case '1':
-						s.SetContent(2, 2, '1', nil, style)
+						s.Put(2, 2, "1", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleBlinkingBlock, tcell.ColorGreen)
 					case '2':
-						s.SetCell(2, 2, tcell.StyleDefault, '2')
+						s.Put(2, 2, "2", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleSteadyBlock, tcell.ColorBlue)
 					case '3':
-						s.SetCell(2, 2, tcell.StyleDefault, '3')
+						s.Put(2, 2, "3", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleBlinkingUnderline, tcell.ColorRed)
 					case '4':
-						s.SetCell(2, 2, tcell.StyleDefault, '4')
+						s.Put(2, 2, "4", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleSteadyUnderline, tcell.ColorOrange)
 					case '5':
-						s.SetCell(2, 2, tcell.StyleDefault, '5')
+						s.Put(2, 2, "5", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleBlinkingBar, tcell.ColorYellow)
 					case '6':
-						s.SetCell(2, 2, tcell.StyleDefault, '6')
+						s.Put(2, 2, "6", tcell.StyleDefault)
 						s.SetCursorStyle(tcell.CursorStyleSteadyBar, tcell.ColorPink)
 					}
 

--- a/_demos/hello_world.go
+++ b/_demos/hello_world.go
@@ -22,36 +22,19 @@ import (
 	"os"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
-
-func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
-	for _, c := range str {
-		var comb []rune
-		w := uniseg.StringWidth(string(c))
-		if w == 0 {
-			comb = []rune{c}
-			c = ' '
-			w = 1
-		}
-		s.SetContent(x, y, c, comb, style)
-		x += w
-	}
-}
 
 func displayHelloWorld(s tcell.Screen) {
 	w, h := s.Size()
 	s.Clear()
 	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
-	emitStr(s, w/2-7, h/2, style, "Hello, World!")
-	emitStr(s, w/2-9, h/2+1, tcell.StyleDefault, "Press ESC to exit.")
+	s.PutStrStyled(w/2-7, h/2, "Hello, World!", style)
+	s.PutStr(w/2-9, h/2+1, "Press ESC to exit.")
 	s.Show()
 }
 
 // This program just prints "Hello, World!".  Press ESC to exit.
 func main() {
-	encoding.Register()
 
 	s, e := tcell.NewScreen()
 	if e != nil {

--- a/_demos/hyperlink.go
+++ b/_demos/hyperlink.go
@@ -22,22 +22,11 @@ import (
 	"os"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
 
 func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) int {
-	for _, c := range str {
-		var comb []rune
-		w := uniseg.StringWidth(string(c))
-		if w == 0 {
-			comb = []rune{c}
-			c = ' '
-			w = 1
-		}
-		s.SetContent(x, y, c, comb, style)
-		x += w
-	}
+	s.PutStrStyled(x, y, str, style)
+	x += len(str)
 	return x
 }
 
@@ -56,7 +45,6 @@ func displayDemo(s tcell.Screen) {
 
 // This program just prints "Hello, World!".  Press ESC to exit.
 func main() {
-	encoding.Register()
 
 	s, e := tcell.NewScreen()
 	if e != nil {

--- a/_demos/setsize.go
+++ b/_demos/setsize.go
@@ -23,22 +23,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
-
-func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
-	for _, c := range str {
-		var comb []rune
-		w := uniseg.StringWidth(string(c))
-		if w == 0 {
-			comb = []rune{c}
-			c = ' '
-			w = 1
-		}
-		s.SetContent(x, y, c, comb, style)
-		x += w
-	}
-}
 
 func displayDemo(s tcell.Screen) {
 	w, h := s.Size()
@@ -46,8 +31,8 @@ func displayDemo(s tcell.Screen) {
 	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
 	sizeStr := fmt.Sprintf("%d x %d", w, h)
 	helpStr := "Use cursors to resize, ESC to exit."
-	emitStr(s, (w-len(sizeStr))/2, h/2, style, sizeStr)
-	emitStr(s, (w-len(helpStr))/2, h/2+1, tcell.StyleDefault, helpStr)
+	s.PutStrStyled((w-len(sizeStr))/2, h/2, sizeStr, style)
+	s.PutStr((w-len(helpStr))/2, h/2+1, helpStr)
 	s.Show()
 }
 

--- a/_demos/showcolor.go
+++ b/_demos/showcolor.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/uniseg"
 )
 
 var red = int32(rand.Int() % 256)
@@ -41,20 +40,6 @@ var inc = int32(8) // rate of color change
 var redi = int32(inc)
 var grni = int32(inc)
 var blui = int32(inc)
-
-func emitStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
-	for _, c := range str {
-		var comb []rune
-		w := uniseg.StringWidth(string(c))
-		if w == 0 {
-			comb = []rune{c}
-			c = ' '
-			w = 1
-		}
-		s.SetContent(x, y, c, comb, style)
-		x += w
-	}
-}
 
 func makebox(s tcell.Screen, name string, color tcell.Color) {
 	w, h := s.Size()
@@ -68,13 +53,12 @@ func makebox(s tcell.Screen, name string, color tcell.Color) {
 	lx := 0
 	ly := 0
 	st := tcell.StyleDefault
-	gl := ' '
 
 	s.Fill(' ', st)
 	bg := st.Background(color)
 	for row := 0; row < lh; row++ {
 		for col := 0; col < lw; col++ {
-			s.SetCell(lx+col, ly+row, bg, gl)
+			s.Put(lx+col, ly+row, " ", bg)
 		}
 	}
 	cn := color.Name()
@@ -87,7 +71,7 @@ func makebox(s tcell.Screen, name string, color tcell.Color) {
 	} else {
 		lx = 0
 	}
-	emitStr(s, lx, lh+1, st, msg)
+	s.PutStrStyled(lx, lh+1, msg, st)
 	s.Show()
 }
 

--- a/_demos/stress.go
+++ b/_demos/stress.go
@@ -40,12 +40,12 @@ func main() {
 	var frames int
 
 	type cell struct {
-		c     rune
+		c     string
 		style tcell.Style
 	}
 
 	width, height := screen.Size()
-	glyphs := []rune{'@', '#', '&', '*', '=', '%', 'Z', 'A'}
+	glyphs := []string{"@", "#", "&", "*", "=", "%", "Z", "A"}
 	attrs := []tcell.AttrMask{tcell.AttrBold, tcell.AttrReverse, tcell.AttrItalic, tcell.AttrNone}
 
 	// Pre-Generate 100 different frame patterns, so we stress the terminal as
@@ -98,7 +98,7 @@ loop:
 		for h := 0; h < height; h++ {
 			for w := 0; w < width; w++ {
 				c := pattern[h][w]
-				screen.SetContent(w, h, c.c, nil, c.style)
+				screen.Put(w, h, c.c, c.style)
 			}
 		}
 		screen.Show()

--- a/_demos/style.go
+++ b/_demos/style.go
@@ -24,61 +24,10 @@ import (
 	"os"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
 
 var row = 0
 var style = tcell.StyleDefault
-
-func puts(s tcell.Screen, style tcell.Style, x, y int, str string) {
-	i := 0
-	var deferred []rune
-	dwidth := 0
-	zwj := false
-	for _, r := range str {
-		if r == '\u200d' {
-			if len(deferred) == 0 {
-				deferred = append(deferred, ' ')
-				dwidth = 1
-			}
-			deferred = append(deferred, r)
-			zwj = true
-			continue
-		}
-		if zwj {
-			deferred = append(deferred, r)
-			zwj = false
-			continue
-		}
-		switch uniseg.StringWidth(string(r)) {
-		case 0:
-			if len(deferred) == 0 {
-				deferred = append(deferred, ' ')
-				dwidth = 1
-			}
-		case 1:
-			if len(deferred) != 0 {
-				s.SetContent(x+i, y, deferred[0], deferred[1:], style)
-				i += dwidth
-			}
-			deferred = nil
-			dwidth = 1
-		case 2:
-			if len(deferred) != 0 {
-				s.SetContent(x+i, y, deferred[0], deferred[1:], style)
-				i += dwidth
-			}
-			deferred = nil
-			dwidth = 2
-		}
-		deferred = append(deferred, r)
-	}
-	if len(deferred) != 0 {
-		s.SetContent(x+i, y, deferred[0], deferred[1:], style)
-		i += dwidth
-	}
-}
 
 func main() {
 
@@ -87,8 +36,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", e)
 		os.Exit(1)
 	}
-
-	encoding.Register()
 
 	if e = s.Init(); e != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", e)
@@ -108,91 +55,91 @@ func main() {
 	style = bold.Foreground(tcell.ColorBlue).Background(tcell.ColorSilver)
 
 	row = 2
-	puts(s, style, 2, row, "Press ESC to Exit")
+	s.PutStrStyled(2, row, "Press ESC to Exit", style)
 	row = 4
-	puts(s, plain, 2, row, "Note: Style support is dependent on your terminal.")
+	s.PutStrStyled(2, row, "Note: Style support is dependent on your terminal.", plain)
 	row = 6
 
 	plain = tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite)
 
 	style = plain
-	puts(s, style, 2, row, "Plain")
+	s.PutStrStyled(2, row, "Plain", style)
 	row++
 
 	style = plain.Blink(true)
-	puts(s, style, 2, row, "Blink")
+	s.PutStrStyled(2, row, "Blink", style)
 	row++
 
 	style = plain.Reverse(true)
-	puts(s, style, 2, row, "Reverse")
+	s.PutStrStyled(2, row, "Reverse", style)
 	row++
 
 	style = plain.Dim(true)
-	puts(s, style, 2, row, "Dim")
+	s.PutStrStyled(2, row, "Dim", style)
 	row++
 
 	style = plain.Underline(true)
-	puts(s, style, 2, row, "Underline")
+	s.PutStrStyled(2, row, "Underline", style)
 	row++
 
 	style = plain.Italic(true)
-	puts(s, style, 2, row, "Italic")
+	s.PutStrStyled(2, row, "Italic", style)
 	row++
 
 	style = plain.Bold(true)
-	puts(s, style, 2, row, "Bold")
+	s.PutStrStyled(2, row, "Bold", style)
 	row++
 
 	style = plain.Bold(true).Italic(true)
-	puts(s, style, 2, row, "Bold Italic")
+	s.PutStrStyled(2, row, "Bold Italic", style)
 	row++
 
 	style = plain.Bold(true).Italic(true).Underline(true)
-	puts(s, style, 2, row, "Bold Italic Underline")
+	s.PutStrStyled(2, row, "Bold Italic Underline", style)
 	row++
 
 	style = plain.StrikeThrough(true)
-	puts(s, style, 2, row, "Strikethrough")
+	s.PutStrStyled(2, row, "Strikethrough", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleDouble)
-	puts(s, style, 2, row, "Double Underline")
+	s.PutStrStyled(2, row, "Double Underline", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleCurly)
-	puts(s, style, 2, row, "Curly Underline")
+	s.PutStrStyled(2, row, "Curly Underline", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleDotted)
-	puts(s, style, 2, row, "Dotted Underline")
+	s.PutStrStyled(2, row, "Dotted Underline", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleDashed)
-	puts(s, style, 2, row, "Dashed Underline")
+	s.PutStrStyled(2, row, "Dashed Underline", style)
 	row++
 
 	style = plain.Underline(true, tcell.ColorBlue)
-	puts(s, style, 2, row, "Blue Underline")
+	s.PutStrStyled(2, row, "Blue Underline", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleSolid, tcell.ColorFireBrick)
-	puts(s, style, 2, row, "Firebrick Underline")
+	s.PutStrStyled(2, row, "Firebrick Underline", style)
 	row++
 
 	style = plain.Underline(tcell.UnderlineStyleCurly, tcell.NewRGBColor(0xc5, 0x8a, 0xf9))
-	puts(s, style, 2, row, "Pink Curly Underline")
+	s.PutStrStyled(2, row, "Pink Curly Underline", style)
 	row++
 
 	style = plain.Url("http://github.com/gdamore/tcell")
-	puts(s, style, 2, row, "HyperLink")
+	s.PutStrStyled(2, row, "HyperLink", style)
 	row++
 
 	style = plain.Foreground(tcell.ColorRed)
-	puts(s, style, 2, row, "Red Foreground")
+	s.PutStrStyled(2, row, "Red Foreground", style)
 	row++
 
 	style = plain.Background(tcell.ColorRed)
-	puts(s, style, 2, row, "Red Background")
+	s.PutStrStyled(2, row, "Red Background", style)
 	row++
 
 	s.Show()

--- a/_demos/unicode.go
+++ b/_demos/unicode.go
@@ -22,11 +22,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/rivo/uniseg"
 )
 
 var row = 0
@@ -34,27 +32,8 @@ var style = tcell.StyleDefault
 
 func putln(s tcell.Screen, str string) {
 
-	puts(s, style, 1, row, str)
+	s.PutStrStyled(1, row, str, style)
 	row++
-}
-
-func puts(s tcell.Screen, style tcell.Style, x, y int, str string) {
-	i := 0
-	state := -1
-	var grapheme string
-	var width int
-
-	for str != "" {
-		grapheme, str, width, state = uniseg.FirstGraphemeClusterInString(str, state)
-		var runes []rune
-		for grapheme != "" {
-			r, rlen := utf8.DecodeRuneInString(grapheme)
-			runes = append(runes, r)
-			grapheme = grapheme[rlen:]
-		}
-		s.SetContent(x+i, y, runes[0], runes[1:], style)
-		i += width
-	}
 }
 
 func main() {
@@ -107,41 +86,15 @@ func main() {
 	putln(s, "Region:    \U0001f1fa\U0001f1f8 (USA! USA!)\n")
 	putln(s, "")
 	putln(s, "Box:")
-	putln(s, string([]rune{
-		tcell.RuneULCorner,
-		tcell.RuneHLine,
-		tcell.RuneTTee,
-		tcell.RuneHLine,
-		tcell.RuneURCorner,
-	}))
-	putln(s, string([]rune{
-		tcell.RuneVLine,
-		tcell.RuneBullet,
-		tcell.RuneVLine,
-		tcell.RuneLantern,
-		tcell.RuneVLine,
-	})+"  (bullet, lantern/section)")
-	putln(s, string([]rune{
-		tcell.RuneLTee,
-		tcell.RuneHLine,
-		tcell.RunePlus,
-		tcell.RuneHLine,
-		tcell.RuneRTee,
-	}))
-	putln(s, string([]rune{
-		tcell.RuneVLine,
-		tcell.RuneDiamond,
-		tcell.RuneVLine,
-		tcell.RuneUArrow,
-		tcell.RuneVLine,
-	})+"  (diamond, up arrow)")
-	putln(s, string([]rune{
-		tcell.RuneLLCorner,
-		tcell.RuneHLine,
-		tcell.RuneBTee,
-		tcell.RuneHLine,
-		tcell.RuneLRCorner,
-	}))
+	putln(s, "┌─┬─┬──┐")
+	putln(s, "│·│§│月│ (bullet, lantern, Swiss)")
+	putln(s, "├─┼─┼──┤")
+	putln(s, "│A│1│😘│ (A, 1, Kiss)")
+	putln(s, "├─┼─┼──┤")
+	putln(s, "│·│§│🇨🇭│ (bullet, lantern, Swiss)")
+	putln(s, "├─┼─┼──┤")
+	putln(s, "│◆│↑│  │ (diamond, up arrow, empty)")
+	putln(s, "└─┴─┴──┘")
 
 	s.Show()
 	go func() {

--- a/cell.go
+++ b/cell.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The TCell Authors
+// Copyright 2025 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -15,31 +15,26 @@
 package tcell
 
 import (
-	"slices"
-
 	"github.com/rivo/uniseg"
 )
 
 type cell struct {
-	currMain  rune
-	currComb  []rune
+	currStr   string
+	lastStr   string
 	currStyle Style
-	lastMain  rune
 	lastStyle Style
-	lastComb  []rune
 	width     int
 	lock      bool
 }
 
 func (c *cell) setDirty(dirty bool) {
 	if dirty {
-		c.lastMain = rune(0)
+		c.lastStr = ""
 	} else {
-		if c.currMain == rune(0) {
-			c.currMain = ' '
+		if c.currStr == "" {
+			c.currStr = " "
 		}
-		c.lastMain = c.currMain
-		c.lastComb = append(c.lastComb[:0], c.currComb...)
+		c.lastStr = c.currStr
 		c.lastStyle = c.currStyle
 	}
 }
@@ -60,33 +55,47 @@ type CellBuffer struct {
 // and style) for a cell at a given location.  If the background or
 // foreground of the style is set to ColorNone, then the respective
 // color is left un changed.
-func (cb *CellBuffer) SetContent(x int, y int,
-	mainc rune, combc []rune, style Style,
-) {
+//
+// Deprecated: Use Put instead, which this is implemented in terms of.
+func (cb *CellBuffer) SetContent(x int, y int, mainc rune, combc []rune, style Style) {
+	cb.Put(x, y, string(append([]rune{mainc}, combc...)), style)
+}
+
+// Put a single styled grapheme using the given string and style
+// at the same location.  Note that only the first grapheme in the string
+// will bre displayed, using only the 1 or 2 (depending on width) cells
+// located at x, y. It returns the rest of the string, and the width used.
+func (cb *CellBuffer) Put(x int, y int, str string, style Style) (string, int) {
+	var width int = 0
 	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
+		var cl string
 		c := &cb.cells[(y*cb.w)+x]
+		state := -1
+		for width == 0 && str != "" {
+			var g string
+			g, str, width, state = uniseg.FirstGraphemeClusterInString(str, state)
+			cl += g
+			if g == "" {
+				break
+			}
+		}
 
 		// Wide characters: we want to mark the "wide" cells
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if c.width > 0 && (mainc != c.currMain || !slices.Equal(combc, c.currComb)) {
+		if width > 0 && cl != c.currStr {
 			// Prevent unnecessary boundchecks for first cell, since we already
 			// received that one.
 			c.setDirty(true)
-			for i := 1; i < c.width; i++ {
+			for i := 1; i < width; i++ {
 				cb.SetDirty(x+i, y, true)
 			}
 		}
 
-		// Reuse slice to prevent allocations
-		c.currComb = append(c.currComb[:0], combc...)
+		c.currStr = cl
+		c.width = width
 
-		if c.currMain != mainc {
-			s := string(mainc) + string(c.currComb)
-			c.width = uniseg.StringWidth(s)
-		}
-		c.currMain = mainc
 		if style.fg == ColorNone {
 			style.fg = c.currStyle.fg
 		}
@@ -95,23 +104,45 @@ func (cb *CellBuffer) SetContent(x int, y int,
 		}
 		c.currStyle = style
 	}
+	return str, width
+}
+
+// Get the contents of a character cell (or two adjacent cells), including the
+// the style and the display width in cells.  (The width can be either 1, normally,
+// or 2 for East Asian full-width characters.  If the width is 0, then the cell is
+// is empty.)
+func (cb *CellBuffer) Get(x, y int) (string, Style, int) {
+	var style Style
+	var width int
+	var str string
+	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
+		c := &cb.cells[(y*cb.w)+x]
+		str, style = c.currStr, c.currStyle
+		if width = c.width; width == 0 || str == "" {
+			width = 1
+			str = " "
+		}
+	}
+	return str, style, width
 }
 
 // GetContent returns the contents of a character cell, including the
 // primary rune, any combining character runes (which will usually be
 // nil), the style, and the display width in cells.  (The width can be
 // either 1, normally, or 2 for East Asian full-width characters.)
+//
+// Deprecated: Use Get, which this implemented in terms of.
 func (cb *CellBuffer) GetContent(x, y int) (rune, []rune, Style, int) {
-	var mainc rune
-	var combc []rune
 	var style Style
 	var width int
-	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
-		c := &cb.cells[(y*cb.w)+x]
-		mainc, combc, style = c.currMain, c.currComb, c.currStyle
-		if width = c.width; width == 0 || mainc < ' ' {
-			width = 1
-			mainc = ' '
+	var mainc rune
+	var combc []rune
+	str, style, width := cb.Get(x, y)
+	for i, r := range str {
+		if i == 0 {
+			mainc = r
+		} else {
+			combc = append(combc, r)
 		}
 	}
 	return mainc, combc, style, width
@@ -125,7 +156,7 @@ func (cb *CellBuffer) Size() (int, int) {
 // Invalidate marks all characters within the buffer as dirty.
 func (cb *CellBuffer) Invalidate() {
 	for i := range cb.cells {
-		cb.cells[i].lastMain = rune(0)
+		cb.cells[i].lastStr = ""
 	}
 }
 
@@ -138,22 +169,11 @@ func (cb *CellBuffer) Dirty(x, y int) bool {
 		if c.lock {
 			return false
 		}
-		if c.lastMain == rune(0) {
-			return true
-		}
-		if c.lastMain != c.currMain {
-			return true
-		}
 		if c.lastStyle != c.currStyle {
 			return true
 		}
-		if len(c.lastComb) != len(c.currComb) {
+		if c.lastStr != c.currStr {
 			return true
-		}
-		for i := range c.lastComb {
-			if c.lastComb[i] != c.currComb[i] {
-				return true
-			}
 		}
 	}
 	return false
@@ -211,11 +231,10 @@ func (cb *CellBuffer) Resize(w, h int) {
 		for x := 0; x < w && x < cb.w; x++ {
 			oc := &cb.cells[(y*cb.w)+x]
 			nc := &newc[(y*w)+x]
-			nc.currMain = oc.currMain
-			nc.currComb = oc.currComb
+			nc.currStr = oc.currStr
 			nc.currStyle = oc.currStyle
 			nc.width = oc.width
-			nc.lastMain = rune(0)
+			nc.lastStr = ""
 		}
 	}
 	cb.cells = newc
@@ -231,8 +250,7 @@ func (cb *CellBuffer) Resize(w, h int) {
 func (cb *CellBuffer) Fill(r rune, style Style) {
 	for i := range cb.cells {
 		c := &cb.cells[i]
-		c.currMain = r
-		c.currComb = nil
+		c.currStr = string(r)
 		cs := style
 		if cs.fg == ColorNone {
 			cs.fg = c.currStyle.fg

--- a/mouse.go
+++ b/mouse.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The TCell Authors
+// Copyright 2025 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.


### PR DESCRIPTION
Having separate runes was awkward in many cases, and was done with an incomplete understanding of unicode segmentation.  Its simpler for everyone if we just treat these as strings, so we introduce new methods for screen (Put, PutStyledStr, and PutStr) for writing either a grapheme cluster, or (for convenience) writing a full string at a given location.

The other methods are now deprecated.  We intend to remove them in tcell v3.