### PR TITLE
refactor: Use common base EventTime for events

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The TCell Authors
+// Copyright 2025 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -16,7 +16,6 @@ package tcell
 
 import (
 	"errors"
-	"time"
 )
 
 var (
@@ -42,13 +41,8 @@ var (
 // An EventError is an event representing some sort of error, and carries
 // an error payload.
 type EventError struct {
-	t   time.Time
+	EventTime
 	err error
-}
-
-// When returns the time when the event was created.
-func (ev *EventError) When() time.Time {
-	return ev.t
 }
 
 // Error implements the error.
@@ -58,5 +52,7 @@ func (ev *EventError) Error() string {
 
 // NewEventError creates an ErrorEvent with the given error payload.
 func NewEventError(err error) *EventError {
-	return &EventError{t: time.Now(), err: err}
+	ev := &EventError{err: err}
+	ev.SetEventNow()
+	return ev
 }

--- a/event_test.go
+++ b/event_test.go
@@ -24,6 +24,7 @@ func TestChannelMouseEvents(t *testing.T) {
 	s := mkTestScreen(t, "")
 	defer s.Fini()
 
+	now := time.Now()
 	s.EnableMouse()
 	s.InjectMouse(4, 9, Button1, ModCtrl)
 	em := new(EventMouse)
@@ -39,6 +40,10 @@ loop:
 				em = evm
 				break loop
 			}
+			if !now.Before(ev.When()) {
+				t.Errorf("Events arrived out of order!")
+			}
+			now = ev.When()
 			continue
 		case <-time.After(time.Second):
 			break loop

--- a/focus.go
+++ b/focus.go
@@ -17,12 +17,14 @@ package tcell
 // EventFocus is a focus event. It is sent when the terminal window (or tab)
 // gets or loses focus.
 type EventFocus struct {
-	*EventTime
+	EventTime
 
 	// True if the window received focus, false if it lost focus
 	Focused bool
 }
 
 func NewEventFocus(focused bool) *EventFocus {
-	return &EventFocus{Focused: focused}
+	ev := &EventFocus{Focused: focused}
+	ev.SetEventNow()
+	return ev
 }

--- a/interrupt.go
+++ b/interrupt.go
@@ -14,20 +14,11 @@
 
 package tcell
 
-import (
-	"time"
-)
-
 // EventInterrupt is a generic wakeup event.  Its can be used to
 // to request a redraw.  It can carry an arbitrary payload, as well.
 type EventInterrupt struct {
-	t time.Time
+	EventTime
 	v any
-}
-
-// When returns the time when this event was created.
-func (ev *EventInterrupt) When() time.Time {
-	return ev.t
 }
 
 // Data is used to obtain the opaque event payload.
@@ -37,5 +28,7 @@ func (ev *EventInterrupt) Data() any {
 
 // NewEventInterrupt creates an EventInterrupt with the given payload.
 func NewEventInterrupt(data any) *EventInterrupt {
-	return &EventInterrupt{t: time.Now(), v: data}
+	ev := &EventInterrupt{v: data}
+	ev.SetEventNow()
+	return ev
 }

--- a/key.go
+++ b/key.go
@@ -17,7 +17,6 @@ package tcell
 import (
 	"fmt"
 	"strings"
-	"time"
 )
 
 // EventKey represents a key press.  Usually this is a key press followed
@@ -45,16 +44,10 @@ import (
 // overly much on availability of modifiers, or the availability of any
 // specific keys.
 type EventKey struct {
-	t   time.Time
+	EventTime
 	mod ModMask
 	key Key
 	str string // string for key, usually just one character, but may be composed sequence
-}
-
-// When returns the time when this Event was created, which should closely
-// match the time when the key was pressed.
-func (ev *EventKey) When() time.Time {
-	return ev.t
 }
 
 // Str returns the string corresponding to the key press, if it makes sense.
@@ -306,7 +299,9 @@ func NewEventKey(k Key, str string, mod ModMask) *EventKey {
 		k = KeyBacktab
 		mod &^= ModShift
 	}
-	return &EventKey{t: time.Now(), key: k, str: str, mod: mod}
+	ev := &EventKey{key: k, str: str, mod: mod}
+	ev.SetEventNow()
+	return ev
 }
 
 // ModMask is a mask of modifier keys.  Note that it will not always be

--- a/mouse.go
+++ b/mouse.go
@@ -14,10 +14,6 @@
 
 package tcell
 
-import (
-	"time"
-)
-
 // EventMouse is a mouse event.  It is sent on either mouse up or mouse down
 // events.  It is also sent on mouse motion events - if the terminal supports
 // it.  We make every effort to ensure that mouse release events are delivered.
@@ -35,16 +31,11 @@ import (
 // Applications can inspect the time between events to resolve double or
 // triple clicks.
 type EventMouse struct {
-	t   time.Time
+	EventTime
 	btn ButtonMask
 	mod ModMask
 	x   int
 	y   int
-}
-
-// When returns the time when this EventMouse was created.
-func (ev *EventMouse) When() time.Time {
-	return ev.t
 }
 
 // Buttons returns the list of buttons that were pressed or wheel motions.
@@ -67,7 +58,9 @@ func (ev *EventMouse) Position() (int, int) {
 // NewEventMouse is used to create a new mouse event.  Applications
 // shouldn't need to use this; its mostly for screen implementors.
 func NewEventMouse(x, y int, btn ButtonMask, mod ModMask) *EventMouse {
-	return &EventMouse{t: time.Now(), x: x, y: y, btn: btn, mod: mod}
+	ev := &EventMouse{x: x, y: y, btn: btn, mod: mod}
+	ev.SetEventNow()
+	return ev
 }
 
 // ButtonMask is a mask of mouse buttons and wheel events.  Mouse button presses

--- a/resize.go
+++ b/resize.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The TCell Authors
+// Copyright 2025 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -14,13 +14,9 @@
 
 package tcell
 
-import (
-	"time"
-)
-
 // EventResize is sent when the window size changes.
 type EventResize struct {
-	t  time.Time
+	EventTime
 	ws WindowSize
 }
 
@@ -31,12 +27,9 @@ func NewEventResize(width, height int) *EventResize {
 		Width:  width,
 		Height: height,
 	}
-	return &EventResize{t: time.Now(), ws: ws}
-}
-
-// When returns the time when the Event was created.
-func (ev *EventResize) When() time.Time {
-	return ev.t
+	ev := &EventResize{ws: ws}
+	ev.SetEventNow()
+	return ev
 }
 
 // Size returns the new window size as width, height in character cells.


### PR DESCRIPTION
This also fixes the missing time initialization for focus events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified event timestamp handling by consolidating individual time fields into an embedded mechanism
  * Applied consistent timestamp initialization across all event types
  * Improved internal event object structure and initialization flow

* **Tests**
  * Added validation to ensure event timestamps remain in chronological order

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->