### PR TITLE
feat(emulator): Add Titler, and tests for it.

### DIFF
--- a/demos/hello/hello.go
+++ b/demos/hello/hello.go
@@ -25,6 +25,7 @@ import (
 func displayHelloWorld(s tcell.Screen) {
 	w, h := s.Size()
 	s.Clear()
+	s.SetTitle("Hello World")
 	x := w/2 - 7
 	y := h/2 - 1
 	style := tcell.StyleDefault.Foreground(color.CadetBlue.TrueColor()).Background(color.White)

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -38,12 +38,16 @@ type MockBackend interface {
 	// position is out of the bounds of the window.
 	GetCell(vt.Coord) Cell
 
+	// Bells counts the number of bells rung.
 	Bells() int
+
+	// GetTitle gets the current window title.
+	GetTitle() string
 }
 
 // mockBackend is a mock of a backend device for use with the emulator.
 // It implements the following interfaces:
-// vt.Backend, vt.Beeper, vt.Colorer
+// vt.Backend, vt.Beeper, vt.Colorer, vt.Titler
 type mockBackend struct {
 	cells     []Cell // Content of cells
 	size      vt.Coord
@@ -56,6 +60,7 @@ type mockBackend struct {
 	modes     map[vt.PrivateMode]vt.ModeStatus
 	bells     int
 	errs      int
+	title     string
 }
 
 func (mb *mockBackend) GetSize() vt.Coord { return mb.size }
@@ -159,6 +164,16 @@ func (mb *mockBackend) SetFgColor(c color.Color) {
 
 func (mb *mockBackend) SetBgColor(c color.Color) {
 	mb.setColor(c, &mb.bg, mb.defaultBg)
+}
+
+// SetWindowTitle implements the Titler interface.
+func (mb *mockBackend) SetWindowTitle(title string) {
+	mb.title = title
+}
+
+// GetTitle allows test code to observe what was set with SetWindowTitle.
+func (mb *mockBackend) GetTitle() string {
+	return mb.title
 }
 
 // MockOpt is an interface by which options can change the behavior of the mocked terminal.

--- a/mock/term.go
+++ b/mock/term.go
@@ -101,6 +101,11 @@ func (mt *mockTerm) KeyEvent(ev vt.KbdEvent) {
 	}
 }
 
+// GetTitle returns the current window title.
+func (mt *mockTerm) GetTitle() string {
+	return mt.mb.GetTitle()
+}
+
 // MockTerm is a mock terminal (emulator).  It can be used to
 // test the emulator itself, or to test applications (or tcell) that
 // uses the terminal.  It also implements the Tty interface used
@@ -119,6 +124,9 @@ type MockTerm interface {
 
 	// Inject a keyboard event.
 	KeyEvent(vt.KbdEvent)
+
+	// GetTitle obtains the current window title.
+	GetTitle() string
 }
 
 // NewMockTerm gives a mock terminal emulator.

--- a/mock/term_test.go
+++ b/mock/term_test.go
@@ -561,3 +561,26 @@ func TestSgrColor8(t *testing.T) {
 		t.Errorf("wrong bg: %s\n", bg.String())
 	}
 }
+
+// TestTitler tests that we can set a window title.
+func TestTitler(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 80, Y: 24})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+	writeF(t, trm, "\x1b]2;Test Application\x1b\\")
+	if s := trm.GetTitle(); s != "Test Application" {
+		t.Errorf("wrong title: %q", s)
+	}
+
+	// test ST termination using legacy bell character
+	writeF(t, trm, "\x1b]2;Bell Ring\x07")
+	if s := trm.GetTitle(); s != "Bell Ring" {
+		t.Errorf("wrong title: %q", s)
+	}
+
+	// try using 8-bit sequence
+	writeF(t, trm, "\x9d2;Eight Bits\x9c")
+	if s := trm.GetTitle(); s != "Eight Bits" {
+		t.Errorf("wrong title: %q", s)
+	}
+}

--- a/vt/backend.go
+++ b/vt/backend.go
@@ -101,3 +101,12 @@ type Resizer interface {
 	// NotifyResize registers a channel to be posted to if the window size changes.
 	NotifyResize(chan<- bool)
 }
+
+// Titler adds support for setting the window title. (Typically this is OSC2.)
+// Note that for security reasons we only support setting this.
+// We don't bother with icon titles, since few terminal emulators support it, and it
+// would be hard for us to do this in any portable fashion.
+type Titler interface {
+	// SetWindowTitle only changes the window title.
+	SetWindowTitle(string)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal emulator now supports setting the window title via standard OSC sequences; title updates are applied and retrievable.
  * OSC termination now recognizes both BEL and ST variants, improving compatibility with different title sequences.

* **Tests**
  * Added tests verifying title handling for multiple OSC termination methods and correct title updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->