### PR TITLE
fix(tscreen): Last column snafu with workaround for wide characters. …

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -706,7 +706,7 @@ func (t *tScreen) drawCell(x, y int) int {
 		width = 1
 		str = " "
 	}
-	if width > 1 {
+	if width > 1 && x+width < t.w {
 		// Clobber over any content in the next cell.
 		// This fixes a problem with some terminals where overwriting two
 		// adjacent single cells with a wide rune would leave an image


### PR DESCRIPTION
…(fixes #1008)

The hack to fix #976 caused another problem where the wide characters didn't render properly on the last column as the backspace did not go backwards with pending wrap state.  (This might actually be considered a terminal bug as well.)

We don't use the work around at the right edge of the screen.  This may mean that buggy terminals will still see screwy behavior in the far right column, but at least it will be fixed everywhere else.

Thanks to @noborous for the analysis and the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where wide characters could corrupt content beyond the current text row when rendering, preventing unintended text overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->