### PR TITLE
Sanitize titles and notifications (fixes #1066)

### DIFF
--- a/style.go
+++ b/style.go
@@ -43,6 +43,7 @@ type urlInfo struct {
 	id  string
 }
 
+// stripOSCControls removes control bytes that can terminate OSC payloads early.
 func stripOSCControls(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))

--- a/tscreen.go
+++ b/tscreen.go
@@ -1401,9 +1401,9 @@ func (t *tScreen) GetCells() *CellBuffer {
 
 func (t *tScreen) SetTitle(title string) {
 	t.Lock()
-	t.title = title
+	t.title = stripOSCControls(title)
 	if t.setTitle != "" && t.running {
-		t.Printf(t.setTitle, title)
+		t.Printf(t.setTitle, t.title)
 	}
 	t.Unlock()
 }
@@ -1432,7 +1432,7 @@ func (t *tScreen) HasClipboard() bool {
 
 func (t *tScreen) ShowNotification(title string, body string) {
 	t.Lock()
-	t.Printf(t.notifyDesktop, title, body)
+	t.Printf(t.notifyDesktop, stripOSCControls(title), stripOSCControls(body))
 	t.Unlock()
 }
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -217,3 +217,44 @@ func NewMockScreen(t *testing.T, opts ...vt.MockOpt) (vt.MockTerm, Screen) {
 	}
 	return mt, scr
 }
+
+func TestSetTitleStripsOSCControls(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})
+	scr, err := NewTerminfoScreenFromTty(mt)
+	if err != nil {
+		t.Fatalf("failed to get terminal: %v", err)
+	}
+
+	scr.SetTitle("good\x07title\x1b\\end")
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+
+	if got := mt.GetTitle(); got != "goodtitle\\end" {
+		t.Fatalf("title not sanitized: %q", got)
+	}
+}
+
+func TestShowNotificationStripsOSCControls(t *testing.T) {
+	mt := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})}
+	scr, err := NewTerminfoScreenFromTty(mt)
+	if err != nil {
+		t.Fatalf("failed to get terminal: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+
+	before := mt.Output()
+	scr.ShowNotification("tit\x07le", "bo\x1b\\dy")
+	delta := mt.Output()[len(before):]
+
+	if strings.Contains(delta, "tit\x07le") || strings.Contains(delta, "bo\x1b\\dy") {
+		t.Fatalf("notification payload still contains control characters: %q", delta)
+	}
+	if !strings.Contains(delta, "title") || !strings.Contains(delta, "bo\\dy") {
+		t.Fatalf("notification payload missing sanitized strings: %q", delta)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal titles and desktop notifications now sanitize control characters from user input to prevent injection attacks and ensure stable output. All input strings containing problematic control bytes are automatically filtered, protecting against potential security vulnerabilities while maintaining reliable terminal display and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->