### PR TITLE
fix(tscreen): fix infinite loop in paste

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1056,9 +1056,14 @@ func (t *tScreen) buildAcsMap() {
 }
 
 func (t *tScreen) scanInput(buf *bytes.Buffer) {
+	// The end of the buffer isn't necessarily the end of the input, because
+	// large inputs are chunked. Set atEOF to false so the UTF-8 validating decoder
+	// returns ErrShortSrc instead of ErrInvalidUTF8 for incomplete multi-byte codepoints.
+	const atEOF = false
+
 	for buf.Len() > 0 {
 		utf := make([]byte, min(8, max(buf.Len()*2, 128)))
-		nOut, nIn, e := t.decoder.Transform(utf, buf.Bytes(), true)
+		nOut, nIn, e := t.decoder.Transform(utf, buf.Bytes(), atEOF)
 		_ = buf.Next(nIn)
 		t.input.ScanUTF8(utf[:nOut])
 		if e == transform.ErrShortSrc {


### PR DESCRIPTION
Bracketed paste with UTF-8 encoding can trigger an infinite loop in `tScreen.scanInput` when the input chunk splits a multi-byte UTF8-encoded codepoint.

This is caused by these lines in the UTF8 validator: https://cs.opensource.google/go/x/text/+/master:encoding/encoding.go;l=312-321;drc=647d7ef61a1782c392d1d8e4a9586d9832ec20e5

Fix it by setting `atEOF=false` so the validator returns `ErrShortSrc` (which exits the loop) instead of `ErrInvalidUTF8` (which prevents the loop from exiting).

Resolves: https://github.com/gdamore/tcell/issues/1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input handling for multi-byte character sequences to properly process incomplete characters across input boundaries, improving text scanning accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->