### PR TITLE
fix(input): handle ESC during CSI and SS3 parse states per ECMA-48

### DIFF
--- a/input.go
+++ b/input.go
@@ -546,7 +546,12 @@ func (ip *inputParser) scan() {
 			// the terminal to the host (queries in the other direction can use it.)
 			// However, this is only true if the first parameter does not have a "?",
 			// because it *does* collide with DEC private mode queries otherwise.
-			if r >= 0x30 && r <= 0x3F { // parameter bytes
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = istEsc
+				ip.escChar = 0
+			} else if r >= 0x30 && r <= 0x3F { // parameter bytes
 				ip.csiParams = append(ip.csiParams, byte(r))
 			} else if r == '$' && len(ip.csiParams) > 0 && ip.csiParams[0] != '?' { // rxvt non-standard
 				ip.handleCsi(r, ip.csiParams, ip.csiInterm)
@@ -565,7 +570,12 @@ func (ip *inputParser) scan() {
 		case istSs3: // typically application mode keys or older terminals
 			ip.state = istInit
 			// some SS3 sequences (old VTE) encode modifiers here just like CSI
-			if r >= 0x30 && r <= 0x3F {
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = istEsc
+				ip.escChar = 0
+			} else if r >= 0x30 && r <= 0x3F {
 				ip.csiParams = append(ip.csiParams, byte(r))
 				ip.state = istSs3
 			} else if k, ok := ss3Keys[r]; ok {

--- a/input_test.go
+++ b/input_test.go
@@ -823,3 +823,69 @@ func TestKeyboardMode(t *testing.T) {
 		})
 	}
 }
+
+// TestEscDuringCsiResetsParser verifies that an ESC byte received while
+// the parser is in CSI state correctly transitions to escape state per
+// ECMA-48 §5.3.1, rather than being swallowed as a "bad parse".
+func TestEscDuringCsiResetsParser(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+
+	// Feed a partial CSI (ESC [) followed immediately by a new escape
+	// sequence for Down arrow (ESC [ B). Without the fix, the second
+	// ESC would be swallowed and 'B' would be emitted as a literal key.
+	ip.ScanUTF8([]byte("\x1b[\x1b[B"))
+
+	var got *EventKey
+	for {
+		select {
+		case ev := <-evch:
+			if kev, ok := ev.(*EventKey); ok {
+				got = kev
+			}
+			continue
+		case <-time.After(100 * time.Millisecond):
+		}
+		break
+	}
+
+	if got == nil {
+		t.Fatal("expected a key event, got none")
+	}
+	if got.Key() != KeyDown {
+		t.Errorf("expected KeyDown, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+	}
+}
+
+// TestEscDuringSs3ResetsParser verifies that an ESC byte received while
+// the parser is accumulating SS3 parameters correctly transitions to
+// escape state per ECMA-48 §5.3.1.
+func TestEscDuringSs3ResetsParser(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+
+	// Feed a partial SS3 with parameter (ESC O 1) followed immediately
+	// by a new escape sequence for Down arrow (ESC [ B). Without the
+	// fix, the ESC would be lost inside the SS3 parameter accumulation.
+	ip.ScanUTF8([]byte("\x1bO1\x1b[B"))
+
+	var got *EventKey
+	for {
+		select {
+		case ev := <-evch:
+			if kev, ok := ev.(*EventKey); ok {
+				got = kev
+			}
+			continue
+		case <-time.After(100 * time.Millisecond):
+		}
+		break
+	}
+
+	if got == nil {
+		t.Fatal("expected a key event, got none")
+	}
+	if got.Key() != KeyDown {
+		t.Errorf("expected KeyDown, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+	}
+}

--- a/input_test.go
+++ b/input_test.go
@@ -824,6 +824,26 @@ func TestKeyboardMode(t *testing.T) {
 	}
 }
 
+// firstKey drains the event channel and returns the first EventKey received,
+// or nil if none arrives within 100ms.
+func firstKey(evch chan Event) *EventKey {
+	var got *EventKey
+	for {
+		select {
+		case ev := <-evch:
+			if got == nil {
+				if kev, ok := ev.(*EventKey); ok {
+					got = kev
+				}
+			}
+			continue
+		case <-time.After(100 * time.Millisecond):
+		}
+		break
+	}
+	return got
+}
+
 // TestEscDuringCsiResetsParser verifies that an ESC byte received while
 // the parser is in CSI state correctly transitions to escape state per
 // ECMA-48 §5.3.1, rather than being swallowed as a "bad parse".
@@ -836,19 +856,7 @@ func TestEscDuringCsiResetsParser(t *testing.T) {
 	// ESC would be swallowed and 'B' would be emitted as a literal key.
 	ip.ScanUTF8([]byte("\x1b[\x1b[B"))
 
-	var got *EventKey
-	for {
-		select {
-		case ev := <-evch:
-			if kev, ok := ev.(*EventKey); ok {
-				got = kev
-			}
-			continue
-		case <-time.After(100 * time.Millisecond):
-		}
-		break
-	}
-
+	got := firstKey(evch)
 	if got == nil {
 		t.Fatal("expected a key event, got none")
 	}
@@ -869,19 +877,7 @@ func TestEscDuringSs3ResetsParser(t *testing.T) {
 	// fix, the ESC would be lost inside the SS3 parameter accumulation.
 	ip.ScanUTF8([]byte("\x1bO1\x1b[B"))
 
-	var got *EventKey
-	for {
-		select {
-		case ev := <-evch:
-			if kev, ok := ev.(*EventKey); ok {
-				got = kev
-			}
-			continue
-		case <-time.After(100 * time.Millisecond):
-		}
-		break
-	}
-
+	got := firstKey(evch)
 	if got == nil {
 		t.Fatal("expected a key event, got none")
 	}


### PR DESCRIPTION
**Disclosure**: I stumbled across this while working on a personal project. AI tools were used to diagnose and resolve the issue as well as generate this potential upstream fix. Systems programming at this level is not my expertise, but the fix seemed small, contained, and testable so I thought it worthwhile to open a PR. AFAIK, the same issue is present in tcell v2.

The input parser's CSI and SS3 state handlers do not check for ESC (0x1B). Per ECMA-48 §5.3.1, ESC is "always effective" and should restart the escape sequence machine from any intermediate state. Instead, ESC falls into the "bad parse" branch in istCsi and is silently discarded, and in istSs3 it fails the key lookup and is similarly lost.

This causes the byte(s) following the discarded ESC to be misinterpreted. In practice, the user's first keystroke after Suspend/Resume can be swallowed: engage() sends escape sequences that may provoke terminal responses, and if those responses leave the parser mid-CSI, the next ESC-prefixed key (arrow keys, function keys) is consumed as the tail of the stale sequence.

The tty input flush added in #1048 reduces the likelihood of stale bytes reaching the parser, but does not eliminate it — terminal responses can arrive after the flush and before inputLoop starts, or bytes can be split across reads leaving a partial sequence in the parser's state machine.

This change adds an ESC check to both istCsi and istSs3 that transitions to istEsc and clears escChar, matching the behavior of istInit. Tests verify that a partial CSI or SS3 followed by a new escape sequence (e.g., arrow key) produces the correct key event.

Related: #194, #480, #1048 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an ESC byte arrives mid-way through an active escape sequence: the parser now correctly resets and emits the intended key event, preventing lost or misclassified input.

* **Tests**
  * Added tests covering escape bytes arriving during active parsing and a test helper to ensure the first resulting key event is observed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->