### PR TITLE
fix: Pasting 32 or more runes is broken (fixes #852)

### DIFF
--- a/input.go
+++ b/input.go
@@ -111,11 +111,7 @@ func (ip *inputProcessor) post(ev Event) {
 		}
 	}
 
-	// this tries to post, will drop events that overflow
-	select {
-	case ip.evch <- ev:
-	default:
-	}
+	ip.evch <- ev
 }
 
 func (ip *inputProcessor) escTimeout() {

--- a/tscreen.go
+++ b/tscreen.go
@@ -230,7 +230,7 @@ func (t *tScreen) Init() error {
 	}
 
 	t.quit = make(chan struct{})
-	t.eventQ = make(chan Event, 32)
+	t.eventQ = make(chan Event, 256)
 	t.input = NewInputProcessor(t.eventQ)
 
 	t.Lock()


### PR DESCRIPTION
This make posting events blocking, but it also increases the size of the event queue to 256, so we hopefully avoid blocking mostly.