### PR TITLE
fix(windows): remove incorrect +1 from console dimension calculations

### DIFF
--- a/tty_win.go
+++ b/tty_win.go
@@ -216,8 +216,8 @@ func (w *winTty) getConsoleInput() error {
 
 			case resizeEvent:
 				w.Lock()
-				w.cols = binary.LittleEndian.Uint16(ir.data[0:]) + 1
-				w.rows = binary.LittleEndian.Uint16(ir.data[2:]) + 1
+				w.cols = binary.LittleEndian.Uint16(ir.data[0:])
+				w.rows = binary.LittleEndian.Uint16(ir.data[2:])
 				cb := w.resizeCb
 				w.Unlock()
 				if cb != nil {
@@ -312,8 +312,8 @@ func NewDevTty() (Tty, error) {
 	_, _, _ = procGetConsoleScreenBufferInfo.Call(uintptr(w.out), uintptr(unsafe.Pointer(&w.oscreen)))
 	_, _, _ = procGetConsoleMode.Call(uintptr(w.out), uintptr(unsafe.Pointer(&w.oomode)))
 	_, _, _ = procGetConsoleMode.Call(uintptr(w.in), uintptr(unsafe.Pointer(&w.oimode)))
-	w.rows = uint16(w.oscreen.size.y + 1)
-	w.cols = uint16(w.oscreen.size.x + 1)
+	w.rows = uint16(w.oscreen.size.y)
+	w.cols = uint16(w.oscreen.size.x)
 
 	return w, nil
 }


### PR DESCRIPTION
The Windows Console API already returns the correct dimensions (0-based
coordinates)

Closes #889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected console window dimensions to accurately reflect actual width and height values during initialization and resize events, eliminating previous offset calculations that resulted in inflated dimension measurements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->