### PR TITLE
fix: ctrl-J is reported as KeyCR/KeyEnter on legacy terminals (fixes …

### DIFF
--- a/input.go
+++ b/input.go
@@ -426,7 +426,7 @@ func (ip *inputParser) scan() {
 				ip.post(NewEventKey(KeyTab, "", ModNone))
 			case '\b', '\x7F':
 				ip.post(NewEventKey(KeyBackspace, "", ModNone))
-			case '\n', '\r':
+			case '\r':
 				ip.post(NewEventKey(KeyEnter, "", ModNone))
 			default:
 				// Control keys - legacy handling

--- a/input_test.go
+++ b/input_test.go
@@ -73,7 +73,7 @@ func TestInputControlKeys(t *testing.T) {
 		{"Ctrl+G", 0x07, KeyCtrlG, "", ModCtrl},
 		{"Ctrl+H", 0x08, KeyBackspace, "", ModNone}, // BS is special
 		{"Ctrl+I", 0x09, KeyTab, "", ModNone},       // Tab is special
-		{"Ctrl+J", 0x0A, KeyEnter, "", ModNone},     // LF is Enter
+		{"Ctrl+J", 0x0A, KeyCtrlJ, "", ModCtrl},
 		{"Ctrl+K", 0x0B, KeyCtrlK, "", ModCtrl},
 		{"Ctrl+L", 0x0C, KeyCtrlL, "", ModCtrl},
 		{"Ctrl+M", 0x0D, KeyEnter, "", ModNone}, // CR is Enter
@@ -235,7 +235,7 @@ func TestInputSpecialKeys(t *testing.T) {
 		{"Tab", '\t', KeyTab, ModNone},
 		{"Backspace_BS", '\b', KeyBackspace, ModNone},
 		{"Backspace_DEL", 0x7F, KeyBackspace, ModNone},
-		{"Enter_LF", '\n', KeyEnter, ModNone},
+		{"Enter_LF", '\n', KeyCtrlJ, ModCtrl},
 		{"Enter_CR", '\r', KeyEnter, ModNone},
 	}
 
@@ -531,7 +531,7 @@ func TestSpecialKeys(t *testing.T) {
 		{"Esc", []byte{'\x1b'}, KeyEscape, ModNone},
 		{"Esc-Esc", []byte{'\x1b', '\x1b'}, KeyEscape, ModAlt},
 		{"Tab", []byte{'\t'}, KeyTab, ModNone},
-		{"NL", []byte{'\n'}, KeyEnter, ModNone},
+		{"NL", []byte{'\n'}, KeyCtrlJ, ModCtrl},
 		{"CR", []byte{'\r'}, KeyEnter, ModNone},
 		{"Backspace", []byte{'\b'}, KeyBackspace, ModNone},
 		{"Delete", []byte{'\x7f'}, KeyBackspace, ModNone},


### PR DESCRIPTION
…#911)

This was a regression relative to 2.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newline handling adjusted: carriage return now maps to Enter; line feed is treated as a regular character. Control key sequences are more accurately distinguished in input mapping.

* **Tests**
  * Updated expectations to match the revised input mapping and control-key behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->