### PR TITLE
refactor(emulator): drop SetStyle & GetStyle (unused)

### DIFF
--- a/vt/backend.go
+++ b/vt/backend.go
@@ -32,12 +32,6 @@ type Backend interface {
 	// The X and Y are counts, so the bottom right cell should be at coordinate (X-1, Y-1).
 	GetSize() Coord
 
-	// SetStyle replaces the current style with the one indicated.
-	SetStyle(Style)
-
-	// GetStyle returns the style in use.  This should return a reasonable value at reset.
-	GetStyle() Style
-
 	// Colors returns the number of colors this terminal can support.  For direct color,
 	// return 1<<24. The XTerm palette is assumed. Monochrome terminals should return 0.
 	Colors() int

--- a/vt/mock.go
+++ b/vt/mock.go
@@ -345,13 +345,6 @@ func (mb *mockBackend) SetStyle(style Style) {
 	mb.style = style
 }
 
-func (mb *mockBackend) GetStyle() Style {
-	mb.lock.Lock()
-	defer mb.lock.Unlock()
-
-	return mb.style
-}
-
 // SetWindowTitle implements the Titler interface.
 func (mb *mockBackend) SetWindowTitle(title string) {
 	mb.lock.Lock()

--- a/vt/mock_test.go
+++ b/vt/mock_test.go
@@ -1149,7 +1149,6 @@ func TestReset(t *testing.T) {
 func backendBox(t *testing.T, mb MockBackend, tl Coord, br Coord, attr Attr) {
 	t.Helper()
 	style := BaseStyle.WithAttr(attr)
-	mb.SetStyle(BaseStyle.WithAttr(attr))
 	hex := []rune{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P'}
 	assertF(t, len(hex) == 16, "wrong hex string")
 	i := 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the terminal emulator's style management system by removing style getter and setter methods from the backend interface. Style state is now managed entirely through internal emulator mechanisms with a standardized default style configuration, reducing architectural complexity and improving separation of concerns between the emulator core and the rendering backend layer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->