### PR TITLE
fix: KeyTab + ModShift shoudl be KeyBacktab

### DIFF
--- a/key.go
+++ b/key.go
@@ -299,6 +299,11 @@ func NewEventKey(k Key, str string, mod ModMask) *EventKey {
 		k = KeyBackspace
 	}
 
+	// Shift-Tab should be Backtab.
+	if k == KeyTab && (mod&ModShift) != 0 {
+		k = KeyBacktab
+		mod &^= ModShift
+	}
 	return &EventKey{t: time.Now(), key: k, str: str, mod: mod}
 }
 


### PR DESCRIPTION
We want this as a separate key stroke because on some keyboards it could theoretically be so (there is an X keycode for it.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for Shift+Tab to correctly generate the Backtab key, enabling more consistent navigation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->