### PR TITLE
style: unify spelling of OSC in code comments

### DIFF
--- a/input.go
+++ b/input.go
@@ -1179,7 +1179,7 @@ type eventPrimaryAttributes struct {
 	Greek         bool // Greek (DA 23)
 	Turkish       bool // Turkish (DA 24)
 	Latin2        bool // ISO Latin-2 (DA 42)
-	Clipboard     bool // OSC-52 support (DA 52)
+	Clipboard     bool // OSC 52 support (DA 52)
 }
 
 // eventTermName is for extended attributes

--- a/tscreen.go
+++ b/tscreen.go
@@ -128,7 +128,7 @@ const (
 	requestPrimaryDA  = "\x1b[c"                            // Request primary device attributes
 	requestExtAttr    = "\x1b[>q"                           // Request extended attribute (emulator name and version)
 	setClipboard      = "\x1b]52;c;%s\x1b\\"                // Clipboard content is base64
-	notifyDesktop9    = "\x1b]9;%[2]s\x1b\\"                // Args are title, body (but osc 9 only has body)
+	notifyDesktop9    = "\x1b]9;%[2]s\x1b\\"                // Args are title, body (but OSC 9 only has body)
 	notifyDesktop777  = "\x1b]777;notify;%s;%s\x1b\\"       // Most commonly supported
 	queryKittyKbd     = "\x1b[?u"                           // Query for Kitty keyboard support
 	enableKittyKbd    = "\x1b[=1u"                          // Technically this pushes

--- a/vt/backend.go
+++ b/vt/backend.go
@@ -79,7 +79,7 @@ type Resizer interface {
 	NotifyResize(chan<- bool)
 }
 
-// Titler adds support for setting the window title. (Typically this is OSC2.)
+// Titler adds support for setting the window title. (Typically this is OSC 2.)
 // Note that for security reasons we only support setting this.
 // We don't bother with icon titles, since few terminal emulators support it, and it
 // would be hard for us to do this in any portable fashion.


### PR DESCRIPTION
This PR unifies the spelling of `OSC` in comments to match the rest of the codebase. I noticed this because one comment used `osc` and did not show up when I searched for all occurrences of `OSC`. I found the other inconsistent spellings along the way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and comments to improve consistency and clarity of technical details throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->