### PR TITLE
Fix expected bell count in beep_test.go

### DIFF
--- a/demos/beep/beep_test.go
+++ b/demos/beep/beep_test.go
@@ -61,6 +61,6 @@ func TestBeep(t *testing.T) {
 	wg.Wait()
 
 	if cnt := mt.Bells(); cnt != 3 {
-		t.Errorf("incorrect bell count %d != 2", cnt)
+		t.Errorf("incorrect bell count %d != 3", cnt)
 	}
 }


### PR DESCRIPTION
  Fix the failure message in demos/beep TestBeep to match the actual assertion.

  The test checks that the bell count is 3, but the error message currently says "!= 2". This does not affect test
  behavior, but it makes failures misleading and harder to debug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated beep assertions to expect 3 bell events instead of 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->