### PR TITLE
fix(emulator): RI does reset autowrap state

### DIFF
--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -330,7 +330,7 @@ func (em *emulator) inbEsc(b byte) {
 		em.nextLine()
 	case 'H': // set tab stop (HTS) - VT52 is go home, but we do not support VT52
 		em.setTabStop(em.getPosition().X)
-	case 'M': // up one line (RI) - note does not reset autoWrap
+	case 'M': // up one line (RI)
 		em.processReverseIndex()
 	case 'N': // single shift two (SS2) (TODO)
 	case 'O': // single shift three (SS3) (TODO)
@@ -935,7 +935,6 @@ func (em *emulator) processHorizontalMargins(str string) {
 }
 
 // processIndex moves down, unless already on the bottom margin, in which case it scrolls Up.
-// Unlike reverse index, it resets the auto-wrap state.
 func (em *emulator) processIndex() {
 	pos := em.getPosition()
 	em.autoWrap = false
@@ -962,14 +961,12 @@ func (em *emulator) processLineFeed() {
 }
 
 // processReverseIndex moves up, unless already on the top margin, in which case it scrolls down.
-// Note that RI does *not* reset the auto-state.
 func (em *emulator) processReverseIndex() {
 	pos := em.getPosition()
 	if pos.Y == em.topMargin {
 		em.scrollDown()
-	} else if pos.Y > 0 {
-		pos.Y--
-		em.setPosition(pos)
+	} else {
+		em.processCursorUp("")
 	}
 }
 

--- a/vt/mock_test.go
+++ b/vt/mock_test.go
@@ -456,9 +456,9 @@ func TestAutoMargin(t *testing.T) {
 	writeF(t, trm, "\x1b[1;80HA\x1bDB")
 	checkPos(t, trm, 79, 1)
 
-	// but not reverse index
+	// and also reverse index
 	writeF(t, trm, "\x1b[2;80HA\x1bMB")
-	checkPos(t, trm, 1, 1)
+	checkPos(t, trm, 79, 0)
 }
 
 // TestUnicode tests basic placement of unicode glyphs.


### PR DESCRIPTION
In spite of the documentation on the Ghostty state, every implementation tested (including XTerm, iTerm2, and Ghostty) all do reset the autowrap state in response to reverse index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated cursor movement logic so index/vertical movements reuse centralized handling, removing scattered position adjustments.

* **Bug Fixes / Behavior**
  * Reverse-index is now treated as a positional movement in non-top cases, aligning with standard vertical movement behavior.

* **Tests**
  * Updated test expectations to reflect the adjusted cursor behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->