### PR TITLE
fix: Shift+letter A-Z treated as Ctrl+letter

### DIFF
--- a/input.go
+++ b/input.go
@@ -426,11 +426,7 @@ func (ip *inputProcessor) scan() {
 				ip.post(NewEventKey(KeyEnter, "", ModNone))
 			default:
 				// Control keys - legacy handling
-				if r >= rune(KeyCtrlA) && r <= rune(KeyCtrlZ) {
-					ip.post(NewEventKey(Key(r), "", ModCtrl))
-				} else if r == 0 {
-					ip.post(NewEventKey(KeyRune, string(" "), ModCtrl))
-				} else if r < ' ' {
+				if r < ' ' {
 					ip.post(NewEventKey(KeyRune, string(r+0x40), ModCtrl))
 				} else {
 					ip.post(NewEventKey(KeyRune, string(r), ModNone))


### PR DESCRIPTION
Fixes bug #881 introduced in 7e9c86d0b98b3f964319db8e650882849f0d8158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined control-key input handling in the scanner for improved consistency in keyboard event processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->