### PR TITLE
fix: Cell width comparison was forcing every cell to always be marked…

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -74,7 +74,7 @@ func (cb *CellBuffer) Put(x int, y int, str string, style Style) (string, int) {
 		// dirty as well as the base cell, to make sure we consider
 		// both cells as dirty together.  We only need to do this
 		// if we're changing content
-		if width > 0 && cl != c.currStr {
+		if width > 1 && cl != c.currStr {
 			// Prevent unnecessary bounds checks for first cell, since we already
 			// received that one.
 			c.setDirty(true)


### PR DESCRIPTION
… dirty

(Reported by 3bd on the Discord channel).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cell marking behavior for single-width characters. The system now correctly avoids marking base cells as dirty when handling single-width content, while preserving multi-cell marking for wider graphemes. This refinement enhances rendering efficiency and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->