### PR TITLE
fix resource leak in NewDevTtyFromDev by closing correct file handle

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -187,11 +187,11 @@ func NewDevTtyFromDev(dev string) (Tty, error) {
 	}
 	tty.fd = int(tty.of.Fd())
 	if !term.IsTerminal(tty.fd) {
-		_ = tty.f.Close()
+		_ = tty.of.Close()
 		return nil, errors.New("not a terminal")
 	}
 	if tty.saved, err = term.GetState(tty.fd); err != nil {
-		_ = tty.f.Close()
+		_ = tty.of.Close()
 		return nil, fmt.Errorf("failed to get state: %w", err)
 	}
 	return tty, nil


### PR DESCRIPTION
## Description

This PR fixes a bug in `NewDevTtyFromDev` where the wrong file handle (`tty.f`) was being closed instead of the intended one (`tty.of`) when an error occurred during initialization (e.g., when the device is not a terminal).

At that point in the function, `tty.f` is nil and `tty.of` holds the open file descriptor that needs to be cleaned up.

## Changes
Relied on `tty.of.Close()` instead of `tty.f.Close()` to prevent leaking the file descriptor on error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file handle cleanup during error scenarios in terminal initialization on Unix systems, ensuring proper resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->