### PR TITLE
refactor: defer registering resize handler (signal handler) until Not…

### DIFF
--- a/tty_win.go
+++ b/tty_win.go
@@ -244,9 +244,6 @@ func (w *winTty) scanInput() {
 
 func (w *winTty) Start() error {
 
-	w.Lock()
-	defer w.Unlock()
-
 	if w.running {
 		return errors.New("already engaged")
 	}
@@ -275,8 +272,6 @@ func (w *winTty) Start() error {
 
 func (w *winTty) Stop() error {
 	w.wg.Wait()
-	w.Lock()
-	defer w.Unlock()
 	_, _, _ = procSetConsoleMode.Call(uintptr(w.in), uintptr(w.oimode))
 	_, _, _ = procSetConsoleMode.Call(uintptr(w.out), uintptr(w.oomode))
 	_, _, _ = procFlushConsoleInputBuffer.Call(uintptr(w.in))
@@ -286,7 +281,9 @@ func (w *winTty) Stop() error {
 }
 
 func (w *winTty) NotifyResize(cb func()) {
+	w.Lock()
 	w.resizeCb = cb
+	w.Unlock()
 }
 
 func (w *winTty) WindowSize() (WindowSize, error) {


### PR DESCRIPTION
…ify call, remove extra locking

We need to move this logic later, because we plan to conditionalize this so that we don't set up signal handling for terminals that can give us in-band size updates.

This also eliminates the extra locks for the tty object, as terminal calls these functions with the locks held  We only need them guarding the callback for the signal handler, as that may be called asynchronously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced synchronization overhead in platform terminal handling to improve responsiveness during start/stop operations.
  * Refined terminal resize handling so resize callbacks are managed and signaled more predictably.
  * No changes to public APIs or intended behavior.

* **Documentation**
  * Minor formatting updates to internal comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->