### PR TITLE
Fix wide character overwrite issue at right edge

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -706,7 +706,7 @@ func (t *tScreen) drawCell(x, y int) int {
 		width = 1
 		str = " "
 	}
-	if width > 1 {
+	if width > 1 && x+width < t.w {
 		// Clobber over any content in the next cell.
 		// This fixes a problem with some terminals where overwriting two
 		// adjacent single cells with a wide rune would leave an image


### PR DESCRIPTION
When drawing wide characters near the right edge of the screen, ensure that overwriting with a single-width character does not leave artifacts in some terminals. Adjust the condition to avoid unnecessary clearing at the rightmost cell. fixes #1008.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering issue where wide characters would display incorrectly when positioned near the right edge of the screen, preventing visual glitches and ensuring proper character display at screen boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->