### PR TITLE
feat: fallback to US-ASCII by default.

### DIFF
--- a/_demos/mouse.go
+++ b/_demos/mouse.go
@@ -27,7 +27,6 @@ import (
 	"runtime"
 
 	"github.com/gdamore/tcell/v3"
-	"github.com/gdamore/tcell/v3/encoding"
 )
 
 var defStyle tcell.Style
@@ -97,8 +96,6 @@ func main() {
 			shell = "/bin/sh"
 		}
 	}
-
-	encoding.Register()
 
 	s, e := tcell.NewScreen()
 	if e != nil {


### PR DESCRIPTION
This allows most terminal applications that do not make use of Unicode to Just Work.  (It does predispose for English.)  All supported encodings are strict US-ASCII supersets, so this is entirely non-risky.

Applications which only need to work with newer systems could just assume UTF-8 by setting the fallback to UTF-8 by default, but we didn't feel confident of that yet.