### PR TITLE
feat: Desktop notifications (fixes #499)

### DIFF
--- a/_demos/notify.go
+++ b/_demos/notify.go
@@ -1,0 +1,97 @@
+//go:build ignore
+// +build ignore
+
+// Copyright 2025 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func displayHelloWorld(s tcell.Screen, secs int) {
+	w, h := s.Size()
+	s.Clear()
+	style := tcell.StyleDefault.Foreground(tcell.ColorCadetBlue.TrueColor()).Background(tcell.ColorWhite)
+	msg := "Notification Demo"
+	s.PutStrStyled((w-len(msg))/2, h/2-1, msg, style)
+	msg = "(Minimize This Window)"
+	s.PutStrStyled((w-len(msg))/2, h/2+1, msg, style)
+	if secs > 0 {
+		msg = fmt.Sprintf("Incoming in %d Seconds", secs)
+	} else {
+		msg = "Notification Sent!"
+	}
+	s.PutStr((w-len(msg))/2, h/2+3, msg)
+	msg = "Press ESC to exit, ENTER to restart."
+	s.PutStr((w-len(msg))/2, h/2+5, msg)
+	s.Show()
+}
+
+// This program just prints "Hello, World!".  Press ESC to exit.
+func main() {
+
+	s, e := tcell.NewScreen()
+	if e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+	if e := s.Init(); e != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", e)
+		os.Exit(1)
+	}
+
+	defStyle := tcell.StyleDefault.
+		Background(tcell.ColorBlack).
+		Foreground(tcell.ColorWhite)
+	s.SetStyle(defStyle)
+
+	when := 10
+	displayHelloWorld(s, when)
+
+	ticker := time.NewTicker(time.Second)
+	var ev tcell.Event
+	for {
+		select {
+		case ev = <-s.EventQ():
+		case <-ticker.C:
+			if when > 0 {
+				when--
+				if when == 0 {
+					s.ShowNotification("Ding Dong!", "The wicked witch is dead.")
+				}
+			}
+			displayHelloWorld(s, when)
+			continue
+		}
+		switch ev := ev.(type) {
+		case *tcell.EventResize:
+			s.Sync()
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEnter:
+				when = 10
+			case tcell.KeyEscape:
+				s.Fini()
+				os.Exit(0)
+			}
+		}
+		displayHelloWorld(s, when)
+	}
+}

--- a/screen.go
+++ b/screen.go
@@ -233,6 +233,10 @@ type Screen interface {
 	// EventPaste with the clipboard content as the Data() field.  Terminals may
 	// prevent this for security reasons.
 	GetClipboard()
+
+	// ShowNotification is used to show a desktop notification, when the terminal
+	// supports it.  Right now only terminals supporting OSC 777 support this.
+	ShowNotification(title string, body string)
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal
@@ -300,6 +304,7 @@ type screenImpl interface {
 	Tty() (Tty, bool)
 	SetClipboard([]byte)
 	GetClipboard()
+	ShowNotification(string, string)
 
 	// Following methods are not part of the Screen api, but are used for interaction with
 	// the common layer code.

--- a/simulation.go
+++ b/simulation.go
@@ -502,3 +502,5 @@ func (s *simscreen) GetClipboard() {
 func (s *simscreen) GetClipboardData() []byte {
 	return s.clipboard
 }
+
+func (s *simscreen) ShowNotification(_ string, _ string) {}

--- a/wscreen.go
+++ b/wscreen.go
@@ -309,7 +309,7 @@ func (t *wScreen) postEvent(ev Event) {
 	}
 }
 
-func (t *wScreen) onMouseEvent(this js.Value, args []js.Value) interface{} {
+func (t *wScreen) onMouseEvent(this js.Value, args []js.Value) any {
 	mod := ModNone
 	button := ButtonNone
 
@@ -395,7 +395,7 @@ func (t *wScreen) onFocus(this js.Value, args []js.Value) any {
 // happen when javascript calls a function (for example, when
 // mouse input is disabled, when onMouseEvent() is called from
 // js, it redirects here and does nothing).
-func (t *wScreen) unset(this js.Value, args []js.Value) interface{} {
+func (t *wScreen) unset(this js.Value, args []js.Value) any {
 	return nil
 }
 
@@ -495,6 +495,8 @@ func (t *wScreen) StopQ() <-chan struct{} {
 func (t *wScreen) SetTitle(title string) {
 	js.Global().Call("setTitle", title)
 }
+
+func (*wScreen) ShowNotification(title string, body string) {}
 
 // WebKeyNames maps string names reported from HTML
 // (KeyboardEvent.key) to tcell accepted keys.


### PR DESCRIPTION
This only adds support for OSC 777 terminals, but that seems to include ghostty, wezterm, and probably a number of others. A demo is included.