### PR TITLE
chore: Move unicode demo into demos

### DIFF
--- a/demos/unicode/unicode.go
+++ b/demos/unicode/unicode.go
@@ -1,7 +1,4 @@
-//go:build ignore
-// +build ignore
-
-// Copyright 2025 The TCell Authors
+// Copyright 2026 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -66,7 +63,7 @@ func main() {
 	quit := make(chan struct{})
 
 	style = bold
-	putln(s, "Press ESC to Exit")
+	putln(s, "Press Control-Q to Exit")
 	putln(s, "Character set: "+s.CharacterSet())
 	style = plain
 
@@ -104,7 +101,7 @@ func main() {
 			switch ev := ev.(type) {
 			case *tcell.EventKey:
 				switch ev.Key() {
-				case tcell.KeyEscape, tcell.KeyEnter:
+				case tcell.KeyEscape, tcell.KeyEnter, tcell.KeyCtrlQ:
 					close(quit)
 					return
 				case tcell.KeyCtrlL:

--- a/demos/unicode/unicode_test.go
+++ b/demos/unicode/unicode_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/vt"
+)
+
+// TestUnicode just exercises the code in the unicode demo program.
+// It does not validate that the content is accurate, that should be done
+// manually by running the program with a real terminal.
+func TestUnicode(t *testing.T) {
+
+	mt := vt.NewMockTerm()
+	scr, err := tcell.NewTerminfoScreenFromTty(mt)
+	if err != nil {
+		t.Fatalf("failed to create screen: %v", err)
+	}
+	tcell.ShimScreen(scr)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		main()
+	}()
+
+	// give enough time for the screen to draw
+	// this is needed because main is running asynchronously.
+	time.Sleep(time.Millisecond * 50)
+
+	mt.Drain()
+
+	// control L (forces sync)
+	mt.KeyEvent(vt.KeyEvent{Code: 'l', Down: true, Mod: vt.ModCtrl})
+	mt.KeyEvent(vt.KeyEvent{Code: 'l', Down: false, Mod: vt.ModCtrl})
+
+	attrs := 0
+	var lastAttr vt.Attr
+	for y := range vt.Row(24) {
+		for x := range vt.Col(80) {
+			if attr := mt.GetCell(vt.Coord{X: vt.Col(x), Y: vt.Row(y)}).S.Attr(); attr != lastAttr {
+				attrs++
+				lastAttr = attr
+			}
+		}
+	}
+	time.Sleep(time.Millisecond * 10)
+	mt.KeyEvent(vt.KeyEvent{Code: 'q', Down: true, Mod: vt.ModCtrl})
+	mt.KeyEvent(vt.KeyEvent{Code: 'q', Down: false, Mod: vt.ModCtrl})
+
+	wg.Wait()
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl-Q keyboard shortcut now available to exit the unicode demo.
  * Updated in-app exit instruction to reference Ctrl-Q.

* **Tests**
  * Added automated test coverage for the unicode demo rendering flow.

* **Chores**
  * Enabled the unicode demo for compilation.
  * Updated copyright year to 2026.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->