### PR TITLE
Fix KeyCtrlRightSq name from 'Ctrl-[' to 'Ctrl-]'

### DIFF
--- a/key.go
+++ b/key.go
@@ -203,7 +203,7 @@ var KeyNames = map[Key]string{
 	KeyCtrlY:          "Ctrl-Y",
 	KeyCtrlZ:          "Ctrl-Z",
 	KeyCtrlLeftSq:     "Ctrl-[",
-	KeyCtrlRightSq:    "Ctrl-[",
+	KeyCtrlRightSq:    "Ctrl-]",
 	KeyCtrlBackslash:  "Ctrl-\\",
 	KeyCtrlCarat:      "Ctrl-^",
 	KeyCtrlUnderscore: "Ctrl-_",


### PR DESCRIPTION
KeyCtrlRightSq (Ctrl+]) was incorrectly named 'Ctrl-[' instead of 'Ctrl-]'. This appears to be a copy-paste error introduced in commit 74fd487.

This fix corrects the KeyNames map entry for KeyCtrlRightSq to properly reflect the right square bracket ']' instead of the left square bracket '['.

This issue was discovered while updating tests in the [cbind](https://codeberg.org/tslocum/cbind) 
library (keyboard event handling library for tcell). 