### PR TITLE
fix: fix for wide not overwriting adjacent character (fixes #976)

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -704,6 +704,13 @@ func (t *tScreen) drawCell(x, y int) int {
 		width = 1
 		str = " "
 	}
+	if width > 1 {
+		// Clobber over any content in the next cell.
+		// This fixes a problem with some terminals where overwriting two
+		// adjacent single cells with a wide rune would leave an image
+		// of the second cell.  This is a workaround for buggy terminals.
+		t.Print("  \b\b")
+	}
 	t.Print(str)
 	t.cx += width
 	t.cells.SetDirty(x, y, false)


### PR DESCRIPTION
This is a workaround - and really if it this is happening it means that your terminal emulator is a bug.  I'm not sure I want to merge this.

I have not observed the behavior that this change is meant to fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of wide characters in terminal display to prevent visual artifacts on certain terminal emulators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->