### PR TITLE
fix(input): handle ESC during CSI and SS3 parse states per ECMA-48

### DIFF
--- a/input.go
+++ b/input.go
@@ -502,7 +502,15 @@ func (ip *inputProcessor) scan() {
 			}
 		case inpStateCsi:
 			// usual case for incoming keys
-			if r >= 0x30 && r <= 0x3F { // parameter bytes
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = inpStateEsc
+				if len(ip.buf) == 0 && ip.nested == nil {
+					ip.expire = time.Now().Add(time.Millisecond * 50)
+					ip.timer = time.AfterFunc(time.Millisecond*60, ip.escTimeout)
+				}
+			} else if r >= 0x30 && r <= 0x3F { // parameter bytes
 				ip.csiParams = append(ip.csiParams, byte(r))
 			} else if r >= 0x20 && r <= 0x2F { // intermediate bytes, rarely used
 				ip.csiInterm = append(ip.csiInterm, byte(r))
@@ -518,7 +526,15 @@ func (ip *inputProcessor) scan() {
 
 		case inpStateSs3: // typically application mode keys or older terminals
 			ip.state = inpStateInit
-			if k, ok := ss3Keys[r]; ok {
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = inpStateEsc
+				if len(ip.buf) == 0 && ip.nested == nil {
+					ip.expire = time.Now().Add(time.Millisecond * 50)
+					ip.timer = time.AfterFunc(time.Millisecond*60, ip.escTimeout)
+				}
+			} else if k, ok := ss3Keys[r]; ok {
 				ip.post(NewEventKey(k, 0, ModNone))
 			}
 

--- a/input_test.go
+++ b/input_test.go
@@ -1,0 +1,67 @@
+package tcell
+
+import (
+	"testing"
+	"time"
+)
+
+// firstKey drains the event channel and returns the first EventKey received,
+// or nil if none arrives within 100ms.
+func firstKey(evch chan Event) *EventKey {
+	var got *EventKey
+	for {
+		select {
+		case ev := <-evch:
+			if got == nil {
+				if kev, ok := ev.(*EventKey); ok {
+					got = kev
+				}
+			}
+			continue
+		case <-time.After(100 * time.Millisecond):
+		}
+		break
+	}
+	return got
+}
+
+// TestEscDuringCsiResetsParser verifies that an ESC byte received while
+// the parser is in CSI state correctly transitions to escape state per
+// ECMA-48 §5.3.1, rather than being swallowed as a "bad parse".
+func TestEscDuringCsiResetsParser(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := NewInputProcessor(evch)
+
+	// Feed a partial CSI (ESC [) followed immediately by a new escape
+	// sequence for Down arrow (ESC [ B). Without the fix, the second
+	// ESC would be swallowed and 'B' would be emitted as a literal key.
+	ip.ScanUTF8([]byte("\x1b[\x1b[B"))
+
+	got := firstKey(evch)
+	if got == nil {
+		t.Fatal("expected a key event, got none")
+	}
+	if got.Key() != KeyDown {
+		t.Errorf("expected KeyDown, got key=%v rune=%v mod=%v", got.Key(), got.Rune(), got.Modifiers())
+	}
+}
+
+// TestEscDuringSs3ResetsParser verifies that an ESC byte received while
+// the parser is in SS3 state correctly transitions to escape state per
+// ECMA-48 §5.3.1.
+func TestEscDuringSs3ResetsParser(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := NewInputProcessor(evch)
+
+	// Feed ESC O (enters SS3) then ESC [ B (Down arrow). Without the
+	// fix, the ESC is lost inside SS3 handling.
+	ip.ScanUTF8([]byte("\x1bO\x1b[B"))
+
+	got := firstKey(evch)
+	if got == nil {
+		t.Fatal("expected a key event, got none")
+	}
+	if got.Key() != KeyDown {
+		t.Errorf("expected KeyDown, got key=%v rune=%v mod=%v", got.Key(), got.Rune(), got.Modifiers())
+	}
+}


### PR DESCRIPTION
**Disclosure**: I stumbled across this while working on a personal project. AI tools were used to diagnose and resolve the issue as well as generate this potential upstream fix. Systems programming at this level is not my expertise, but the fix seemed small, contained, and testable so I thought it worthwhile to open a PR.

The input parser's CSI and SS3 state handlers do not check for ESC (0x1B). Per ECMA-48 §5.3.1, ESC is "always effective" and should restart the escape sequence machine from any intermediate state. Instead, ESC falls into the "bad parse" branch in inpStateCsi and is silently discarded, and in inpStateSs3 it fails the key lookup and is similarly lost.

This causes the byte(s) following the discarded ESC to be misinterpreted. In practice, the user's first keystroke after Suspend/Resume can be swallowed: engage() sends escape sequences that may provoke terminal responses, and if those responses leave the parser mid-CSI, the next ESC-prefixed key (arrow keys, function keys) is consumed as the tail of the stale sequence.

The tty input flush added in #1048 reduces the likelihood of stale bytes reaching the parser, but does not eliminate it — terminal responses can arrive after the flush and before inputLoop starts, or bytes can be split across reads leaving a partial sequence in the parser's state machine.

This adds an ESC check to both inpStateCsi and inpStateSs3 that transitions to inpStateEsc with the standard timeout setup, matching the behavior of inpStateInit. Tests verify that a partial CSI or SS3 followed by a new escape sequence produces the correct key event.

Backport of the equivalent fix on main (#1053)
