### PR TITLE
docs: Update some left over references to Rune() to Str() in docs (fi…

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -38,8 +38,8 @@ When a non-rune key is pressed, it is available as the `Key` of the event.
 ```go
 switch ev := ev.(type) {
 case *tcell.EventKey:
-    mod, key, ch := ev.Mod(), ev.Key(), ev.Rune()
-    logMessage(fmt.Sprintf("EventKey Modifiers: %d Key: %d Rune: %d", mod, key, ch))
+    mod, key, ch := ev.Mod(), ev.Key(), ev.Str()
+    logMessage(fmt.Sprintf("EventKey Modifiers: %d Key: %d Str: %q", mod, key, ch))
 }
 ```
 
@@ -304,7 +304,7 @@ func main() {
 				return
 			} else if ev.Key() == tcell.KeyCtrlL {
 				s.Sync()
-			} else if ev.Rune() == 'C' || ev.Rune() == 'c' {
+			} else if ev.Str() == "C" || ev.Str() == "c" {
 				s.Clear()
 			}
 		case *tcell.EventMouse:

--- a/key.go
+++ b/key.go
@@ -31,7 +31,9 @@ import (
 // high bit set, or in some cases, by sending an ESC prior to the rune.)
 //
 // If the value of Key() is KeyRune, then the actual key value will be
-// available with the Rune() method.  This will be the case for most keys.
+// available (as a grapheme cluster) with the Str() method.
+// This will be the case for most keys.
+//
 // In most situations, the modifiers will not be set.  For example, if the
 // rune is 'A', this will be reported without the ModShift bit set, since
 // really can't tell if the Shift key was pressed (it might have been CAPSLOCK,
@@ -66,7 +68,7 @@ func (ev *EventKey) Str() string {
 // codes, such as KeyEnter, etc.  Most control and function keys are reported
 // with unique Key values.  Normal alphanumeric and punctuation keys will
 // generally return KeyRune here; the specific key can be further decoded
-// using the Rune() function.
+// using the Str() function.
 func (ev *EventKey) Key() Key {
 	return ev.key
 }
@@ -328,7 +330,7 @@ const (
 // Key is a generic value for representing keys, and especially special
 // keys (function keys, cursor movement keys, etc.)  For normal keys, like
 // ASCII letters, we use KeyRune, and then expect the application to
-// inspect the Rune() member of the EventKey.
+// inspect the Str() member of the EventKey.
 type Key int16
 
 // This is the list of named keys.  KeyRune is special however, in that it is


### PR DESCRIPTION
…xes #897)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial and API documentation to use string-based key retrieval and comparisons (Str()) instead of rune-based access.
  * Clarified examples and explanatory text to note key values are available as grapheme clusters; examples and log message formats were updated accordingly.
  * This is purely documentation; runtime behavior and public API signatures are unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->