### PR TITLE
fix: possible panic in getConsoleInput if no event returned

### DIFF
--- a/tty/tty_win.go
+++ b/tty/tty_win.go
@@ -189,6 +189,10 @@ func (w *winTty) getConsoleInput() error {
 		rv, _, er := procGetNumberOfConsoleInputEvents.Call(
 			uintptr(w.in),
 			uintptr(unsafe.Pointer(&nrec)))
+		if rv == 0 {
+			return er
+		}
+
 		rec := make([]inputRecord, max(nrec, 1))
 		rv, _, er = procReadConsoleInput.Call(
 			uintptr(w.in),


### PR DESCRIPTION
This is to resolve an issue found in lazygit (https://github.com/jesseduffield/lazygit/issues/5336 and a few other duplicates).
It would cause an out of range index, here is the lazygit crash stack:
```
panic: runtime error: index out of range [0] with length 0

goroutine 30 [running]:
github.com/gdamore/tcell/v2.(*winTty).getConsoleInput(0xc000146000)
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tty_win.go:156 +0x508
github.com/gdamore/tcell/v2.(*winTty).scanInput(0xc000146000)
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tty_win.go:210 +0x51
created by github.com/gdamore/tcell/v2.(*winTty).Start in goroutine 1
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tty_win.go:243 +0x205

goroutine 1 [select]:
github.com/jesseduffield/gocui.(*Gui).processEvent(0xc000142000)
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:829 +0xd8
github.com/jesseduffield/gocui.(*Gui).MainLoop(0xc000142000)
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:813 +0xea
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).Run(0xc000140008, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}})
	/home/runner/work/lazygit/lazygit/pkg/gui/gui.go:938 +0x57c
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError.func1()
	/home/runner/work/lazygit/lazygit/pkg/gui/gui.go:944 +0x48
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0x7ff694582280?)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:80 +0x56
github.com/jesseduffield/lazygit/pkg/gui.(*Gui).RunAndHandleError(0xc000140008, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}})
	/home/runner/work/lazygit/lazygit/pkg/gui/gui.go:943 +0xff
github.com/jesseduffield/lazygit/pkg/app.(*App).Run(...)
	/home/runner/work/lazygit/lazygit/pkg/app/app.go:277
github.com/jesseduffield/lazygit/pkg/app.Run({0x7ff693ed7f58?, 0xc0001fe210?}, 0xc000044f40, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}})
	/home/runner/work/lazygit/lazygit/pkg/app/app.go:48 +0xda
github.com/jesseduffield/lazygit/pkg/app.Start(0xc000129f00, {0x0, 0x0})
	/home/runner/work/lazygit/lazygit/pkg/app/entry_point.go:177 +0xe05
main.main()
	/home/runner/work/lazygit/lazygit/main.go:23 +0x98

goroutine 31 [select]:
github.com/gdamore/tcell/v2.(*winTty).Read(0xc000146000, {0xc000134000, 0x80, 0x0?})
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tty_win.go:82 +0x85
github.com/gdamore/tcell/v2.(*tScreen).inputLoop(0xc000144008, 0xc000088150)
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go:1051 +0xc5
created by github.com/gdamore/tcell/v2.(*tScreen).engage in goroutine 1
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go:1211 +0x446

goroutine 32 [select]:
github.com/gdamore/tcell/v2.(*tScreen).mainLoop(0xc000144008, 0xc000088150)
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go:1020 +0x125
created by github.com/gdamore/tcell/v2.(*tScreen).engage in goroutine 1
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/tscreen.go:1212 +0x49a

goroutine 67 [syscall]:
syscall.SyscallN(0x7ff6933ea637?, {0xc00003d740?, 0x7ff6945ca800?, 0xc0002ec480?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/syscall_windows.go:500 +0x1e
syscall.WaitForSingleObject(0x494, 0xffffffff)
	/opt/hostedtoolcache/go/1.25.8/x64/src/syscall/zsyscall_windows.go:1159 +0x6a
os.(*Process).wait(0xc000044700)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec_windows.go:28 +0x89
os.(*Process).Wait(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec.go:340
os/exec.(*Cmd).Wait(0xc000530300)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:922 +0x45
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runAndStreamAux(0xc00009a5d0, 0xc000044240, 0xc00003db78)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:271 +0x63e
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runAndDetectCredentialRequest(0xc00009a5d0, 0xc000044240, 0x7ff693dd4850)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:345 +0x190
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runWithCredentialHandling(0xc00009a5d0, 0xc000044240)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:320 +0x45
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).RunWithOutput(0xc00027e080?, 0xc000516040?)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:57 +0x179
github.com/jesseduffield/lazygit/pkg/commands.(*gitCmdObjRunner).RunWithOutput(0xc000008060, 0xc000044040)
	/home/runner/work/lazygit/lazygit/pkg/commands/git_cmd_obj_runner.go:33 +0x1b1
github.com/jesseduffield/lazygit/pkg/commands.(*gitCmdObjRunner).Run(0xc000066038?, 0x7ff693c975a0?)
	/home/runner/work/lazygit/lazygit/pkg/commands/git_cmd_obj_runner.go:24 +0x13
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*CmdObj).Run(...)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj.go:185
github.com/jesseduffield/lazygit/pkg/commands/git_commands.(*SyncCommands).FetchBackground(0x300f693424180?)
	/home/runner/work/lazygit/lazygit/pkg/commands/git_commands/sync.go:87 +0x27
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).backgroundFetch(0xc000094270)
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:156 +0x2a
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).startBackgroundFetch.(*BackgroundRoutineMgr).startBackgroundFetch.func1.func3({0x7ff693c975a0?, 0xc00049be08?})
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:94 +0x17
github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers.(*AppStatusHelper).WithWaitingStatusImpl.func1(0xc00050c030?)
	/home/runner/work/lazygit/lazygit/pkg/gui/controllers/helpers/app_status_helper.go:69 +0x53
github.com/jesseduffield/lazygit/pkg/gui/status.(*StatusManager).WithWaitingStatus(0xc000138d50, {0x7ff693d1b97c, 0x8}, 0xc00027e040, 0xc00049beb0)
	/home/runner/work/lazygit/lazygit/pkg/gui/status/status_manager.go:56 +0xd7
github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers.(*AppStatusHelper).WithWaitingStatusImpl(0xc000008db0, {0x7ff693d1b97c, 0x8}, 0xc00049bf30, {0x0, 0x0})
	/home/runner/work/lazygit/lazygit/pkg/gui/controllers/helpers/app_status_helper.go:68 +0xc7
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).startBackgroundFetch.func1(...)
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:93
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).startBackgroundFetch(0xc000094270)
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:103 +0x14b
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).startBackgroundRoutines.gowrap1.Safe.1()
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69 +0x13
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0x0?)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:80 +0x56
github.com/jesseduffield/lazygit/pkg/utils.Safe(...)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69
created by github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).startBackgroundRoutines in goroutine 1
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:35 +0xc7

goroutine 69 [select]:
github.com/gdamore/tcell/v2.(*baseScreen).PollEvent(0xc00009a600)
	/home/runner/work/lazygit/lazygit/vendor/github.com/gdamore/tcell/v2/screen.go:511 +0x8d
github.com/jesseduffield/gocui.(*Gui).pollEvent(0x0?)
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/tcell_driver.go:279 +0x182
github.com/jesseduffield/gocui.(*Gui).MainLoop.func1()
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:793 +0x2c
created by github.com/jesseduffield/gocui.(*Gui).MainLoop in goroutine 1
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:787 +0x56

goroutine 8 [select]:
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).goEvery.func1()
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:141 +0xf8
github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).goEvery.gowrap1.Safe.1()
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69 +0x13
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0xc00027e020?)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:80 +0x56
github.com/jesseduffield/lazygit/pkg/utils.Safe(...)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69
created by github.com/jesseduffield/lazygit/pkg/gui.(*BackgroundRoutineMgr).goEvery in goroutine 68
	/home/runner/work/lazygit/lazygit/pkg/gui/background.go:123 +0x116

goroutine 7 [chan receive]:
github.com/jesseduffield/lazygit/pkg/gui/controllers/helpers.(*AppStatusHelper).renderAppStatus-fm.(*AppStatusHelper).renderAppStatus.func1({0x0?, 0x0?})
	/home/runner/work/lazygit/lazygit/pkg/gui/controllers/helpers/app_status_helper.go:96 +0xcb
github.com/jesseduffield/gocui.(*Gui).onWorkerAux(0xc000142000, 0x0?, {0x7ff693ed1ad8?, 0xc00050a020?})
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:738 +0x65
github.com/jesseduffield/gocui.(*Gui).OnWorker.func1()
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:725 +0x2b
created by github.com/jesseduffield/gocui.(*Gui).OnWorker in goroutine 67
	/home/runner/work/lazygit/lazygit/vendor/github.com/jesseduffield/gocui/gui.go:724 +0x90

goroutine 99 [syscall]:
syscall.SyscallN(0xc00009e5a0?, {0xc000499bb0?, 0xe?, 0xc00009e5a0?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/syscall_windows.go:500 +0x1e
syscall.readFile(0x474, {0xc0004ba000?, 0x8000, 0xc000499c88?}, 0x7ff69340f1a7?, 0x1?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/syscall/zsyscall_windows.go:1030 +0xbe
syscall.ReadFile(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/syscall/syscall_windows.go:482
internal/poll.(*FD).Read.func1(0x19340347b?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:522 +0x4d
internal/poll.execIO(0xc0000f3ba0, 0x7ff693dd5190)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:233 +0xa7
internal/poll.(*FD).Read(0xc0000f3b88, {0xc0004ba000, 0x8000, 0x8000})
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:521 +0x288
os.(*File).read(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file_posix.go:29
os.(*File).Read(0xc00008e0f0, {0xc0004ba000?, 0x7ff69344c71f?, 0x8?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:144 +0x4f
io.copyBuffer({0x7ff693ecca40, 0xc0000f4600}, {0x7ff693ecc860, 0xc00008e1c8}, {0x0, 0x0, 0x0})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:429 +0x190
io.Copy(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:388
os.genericWriteTo(0xc000499e88?, {0x7ff693ecca40, 0xc0000f4600})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:295 +0x4f
os.(*File).WriteTo(0x7ff69455d5c0?, {0x7ff693ecca40?, 0xc0000f4600?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:273 +0x49
io.copyBuffer({0x7ff693ecca40, 0xc0000f4600}, {0x7ff693ecc320, 0xc00008e0f0}, {0x0, 0x0, 0x0})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:411 +0x9d
io.Copy(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:388
os/exec.(*Cmd).writerDescriptor.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:596 +0x34
os/exec.(*Cmd).Start.func2(0xc00050a0e0?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:749 +0x2c
created by os/exec.(*Cmd).Start in goroutine 67
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:748 +0x9ce

goroutine 100 [syscall]:
syscall.SyscallN(0x455c293638782820?, {0xc000125bb0?, 0x53204441525c6f72?, 0x2e395c6f69647574?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/syscall_windows.go:500 +0x1e
syscall.readFile(0x47c, {0xc00053c000?, 0x8000, 0xc000125c88?}, 0x7ff69340f1a7?, 0x5c34366e69625c30?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/syscall/zsyscall_windows.go:1030 +0xbe
syscall.ReadFile(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/syscall/syscall_windows.go:482
internal/poll.(*FD).Read.func1(0x29340347b?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:522 +0x4d
internal/poll.execIO(0xc0001907a0, 0x7ff693dd5190)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:233 +0xa7
internal/poll.(*FD).Read(0xc000190788, {0xc00053c000, 0x8000, 0x8000})
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:521 +0x288
os.(*File).read(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file_posix.go:29
os.(*File).Read(0xc00008e100, {0xc00053c000?, 0x7ff69344c71f?, 0x8?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:144 +0x4f
io.copyBuffer({0x7ff693ecc720, 0xc000094210}, {0x7ff693ecc860, 0xc00008e1d0}, {0x0, 0x0, 0x0})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:429 +0x190
io.Copy(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:388
os.genericWriteTo(0x302e395c6f696475?, {0x7ff693ecc720, 0xc000094210})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:295 +0x4f
os.(*File).WriteTo(0x7ff69455d5c0?, {0x7ff693ecc720?, 0xc000094210?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/file.go:273 +0x49
io.copyBuffer({0x7ff693ecc720, 0xc000094210}, {0x7ff693ecc320, 0xc00008e100}, {0x0, 0x0, 0x0})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:411 +0x9d
io.Copy(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:388
os/exec.(*Cmd).writerDescriptor.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:596 +0x34
os/exec.(*Cmd).Start.func2(0x5c63696c6275505c?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:749 +0x2c
created by os/exec.(*Cmd).Start in goroutine 67
	/opt/hostedtoolcache/go/1.25.8/x64/src/os/exec/exec.go:748 +0x9ce

goroutine 101 [select]:
io.(*pipe).read(0xc0000f4600, {0xc0002fa000, 0x1000, 0xc000146b59?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/pipe.go:57 +0xa5
io.(*PipeReader).Read(0x1ba4cd80e68?, {0xc0002fa000?, 0x1000?, 0xc000600008?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/pipe.go:134 +0x1a
io.(*teeReader).Read(0xc00050a340, {0xc0002fa000, 0xc00049bd28?, 0x1000})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:628 +0x2e
io.(*teeReader).Read(0xc00050a360, {0xc0002fa000, 0x3?, 0x1000})
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:628 +0x2e
bufio.(*Scanner).Scan(0xc00049be78)
	/opt/hostedtoolcache/go/1.25.8/x64/src/bufio/scan.go:219 +0x83e
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).processOutput(0xc00009a5d0, {0x7ff693ecc760, 0xc00050a360}, {0x7ff693ecca80, 0xc0002e67b0}, 0x7ff693dd4850, 0x7ff693dd4848, 0xc000044240)
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:366 +0xd4
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runAndDetectCredentialRequest.func1.1()
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:349 +0x37
github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runAndDetectCredentialRequest.func1.gowrap1.Safe.1()
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69 +0x13
github.com/jesseduffield/lazygit/pkg/utils.SafeWithError(0x0?)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:80 +0x56
github.com/jesseduffield/lazygit/pkg/utils.Safe(...)
	/home/runner/work/lazygit/lazygit/pkg/utils/utils.go:69
created by github.com/jesseduffield/lazygit/pkg/commands/oscommands.(*cmdObjRunner).runAndDetectCredentialRequest.func1 in goroutine 67
	/home/runner/work/lazygit/lazygit/pkg/commands/oscommands/cmd_obj_runner.go:348 +0x176

goroutine 96 [IO wait]:
internal/poll.runtime_pollWait(0x1ba4cd65e00, 0x72)
	/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0x498?, 0x7ff6933e0e06?, 0x0)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.waitIO(0x93?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:187 +0x65
internal/poll.execIO(0xc000190520, 0x7ff693dd5198)
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:240 +0x13a
internal/poll.(*FD).Read(0xc000190508, {0xc0007e4000, 0xd80, 0xd80})
	/opt/hostedtoolcache/go/1.25.8/x64/src/internal/poll/fd_windows.go:537 +0x1ee
net.(*netFD).Read(0xc000190508, {0xc0007e4000?, 0x0?, 0x80b?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/fd_posix.go:68 +0x25
net.(*conn).Read(0xc0004a6008, {0xc0007e4000?, 0x1ba05c8b8a0?, 0x1ba05c80108?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/net.go:196 +0x45
crypto/tls.(*atLeastReader).Read(0xc0005b0810, {0xc0007e4000?, 0x8?, 0x140?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/crypto/tls/conn.go:819 +0x3b
bytes.(*Buffer).ReadFrom(0xc000189428, {0x7ff693ecdda0, 0xc0005b0810})
	/opt/hostedtoolcache/go/1.25.8/x64/src/bytes/buffer.go:217 +0x98
crypto/tls.(*Conn).readFromUntil(0xc000189188, {0x1ba4cd66000, 0xc0004a6008}, 0xc0005c39a8?)
	/opt/hostedtoolcache/go/1.25.8/x64/src/crypto/tls/conn.go:841 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc000189188, 0x0)
	/opt/hostedtoolcache/go/1.25.8/x64/src/crypto/tls/conn.go:630 +0x3db
crypto/tls.(*Conn).readRecord(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/crypto/tls/conn.go:592
crypto/tls.(*Conn).Read(0xc000189188, {0xc0002fb000, 0x1000, 0xc0005c3ca8?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/crypto/tls/conn.go:1397 +0x145
bufio.(*Reader).Read(0xc0008228a0, {0xc0007f0ac0, 0x9, 0x7ff6933e2ae0?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/bufio/bufio.go:245 +0x197
io.ReadAtLeast({0x7ff693ecc380, 0xc0008228a0}, {0xc0007f0ac0, 0x9, 0x9}, 0x9)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:335 +0x8e
io.ReadFull(...)
	/opt/hostedtoolcache/go/1.25.8/x64/src/io/io.go:354
net/http.http2readFrameHeader({0xc0007f0ac0, 0x9, 0x7ff6936e695f?}, {0x7ff693ecc380?, 0xc0008228a0?})
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/http/h2_bundle.go:1811 +0x65
net/http.(*http2Framer).ReadFrame(0xc0007f0a80)
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/http/h2_bundle.go:2078 +0x7d
net/http.(*http2clientConnReadLoop).run(0xc0005c3fa8)
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/http/h2_bundle.go:9539 +0xda
net/http.(*http2ClientConn).readLoop(0xc00079afc0)
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/http/h2_bundle.go:9408 +0x79
created by net/http.(*http2Transport).newClientConn in goroutine 95
	/opt/hostedtoolcache/go/1.25.8/x64/src/net/http/h2_bundle.go:8192 +0xde5
```
Let me know if anything needs changing!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows console input handling to avoid unnecessary read attempts and memory allocation when input availability checks fail, reducing spurious errors and improving stability in shared/empty-console scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->