### PR TITLE
Sanitize OSC 8 links (fixes #1061)

### DIFF
--- a/style.go
+++ b/style.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The TCell Authors
+// Copyright 2026 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,18 @@ type Style struct {
 type urlInfo struct {
 	url string
 	id  string
+}
+
+func stripOSCControls(s string) string {
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+			continue
+		}
+		b = append(b, c)
+	}
+	return string(b)
 }
 
 // StyleDefault represents a default style, based upon the context.
@@ -201,7 +213,7 @@ func (s Style) GetAttributes() AttrMask {
 func (s Style) Url(url string) Style {
 
 	s2 := s
-	s2.url = &urlInfo{url: url}
+	s2.url = &urlInfo{url: stripOSCControls(url)}
 	if s.url != nil {
 		s2.url.id = s.url.id
 	}
@@ -215,7 +227,7 @@ func (s Style) Url(url string) Style {
 func (s Style) UrlId(id string) Style {
 	s2 := s
 	s2.url = &urlInfo{
-		id: "id=" + id,
+		id: "id=" + stripOSCControls(id),
 	}
 	if s.url != nil {
 		s2.url.url = s.url.url

--- a/style.go
+++ b/style.go
@@ -16,6 +16,7 @@ package tcell
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v3/color"
 )
@@ -43,15 +44,28 @@ type urlInfo struct {
 }
 
 func stripOSCControls(s string) string {
-	b := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			c := s[i]
+			if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+				i++
+				continue
+			}
+			_ = b.WriteByte(c)
+			i++
 			continue
 		}
-		b = append(b, c)
+		if r <= 0x1f || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			i += size
+			continue
+		}
+		b.WriteString(s[i : i+size])
+		i += size
 	}
-	return string(b)
+	return b.String()
 }
 
 // StyleDefault represents a default style, based upon the context.

--- a/style_test.go
+++ b/style_test.go
@@ -16,6 +16,7 @@ package tcell
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v3/color"
 )
@@ -112,5 +113,26 @@ func TestStyleUrlStripsOSCControls(t *testing.T) {
 	}
 	if url != "http://example.com/\\path" {
 		t.Fatalf("unexpected sanitized url: %q", url)
+	}
+
+	s = StyleDefault.
+		Url("http://example.com/\u3042\u009b").
+		UrlId("id\u3042\u009bend")
+
+	id, url = s.GetUrl()
+	combined = id + url
+	if !utf8.ValidString(combined) {
+		t.Fatalf("UTF-8 was corrupted during sanitization: id=%q url=%q", id, url)
+	}
+	for _, r := range combined {
+		if r <= 0x1f || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			t.Fatalf("control characters survived UTF-8 sanitization: id=%q url=%q", id, url)
+		}
+	}
+	if id != "id\u3042end" {
+		t.Fatalf("unexpected sanitized UTF-8 id: %q", id)
+	}
+	if url != "http://example.com/\u3042" {
+		t.Fatalf("unexpected sanitized UTF-8 url: %q", url)
 	}
 }

--- a/style_test.go
+++ b/style_test.go
@@ -93,3 +93,24 @@ func TestStyle(t *testing.T) {
 		t.Errorf("wrong attributes: %v", us.GetAttributes())
 	}
 }
+
+func TestStyleUrlStripsOSCControls(t *testing.T) {
+	s := StyleDefault.
+		Url("http://exa\x07mple.com/\x1b\\path").
+		UrlId("id\x00\x1f\x7f\x80\x9fend")
+
+	id, url := s.GetUrl()
+	combined := id + url
+	for i := 0; i < len(combined); i++ {
+		c := combined[i]
+		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+			t.Fatalf("control characters survived sanitization: id=%q url=%q", id, url)
+		}
+	}
+	if id != "idend" {
+		t.Fatalf("unexpected sanitized id: %q", id)
+	}
+	if url != "http://example.com/\\path" {
+		t.Fatalf("unexpected sanitized url: %q", url)
+	}
+}

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -112,6 +112,45 @@ func TestOptAltScreenDefault(t *testing.T) {
 	}
 }
 
+func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	style := StyleDefault.
+		Url("http://exa\x07mple.com/\x1b\\path").
+		UrlId("id\x00\x1f\x7f\x80\x9fend")
+
+	s.PutStrStyled(0, 0, "X", style)
+	s.Show()
+
+	out := tty.Output()
+	const prefix = "\x1b]8;id=idend;"
+	_, link, ok := strings.Cut(out, prefix)
+	if !ok {
+		t.Fatalf("missing OSC 8 link open sequence in output: %q", out)
+	}
+	link, _, ok = strings.Cut(link, "\x1b\\")
+	if !ok {
+		t.Fatalf("missing OSC 8 terminator in output: %q", out)
+	}
+	if link != "http://example.com/\\path" {
+		t.Fatalf("unexpected emitted URL payload: %q", link)
+	}
+	for i := 0; i < len(link); i++ {
+		c := link[i]
+		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+			t.Fatalf("control characters survived in emitted URL payload: %q", link)
+		}
+	}
+}
+
 // TestInitScreenStdio just tries to initialize the default screen using standard I/O.
 // It requires a working tty.
 func TestInitScreenStdio(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URLs and URL identifiers are now sanitized: ASCII control characters (C0, DEL, C1) are stripped so stored and emitted values contain no control bytes.

* **Tests**
  * New tests validate sanitization at assignment and in rendered terminal output, asserting sanitized values and absence of control characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->