### PR TITLE
feat(emulator): Implement horizontal scroll regions.

### DIFF
--- a/vt/mock_test.go
+++ b/vt/mock_test.go
@@ -1452,3 +1452,558 @@ func TestScrollDown(t *testing.T) {
 	checkContent(t, trm, 0, 4, "B")
 	checkPos(t, trm, 2, 2)
 }
+
+// TestDECSTBMv1 tests full screen scroll region (test courtesy of ghostty)
+func TestDECSTBMv1(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "ABC\n")
+	writeF(t, trm, "DEF\n")
+	writeF(t, trm, "GHI\n")
+	writeF(t, trm, "\033[r") // scroll region top/bottom
+	writeF(t, trm, "\033[T") // scroll down one
+
+	// |c_______|
+	// |ABC_____|
+	// |DEF_____|
+	// |GHI_____|
+	checkPos(t, trm, 0, 0)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "B")
+	checkContent(t, trm, 2, 1, "C")
+	checkContent(t, trm, 0, 2, "D")
+	checkContent(t, trm, 1, 2, "E")
+	checkContent(t, trm, 2, 2, "F")
+	checkContent(t, trm, 0, 3, "G")
+	checkContent(t, trm, 1, 3, "H")
+	checkContent(t, trm, 2, 3, "I")
+}
+
+// TestDECSTBMv2 top only
+func TestDECSTBMv2(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "ABC\n")
+	writeF(t, trm, "DEF\n")
+	writeF(t, trm, "GHI\n")
+	writeF(t, trm, "\033[2;2r") // scroll region top/bottom
+	writeF(t, trm, "\033[T")    // scroll down one
+
+	// |________|
+	// |ABC_____|
+	// |DEF_____|
+	// |GHI_____|
+	checkPos(t, trm, 0, 3) // did not move
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "B")
+	checkContent(t, trm, 2, 1, "C")
+	checkContent(t, trm, 0, 2, "D")
+	checkContent(t, trm, 1, 2, "E")
+	checkContent(t, trm, 2, 2, "F")
+	checkContent(t, trm, 0, 3, "G")
+	checkContent(t, trm, 1, 3, "H")
+	checkContent(t, trm, 2, 3, "I")
+}
+
+// TestDECSTBMv3 top and bottom
+func TestDECSTBMv3(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "ABC\n")
+	writeF(t, trm, "DEF\n")
+	writeF(t, trm, "GHI\n")
+	writeF(t, trm, "\033[1;2r") // scroll region top/bottom
+	writeF(t, trm, "\033[T")    // scroll down one
+
+	// |________|
+	// |ABC_____|
+	// |GHI_____|
+	// |________|
+	checkPos(t, trm, 0, 0)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "B")
+	checkContent(t, trm, 2, 1, "C")
+	checkContent(t, trm, 0, 2, "G")
+	checkContent(t, trm, 1, 2, "H")
+	checkContent(t, trm, 2, 2, "I")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestDECSTBMv4 top == bottom
+func TestDECSTBMv4(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "ABC\n")
+	writeF(t, trm, "DEF\n")
+	writeF(t, trm, "GHI\n")
+	writeF(t, trm, "\033[2;2r")
+	writeF(t, trm, "\033[T")
+
+	// |________|
+	// |ABC_____|
+	// |DEF_____|
+	// |GHI_____|
+	checkPos(t, trm, 0, 3)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "B")
+	checkContent(t, trm, 2, 1, "C")
+	checkContent(t, trm, 0, 2, "D")
+	checkContent(t, trm, 1, 2, "E")
+	checkContent(t, trm, 2, 2, "F")
+	checkContent(t, trm, 0, 3, "G")
+	checkContent(t, trm, 1, 3, "H")
+	checkContent(t, trm, 2, 3, "I")
+}
+
+// TestRIv1 top of screen, no scroll
+func TestRIv1(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "A\n")
+	writeF(t, trm, "B\n")
+	writeF(t, trm, "C\n")
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033M")
+	writeF(t, trm, "X")
+
+	// |Xc______|
+	// |A_______|
+	// |B_______|
+	// |C_______|
+
+	checkPos(t, trm, 1, 0)
+	checkContent(t, trm, 0, 0, "X")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "B")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "C")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestRIv2 not top of screen, no scroll
+func TestRIv2(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "A\n")
+	writeF(t, trm, "B\n")
+	writeF(t, trm, "C\n")
+	writeF(t, trm, "\033[2;1H")
+	writeF(t, trm, "\033M")
+	writeF(t, trm, "X")
+
+	// |Xc______|
+	// |B_______|
+	// |C_______|
+	// |________|
+
+	checkPos(t, trm, 1, 0)
+	checkContent(t, trm, 0, 0, "X")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "B")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "C")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestRIv3 scroll region
+func TestRIv3(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "A\n")
+	writeF(t, trm, "B\n")
+	writeF(t, trm, "C\n")
+	writeF(t, trm, "\033[2;3r")
+	writeF(t, trm, "\033[2;1H")
+	writeF(t, trm, "\033M")
+
+	// |A_______|
+	// |c_______|
+	// |B_______|
+	// |________|
+
+	checkPos(t, trm, 0, 1)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "B")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestRIv4 outside scroll region - goes to top, does not scroll
+func TestRIv4(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "A\n")
+	writeF(t, trm, "B\n")
+	writeF(t, trm, "C\n")
+	writeF(t, trm, "\033[2;3r")
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033M")
+
+	// |A_______|
+	// |B_______|
+	// |C_______|
+	// |________|
+
+	checkPos(t, trm, 0, 0)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "B")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "C")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TODO: RIv5 - left right scroll regions (when we implement left/right regions)
+// TODO: RIv6 - outside left/right scroll regions (when we implement left/right regions)
+
+// TestINDv1 no scroll region, top of screen
+func TestINDv1(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033D")
+	writeF(t, trm, "X")
+
+	// |A_______|
+	// |_Xc_____|
+	// |________|
+	// |________|
+
+	checkPos(t, trm, 2, 1)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "X")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestINDv2 no scroll region, bottom of screen
+func TestINDv2(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")   //  clear screen
+	writeF(t, trm, "\033[4;1H")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033D")
+	writeF(t, trm, "X")
+
+	// |________|
+	// |________|
+	// |A_______|
+	// |_Xc_____|
+
+	checkPos(t, trm, 2, 3)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "A")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "X")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestINDv3 inside scroll region
+func TestINDv3(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "\033[1;3r")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033D")
+	writeF(t, trm, "X")
+
+	// |A_______|
+	// |_Xc_____|
+	// |________|
+	// |________|
+
+	checkPos(t, trm, 2, 1)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "X")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestINDv4 bottom of scroll region
+func TestINDv4(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "\033[1;3r")
+	writeF(t, trm, "\033[4;1H")
+	writeF(t, trm, "B")
+	writeF(t, trm, "\033[3;1H")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033D")
+	writeF(t, trm, "X")
+
+	// |________|
+	// |A_______|
+	// |_Xc_____|
+	// |B_______|
+
+	checkPos(t, trm, 2, 2)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "A")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "X")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "B")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestINDv5 bottom of screen with scroll region
+func TestINDv5(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 5})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H") // move to top-left
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "\033[1;3r")
+	writeF(t, trm, "\033[3;1H")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033[4;1H")
+	writeF(t, trm, "\033D")
+	writeF(t, trm, "X")
+
+	// |________|
+	// |________|
+	// |A_______|
+	// |________|
+	// |Xc______|
+
+	checkPos(t, trm, 1, 4)
+	checkContent(t, trm, 0, 0, "")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "A")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+	checkContent(t, trm, 0, 4, "X")
+	checkContent(t, trm, 1, 4, "")
+	checkContent(t, trm, 2, 4, "")
+}
+
+// TODO: INDv6 - outside of left/right scroll region (when we have them)
+// TODO: INDv7 - inside of left/right scroll region (when we have them)
+
+// TestCUDv1 - cursor down
+func TestCUDv1(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033[2B")
+	writeF(t, trm, "X")
+
+	// |A_______|
+	// |________|
+	// |_Xc_____|
+	// |________|
+
+	checkPos(t, trm, 2, 2)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "X")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestCUDv2 - cursor down above bottom margin
+func TestCUDv2(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 4})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "\n\n\n\n")
+	writeF(t, trm, "\033[1;3r")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033[5B")
+	writeF(t, trm, "X")
+
+	// |A_______|
+	// |________|
+	// |_Xc_____|
+	// |________|
+
+	checkPos(t, trm, 2, 2)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "X")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+}
+
+// TestCUDv3 - cursor down below bottom margin
+func TestCUDv3(t *testing.T) {
+	trm := NewMockTerm(MockOptSize{X: 8, Y: 5})
+	defer mustClose(t, trm)
+	mustStart(t, trm)
+
+	writeF(t, trm, "\033[1;1H")
+	writeF(t, trm, "\033[0J")
+	writeF(t, trm, "\033[1;3r")
+	writeF(t, trm, "A")
+	writeF(t, trm, "\033[4;1H")
+	writeF(t, trm, "\033[5B")
+	writeF(t, trm, "X")
+
+	// |A_______|
+	// |________|
+	// |________|
+	// |________|
+	// |Xc______|
+
+	checkPos(t, trm, 1, 4)
+	checkContent(t, trm, 0, 0, "A")
+	checkContent(t, trm, 1, 0, "")
+	checkContent(t, trm, 2, 0, "")
+	checkContent(t, trm, 0, 1, "")
+	checkContent(t, trm, 1, 1, "")
+	checkContent(t, trm, 2, 1, "")
+	checkContent(t, trm, 0, 2, "")
+	checkContent(t, trm, 1, 2, "")
+	checkContent(t, trm, 2, 2, "")
+	checkContent(t, trm, 0, 3, "")
+	checkContent(t, trm, 1, 3, "")
+	checkContent(t, trm, 2, 3, "")
+	checkContent(t, trm, 0, 4, "X")
+	checkContent(t, trm, 1, 4, "")
+	checkContent(t, trm, 2, 4, "")
+}
+
+// TODO: Test cases for CUU, CNL, CPL.


### PR DESCRIPTION
We still need to finish adding tests for the CPL, CNL, CUU cases, and then we need to add DEC origin mode and left and right margins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal now respects configurable top/bottom margins for cursor movement and scrolling; index/reverse-index and newline behavior correctly trigger scrolling at region boundaries.
  * Vertical margin commands reset and apply scroll regions reliably, and scrolling operations confine to the active region.

* **Tests**
  * Added comprehensive tests covering scroll-region setups, index/reverse-index, cursor movement, and edge-case behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->