### PR TITLE
feat: Add terminal information to handshake, make iTerm2 notification…

### DIFF
--- a/_demos/mouse.go
+++ b/_demos/mouse.go
@@ -122,6 +122,7 @@ func main() {
 	keyfmt := "Keys: %s"
 	pastefmt := "Paste: [%d] %s"
 	focusfmt := "Focus: %s"
+	termFmt := "Term: %s (%s)"
 	style := tcell.StyleDefault.
 		Foreground(tcell.ColorMidnightBlue).Background(tcell.ColorLightCoral)
 
@@ -138,7 +139,7 @@ func main() {
 	focus := true // assume we are focused when we start
 
 	for {
-		drawBox(s, 1, 1, 42, 8, style, ' ')
+		drawBox(s, 1, 1, 42, 9, style, ' ')
 		s.PutStrStyled(2, 2, "Press Ctrl-Q to Quit, C to clear.", style)
 		s.PutStrStyled(2, 3, fmt.Sprintf(posfmt, mx, my), style)
 		s.PutStrStyled(2, 4, fmt.Sprintf(btnfmt, bstr), style)
@@ -155,6 +156,9 @@ func main() {
 			fstr = "true"
 		}
 		s.PutStrStyled(2, 7, fmt.Sprintf(focusfmt, fstr), style)
+
+		n, v := s.Terminal()
+		s.PutStrStyled(2, 8, fmt.Sprintf(termFmt, n, v), style)
 
 		s.Show()
 		bstr = ""

--- a/screen.go
+++ b/screen.go
@@ -237,6 +237,12 @@ type Screen interface {
 	// ShowNotification is used to show a desktop notification, when the terminal
 	// supports it.  Right now only terminals supporting OSC 777 support this.
 	ShowNotification(title string, body string)
+
+	// Terminal returns the terminal name and version if known.  If either of these
+	// are unknown, then empty strings are returned in their place.  This is intended
+	// to facilitate debug, and also applications that wish to enable very specific
+	// behaviors for the terminal
+	Terminal() (string, string)
 }
 
 // NewScreen returns a default Screen suitable for the user's terminal
@@ -305,6 +311,7 @@ type screenImpl interface {
 	SetClipboard([]byte)
 	GetClipboard()
 	ShowNotification(string, string)
+	Terminal() (string, string)
 
 	// Following methods are not part of the Screen api, but are used for interaction with
 	// the common layer code.

--- a/simulation.go
+++ b/simulation.go
@@ -504,3 +504,7 @@ func (s *simscreen) GetClipboardData() []byte {
 }
 
 func (s *simscreen) ShowNotification(_ string, _ string) {}
+
+func (s *simscreen) Terminal() (string, string) {
+	return "simulator", ""
+}

--- a/wscreen.go
+++ b/wscreen.go
@@ -602,3 +602,5 @@ var curStyleClasses = map[CursorStyle]string{
 	CursorStyleBlinkingBar:       "cursor-blinking-bar",
 	CursorStyleSteadyBar:         "cursor-steady-bar",
 }
+
+func (*wScreen) Terminal() (string, string) { return "Tcell-WebASM", "" }


### PR DESCRIPTION
…s work

This adds a new Terminal API to get the terminal, so its possible to query the terminal name and version.  This is added to the mouse demo as well.

Finally iTerm2-specific handling for the desktop notification is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal identification support: apps can query and retrieve terminal name and version.
  * Demo app shows a new status line with detected terminal metadata.
  * Extended terminal attribute detection for improved compatibility with diverse terminals.
  * Simulator and WebAssembly builds expose sensible terminal identifiers for testing and runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->