### PR TITLE
feat(events): add Unwrap() to EventError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -50,6 +50,13 @@ func (ev *EventError) Error() string {
 	return ev.err.Error()
 }
 
+// Unwrap exposes the underlying error payload so callers can use
+// errors.Is / errors.As to match against sentinel values such as
+// io.EOF.
+func (ev *EventError) Unwrap() error {
+	return ev.err
+}
+
 // NewEventError creates an ErrorEvent with the given error payload.
 func NewEventError(err error) *EventError {
 	ev := &EventError{err: err}


### PR DESCRIPTION
Adds `Unwrap()` to `*EventError` so consumers can use `errors.Is` / `errors.As` to match the underlying payload. For example, `errors.Is(ev, io.EOF)` detects a closed terminal cleanly.

### Why

Without payload access, the only way to distinguish an EOF from a real input error is string-matching `ev.Error()`, which most consumers skip, so a terminal close silently hangs the event loop. Recurring pattern downstream:

- rivo/tview#617: terminal close, EOF fired, app hangs forever
- rivo/tview#624: `panic: EOF` on Suspend/Resume
- gokcehan/lf#1278, #771: freeze on shell return, EOF logged but unactionable
- micro-editor/micro#2085: editor spins at 40% CPU after its host terminal is killed

Two tcell forks already carry a custom `Err()` accessor for the same reason:

- [micro-editor/tcell@54f6acda](https://github.com/micro-editor/tcell/commit/54f6acdada) (2023), *"Return input EOF errors as normal event errors"*
- [go-curses/cdk `event_error.go`](https://github.com/go-curses/cdk/blob/trunk/event_error.go)

Using `Unwrap` rather than a custom `Err()` accessor means `errors.Is` / `errors.As` work out of the box.

### Test plan

- `go test ./...` passes.

Assisted-by: Claude:claude-opus-4-7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling enabling better error diagnostics and compatibility with standard error matching patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->