### PR TITLE
docs: Change single quotes to double quotes in tutorial s.Put()

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -110,9 +110,9 @@ s.Clear()
 Text may be drawn on the screen using `Put`, `PutStr`, or `PutStrStyled`.
 
 ```go
-s.Put(0, 0, 'H', defStyle)
-s.Put(1, 0, 'i', defStyle)
-s.Put(2, 0, '!', defStyle)
+s.Put(0, 0, "H", defStyle)
+s.Put(1, 0, "i", defStyle)
+s.Put(2, 0, "!", defStyle)
 ```
 
 which is equivalent to


### PR DESCRIPTION
using single quotes causes the following error:

<img width="1118" height="84" alt="image" src="https://github.com/user-attachments/assets/ad9242a4-10f6-4a1b-a805-541abc719700" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial code examples to use string literals for character values in function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->