### PR TITLE
feat: support inline resize and refactor private mode support

### DIFF
--- a/input_test.go
+++ b/input_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !js || !wasm
+// +build !js !wasm
+
 package tcell
 
 import (


### PR DESCRIPTION
This adds a number new private mode values that we can query for, and a cleaner internal API for setting and querying them.

The first use of this is to query for the ability to do inline resize notifications, and if we have it, to skip use of signals. This may allow us to work with resize events in circumstances where the OS does not provide resize indications (for example if the file descriptor in use not actually a tty!)  Only a few terminals support this resize notifcation (ghostty, iTerm2, kitty, foot), btu they are not niche.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified handling for private terminal modes and streamlined escape-sequence processing.

* **New Features**
  * Emit and consume private-mode events to negotiate capabilities, including an inline resize reporting path.

* **Bug Fixes**
  * Added stricter validation to CSI processing to avoid premature/incorrect handling.
  * Improved window resize detection and reporting when dimensions change.

* **Tests**
  * Adjusted test build constraints to exclude js/wasm environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->