### PR TITLE
Add emulation resize support

### DIFF
--- a/mock/term.go
+++ b/mock/term.go
@@ -106,6 +106,12 @@ func (mt *mockTerm) GetTitle() string {
 	return mt.mb.GetTitle()
 }
 
+// SetSize is used to change the terminal size.
+func (mt *mockTerm) SetSize(size vt.Coord) {
+	mt.mb.SetSize(size)
+	mt.em.ResizeEvent()
+}
+
 // MockTerm is a mock terminal (emulator).  It can be used to
 // test the emulator itself, or to test applications (or tcell) that
 // uses the terminal.  It also implements the Tty interface used
@@ -127,6 +133,9 @@ type MockTerm interface {
 
 	// GetTitle obtains the current window title.
 	GetTitle() string
+
+	// SetSize is used to resize the terminal.
+	SetSize(vt.Coord)
 }
 
 // NewMockTerm gives a mock terminal emulator.

--- a/resize_test.go
+++ b/resize_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v3/vt"
+)
+
+func TestPixelSize(t *testing.T) {
+	// simulate 8x16 font, VGA (640x480)
+	ev := NewEventResize(80, 25)
+	ev.ws.PixelHeight = ev.ws.Height * 16
+	ev.ws.PixelWidth = ev.ws.Width * 8
+	if w, h := ev.PixelSize(); w != 640 || h != 400 {
+		t.Errorf("pixelsize wrong: %d %d", w, h)
+	}
+}
+
+// TestEventResize creates a screen and does some resizing to prove it works.
+func TestEventResize(t *testing.T) {
+	mt, ms := NewMockScreen(t)
+	defer ms.Fini()
+
+	// drain the eventQ
+loop:
+	for {
+		select {
+		case <-ms.EventQ():
+		default:
+			break loop
+		}
+	}
+
+	mt.SetSize(vt.Coord{X: 50, Y: 132})
+
+	select {
+	case ev := <-ms.EventQ():
+		if re, ok := ev.(*EventResize); ok {
+			if y, x := re.Size(); y != 50 || x != 132 {
+				t.Errorf("wrong size: %d %d", y, x)
+			}
+		} else {
+			t.Errorf("wrong event type %T", ev)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Errorf("never got resize signal")
+	}
+}


### PR DESCRIPTION
This adds automatic handling of inline notifications as well, and adds both tscreen and emulator specific test cases.

In order to make sure that this code is bullet proof for asynchronous event injection, we also made writing to the read queue atomic for the full length of the written strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal window resizing with dimension updates and in-band resize notifications
  * Emulator now sends resize events reliably and serializes raw output to avoid interleaved output

* **Tests**
  * Added tests covering window resizing, resize notification delivery, event resize handling, and pixel-size calculations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->