### PR TITLE
feat(emulator): This is the start of support for left and right margins.

### DIFF
--- a/vt/mode.go
+++ b/vt/mode.go
@@ -37,6 +37,7 @@ const (
 	PmPrintExtent      PrivateMode = 19   // Print full screen (on) or scrolling region (off).
 	PmShowCursor       PrivateMode = 25   // Show the cursor (default on).
 	PmCharSet          PrivateMode = 42   // Enable national (on) or multinational (off) character sets.
+	PmLeftRightMargin  PrivateMode = 69   // Enable left and right margins
 	PmMouseButton      PrivateMode = 1000 // Report mouse button events.
 	PmMouseDrag        PrivateMode = 1002 // Report mouse motion events when button depressed, requires PmMouseButton.
 	PmMouseMotion      PrivateMode = 1003 // Report mouse motion events, requires PmMouseButton.


### PR DESCRIPTION
Its not particularly useful right now, although you can set the margins for scrolling to scroll a subset of the screen.  We really need more editing functions to be implemented to take advantage of this, but adding it now means that we can avoid having to retrofit it later.

In order to accommodate a test, Erase Character (ECH) was also added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added left/right margin support that confines cursor, scrolling, erasing, and resize behavior to a configurable subregion for improved terminal compatibility.

* **Tests**
  * Added tests validating left/right margin behavior, interactions with vertical scroll regions, cursor movement, insertion, and erase/scroll outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->