### PR TITLE
feat: Optionally sanitize content before putting to the terminal (fix…

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -42,9 +42,10 @@ func (c *cell) setDirty(dirty bool) {
 //
 // CellBuffer is not thread safe.
 type CellBuffer struct {
-	w     int
-	h     int
-	cells []cell
+	w               int
+	h               int
+	cells           []cell
+	sanitizeContent bool
 }
 
 // Put a single styled grapheme using the given string and style
@@ -52,6 +53,13 @@ type CellBuffer struct {
 // will be displayed, using only the 1 or 2 (depending on width) cells
 // located at x, y. It returns the rest of the string, and the width used.
 func (cb *CellBuffer) Put(x int, y int, str string, style Style) (string, int) {
+	if cb.sanitizeContent {
+		str = stripOSCControlsIfNeeded(str)
+	}
+	return cb.put(x, y, str, style)
+}
+
+func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 	var width int = 0
 	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
 		var cl string

--- a/cell_bench_test.go
+++ b/cell_bench_test.go
@@ -15,25 +15,22 @@
 package tcell
 
 import (
-	"strings"
 	"testing"
 )
 
-var mixedCellStream = strings.Repeat("Hello, 世界 👩‍🚀 e\u0301 ", 8)
-
 func BenchmarkCellBufferPutCurrent(b *testing.B) {
-	benchCellBufferPut(b, "current", func(cb *CellBuffer, x, y int, str string, style Style) (string, int) {
+	benchCellBufferPut(b, "current", false, func(cb *CellBuffer, x, y int, str string, style Style) (string, int) {
 		return cb.Put(x, y, str, style)
 	})
 }
 
-func BenchmarkCellBufferPutStreamCurrent(b *testing.B) {
-	benchCellBufferPutStream(b, "current", func(cb *CellBuffer, x int, y int, str string, style Style) (string, int) {
+func BenchmarkCellBufferPutSanitizedCurrent(b *testing.B) {
+	benchCellBufferPut(b, "sanitized", true, func(cb *CellBuffer, x, y int, str string, style Style) (string, int) {
 		return cb.Put(x, y, str, style)
 	})
 }
 
-func benchCellBufferPut(b *testing.B, name string, put func(*CellBuffer, int, int, string, Style) (string, int)) {
+func benchCellBufferPut(b *testing.B, name string, sanitize bool, put func(*CellBuffer, int, int, string, Style) (string, int)) {
 	cases := []struct {
 		name string
 		str  string
@@ -46,7 +43,7 @@ func benchCellBufferPut(b *testing.B, name string, put func(*CellBuffer, int, in
 
 	for _, tc := range cases {
 		b.Run(name+"/"+tc.name, func(b *testing.B) {
-			cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+			cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8), sanitizeContent: sanitize}
 			style := Style{}
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -56,30 +53,4 @@ func benchCellBufferPut(b *testing.B, name string, put func(*CellBuffer, int, in
 			}
 		})
 	}
-}
-
-func benchCellBufferPutStream(b *testing.B, name string, put func(*CellBuffer, int, int, string, Style) (string, int)) {
-	b.Helper()
-
-	b.Run(name+"/mixed-stream", func(b *testing.B) {
-		cb := &CellBuffer{w: 128, h: 1, cells: make([]cell, 128)}
-		style := Style{}
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			for j := range cb.cells {
-				cb.cells[j] = cell{}
-			}
-			x := 0
-			rest := mixedCellStream
-			for rest != "" && x < cb.w {
-				var width int
-				rest, width = put(cb, x, 0, rest, style)
-				if width == 0 {
-					break
-				}
-				x += width
-			}
-		}
-	})
 }

--- a/cell_test.go
+++ b/cell_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import "testing"
+
+func TestCellBufferPutAndSanitize(t *testing.T) {
+	t.Run("unsanitized", func(t *testing.T) {
+		cb := &CellBuffer{w: 4, h: 1, cells: make([]cell, 4)}
+		rest, width := cb.Put(0, 0, "A\x1bB", StyleDefault)
+		if rest != "\x1bB" {
+			t.Fatalf("unexpected remainder: %q", rest)
+		}
+		if width != 1 {
+			t.Fatalf("unexpected width: %d", width)
+		}
+		if got, _, gotWidth := cb.Get(0, 0); got != "A" || gotWidth != 1 {
+			t.Fatalf("unexpected cell content: %q width=%d", got, gotWidth)
+		}
+	})
+
+	t.Run("sanitized", func(t *testing.T) {
+		cb := &CellBuffer{w: 4, h: 1, cells: make([]cell, 4), sanitizeContent: true}
+		rest, width := cb.Put(0, 0, "A\x1bB", StyleDefault)
+		if rest != "B" {
+			t.Fatalf("unexpected sanitized remainder: %q", rest)
+		}
+		if width != 1 {
+			t.Fatalf("unexpected width: %d", width)
+		}
+		if got, _, gotWidth := cb.Get(0, 0); got != "A" || gotWidth != 1 {
+			t.Fatalf("unexpected sanitized cell content: %q width=%d", got, gotWidth)
+		}
+	})
+}
+
+func TestCellBufferWideAndColorNone(t *testing.T) {
+	cb := &CellBuffer{w: 3, h: 1, cells: make([]cell, 3)}
+
+	base := StyleDefault.Foreground(ColorRed).Background(ColorBlue)
+	cb.Put(0, 0, "a", base)
+	cb.SetDirty(0, 0, false)
+	cb.Put(1, 0, "z", base)
+	cb.SetDirty(1, 0, false)
+
+	reused := Style{fg: ColorNone, bg: ColorNone}
+	rest, width := cb.Put(0, 0, "你", reused)
+	if rest != "" {
+		t.Fatalf("unexpected remainder for wide rune: %q", rest)
+	}
+	if width != 2 {
+		t.Fatalf("unexpected width for wide rune: %d", width)
+	}
+	if !cb.Dirty(0, 0) {
+		t.Fatalf("wide rune should dirty the base cell")
+	}
+	if !cb.Dirty(1, 0) {
+		t.Fatalf("wide rune should dirty the second cell")
+	}
+
+	got, gotStyle, gotWidth := cb.Get(0, 0)
+	if got != "你" || gotWidth != 2 {
+		t.Fatalf("unexpected wide cell content: %q width=%d", got, gotWidth)
+	}
+	if gotStyle.GetForeground() != ColorRed || gotStyle.GetBackground() != ColorBlue {
+		t.Fatalf("ColorNone should preserve existing colors, got fg=%v bg=%v", gotStyle.GetForeground(), gotStyle.GetBackground())
+	}
+}
+
+func TestCellBufferDirtyState(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
+
+	cb.cells[0].setDirty(false)
+	if got := cb.cells[0].lastStr; got != " " {
+		t.Fatalf("setDirty(false) should normalize empty content to space, got %q", got)
+	}
+	if got := cb.cells[0].lastStyle; got != cb.cells[0].currStyle {
+		t.Fatalf("setDirty(false) should copy style")
+	}
+
+	cb.cells[0].setDirty(true)
+	if got := cb.cells[0].lastStr; got != "" {
+		t.Fatalf("setDirty(true) should clear lastStr, got %q", got)
+	}
+
+	cb.Put(0, 0, "x", StyleDefault)
+	cb.SetDirty(0, 0, false)
+	if cb.Dirty(0, 0) {
+		t.Fatalf("clean cell should not be dirty")
+	}
+
+	cb.cells[0].currStyle = cb.cells[0].currStyle.Bold(true)
+	if !cb.Dirty(0, 0) {
+		t.Fatalf("style change should make cell dirty")
+	}
+	cb.SetDirty(0, 0, false)
+	cb.cells[0].currStyle = cb.cells[0].lastStyle
+	cb.cells[0].currStr = "y"
+	if !cb.Dirty(0, 0) {
+		t.Fatalf("content change should make cell dirty")
+	}
+}
+
+func TestCellBufferLockResizeFill(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 2, cells: make([]cell, 4)}
+	cb.Fill('x', StyleDefault)
+	if got, _, _ := cb.Get(1, 1); got != "x" {
+		t.Fatalf("unexpected fill content: %q", got)
+	}
+
+	cb.LockCell(1, 1)
+	if cb.Dirty(1, 1) {
+		t.Fatalf("locked cell should not be dirty")
+	}
+	cb.UnlockCell(1, 1)
+	if !cb.Dirty(1, 1) {
+		t.Fatalf("unlocked cell should be dirty")
+	}
+
+	cb.Put(0, 0, "ab", StyleDefault)
+	cb.Resize(3, 1)
+	if got, _, _ := cb.Get(0, 0); got != "a" {
+		t.Fatalf("resize should preserve content, got %q", got)
+	}
+	if _, _, width := cb.Get(0, 0); width != 1 {
+		t.Fatalf("unexpected width after resize: %d", width)
+	}
+
+	cb.Invalidate()
+	if !cb.Dirty(0, 0) {
+		t.Fatalf("invalidate should mark content dirty")
+	}
+}
+
+func TestCellBufferOutOfRangeAndResizeNoop(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
+
+	if rest, width := cb.Put(-1, 0, "x", StyleDefault); rest != "x" || width != 0 {
+		t.Fatalf("out-of-range put should be a no-op, got rest=%q width=%d", rest, width)
+	}
+
+	cb.Put(0, 0, "x", StyleDefault.Foreground(ColorRed).Background(ColorBlue))
+	cb.SetDirty(0, 0, false)
+
+	if rest, width := cb.Put(0, 0, "", StyleDefault.Foreground(ColorGreen)); rest != "" || width != 0 {
+		t.Fatalf("empty put should be a no-op, got rest=%q width=%d", rest, width)
+	}
+	afterStr, afterStyle, afterWidth := cb.Get(0, 0)
+	if afterStr != " " || afterStyle.GetForeground() != ColorGreen || afterWidth != 1 {
+		t.Fatalf("empty put should clear the cell and apply the new style: got=%q/%v/%d", afterStr, afterStyle, afterWidth)
+	}
+	if got := cb.Dirty(0, 0); !got {
+		t.Fatalf("empty put should mark the cell dirty")
+	}
+
+	cb.LockCell(-1, 0)
+	cb.LockCell(2, 0)
+	cb.UnlockCell(-1, 0)
+	cb.UnlockCell(2, 0)
+
+	cb.Resize(2, 1)
+	if w, h := cb.Size(); w != 2 || h != 1 {
+		t.Fatalf("resize no-op changed size to %dx%d", w, h)
+	}
+}

--- a/screen.go
+++ b/screen.go
@@ -260,7 +260,8 @@ var overrideScreen chan Screen
 var overrideOnce sync.Once
 
 // NewScreen returns a default Screen suitable for the user's terminal environment.
-func NewScreen() (Screen, error) {
+// Any options are passed through to NewTerminfoScreen.
+func NewScreen(opts ...TerminfoScreenOption) (Screen, error) {
 
 	// Allow an application (presumably test code) to inject a replacement default
 	// screen.  This could also be used to create shims for things like nesting screens.
@@ -270,7 +271,7 @@ func NewScreen() (Screen, error) {
 	default:
 	}
 
-	if s, e := NewTerminfoScreen(); s != nil {
+	if s, e := NewTerminfoScreen(opts...); s != nil {
 		return s, nil
 	} else {
 		return nil, e
@@ -383,9 +384,12 @@ func (b *baseScreen) PutStrStyled(x int, y int, str string, style Style) {
 	cells := b.GetCells()
 	b.Lock()
 	cols, rows := cells.Size()
+	if cells.sanitizeContent {
+		str = stripOSCControlsIfNeeded(str)
+	}
 	width := 0
 	for str != "" && x < cols && y < rows {
-		str, width = cells.Put(x, y, str, style)
+		str, width = cells.put(x, y, str, style)
 		if width == 0 {
 			break
 		}

--- a/style.go
+++ b/style.go
@@ -69,6 +69,18 @@ func stripOSCControls(s string) string {
 	return b.String()
 }
 
+// stripOSCControlsIfNeeded returns the original string when it contains no
+// control bytes and only allocates when stripping is required.
+func stripOSCControlsIfNeeded(s string) string {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+			return stripOSCControls(s)
+		}
+	}
+	return s
+}
+
 // StyleDefault represents a default style, based upon the context.
 // It is the zero value.
 var StyleDefault Style
@@ -228,7 +240,7 @@ func (s Style) GetAttributes() AttrMask {
 func (s Style) Url(url string) Style {
 
 	s2 := s
-	s2.url = &urlInfo{url: stripOSCControls(url)}
+	s2.url = &urlInfo{url: stripOSCControlsIfNeeded(url)}
 	if s.url != nil {
 		s2.url.id = s.url.id
 	}
@@ -242,7 +254,7 @@ func (s Style) Url(url string) Style {
 func (s Style) UrlId(id string) Style {
 	s2 := s
 	s2.url = &urlInfo{
-		id: "id=" + stripOSCControls(id),
+		id: "id=" + stripOSCControlsIfNeeded(id),
 	}
 	if s.url != nil {
 		s2.url.url = s.url.url

--- a/style_test.go
+++ b/style_test.go
@@ -136,3 +136,13 @@ func TestStyleUrlStripsOSCControls(t *testing.T) {
 		t.Fatalf("unexpected sanitized UTF-8 url: %q", url)
 	}
 }
+
+func TestStripOSCControlsIfNeeded(t *testing.T) {
+	if got := stripOSCControlsIfNeeded("hello world"); got != "hello world" {
+		t.Fatalf("clean string changed: %q", got)
+	}
+
+	if got := stripOSCControlsIfNeeded("he\x07llo\x1bworld"); got != "helloworld" {
+		t.Fatalf("dirty string not stripped correctly: %q", got)
+	}
+}

--- a/style_test.go
+++ b/style_test.go
@@ -146,3 +146,46 @@ func TestStripOSCControlsIfNeeded(t *testing.T) {
 		t.Fatalf("dirty string not stripped correctly: %q", got)
 	}
 }
+
+func TestStripOSCControlsInvalidUTF8(t *testing.T) {
+	got := stripOSCControls(string([]byte{0xff, 0x1b, 0xfe, 'A'}))
+	if got != string([]byte{0xff, 0xfe, 'A'}) {
+		t.Fatalf("unexpected invalid-UTF8 sanitization result: %q", got)
+	}
+}
+
+func TestStyleHelperMethods(t *testing.T) {
+	s := StyleDefault.
+		Dim(true).
+		StrikeThrough(true).
+		Underline(true)
+	if !s.HasDim() {
+		t.Fatalf("Dim(true) should set dim")
+	}
+	if !s.HasStrikeThrough() {
+		t.Fatalf("StrikeThrough(true) should set strike-through")
+	}
+	if !s.HasUnderline() {
+		t.Fatalf("Underline(true) should set underline")
+	}
+
+	s = s.Underline(false)
+	if s.HasUnderline() {
+		t.Fatalf("Underline(false) should clear underline")
+	}
+
+	s = s.Attributes(AttrBold | AttrItalic)
+	if got := s.GetAttributes(); got != AttrBold|AttrItalic {
+		t.Fatalf("unexpected attributes: %v", got)
+	}
+}
+
+func TestUnderlineBadTypePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Underline should panic on unsupported parameter type")
+		}
+	}()
+
+	_ = StyleDefault.Underline("bad")
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -83,6 +83,15 @@ func (o OptAltScreen) apply(t *tScreen) {
 	t.altScreen = bool(o)
 }
 
+// OptSanitizeContent enables stripping control characters from content passed
+// to Put and PutStr. This is safer, but a little slower than leaving content
+// unsanitized.
+type OptSanitizeContent bool
+
+func (o OptSanitizeContent) apply(t *tScreen) {
+	t.cells.sanitizeContent = bool(o)
+}
+
 // Some terminal escapes that are basically universal.
 // We would really like to be able to use private mode queries for some of
 // these but generally we've found that support for queries is not always present,
@@ -1401,7 +1410,7 @@ func (t *tScreen) GetCells() *CellBuffer {
 
 func (t *tScreen) SetTitle(title string) {
 	t.Lock()
-	t.title = stripOSCControls(title)
+	t.title = stripOSCControlsIfNeeded(title)
 	if t.setTitle != "" && t.running {
 		t.Printf(t.setTitle, t.title)
 	}
@@ -1432,7 +1441,7 @@ func (t *tScreen) HasClipboard() bool {
 
 func (t *tScreen) ShowNotification(title string, body string) {
 	t.Lock()
-	t.Printf(t.notifyDesktop, stripOSCControls(title), stripOSCControls(body))
+	t.Printf(t.notifyDesktop, stripOSCControlsIfNeeded(title), stripOSCControlsIfNeeded(body))
 	t.Unlock()
 }
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -112,6 +112,80 @@ func TestOptAltScreenDefault(t *testing.T) {
 	}
 }
 
+func TestOptSanitizeContent(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+		scr, err := NewTerminfoScreenFromTty(mt)
+		if err != nil {
+			t.Fatalf("failed to get screen: %v", err)
+		}
+		if err := scr.Init(); err != nil {
+			t.Fatalf("failed to initialize screen: %v", err)
+		}
+		defer scr.Fini()
+
+		scr.PutStr(0, 0, "\x1bA\x07B")
+		if got, _, _ := scr.Get(0, 0); !strings.Contains(got, "\x1b") {
+			t.Fatalf("expected control bytes to remain when sanitizer is disabled, got %q", got)
+		}
+		if got, _, _ := scr.Get(1, 0); !strings.Contains(got, "\x07") {
+			t.Fatalf("expected control bytes to remain when sanitizer is disabled, got %q", got)
+		}
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+		scr, err := NewTerminfoScreenFromTty(mt, OptSanitizeContent(true))
+		if err != nil {
+			t.Fatalf("failed to get screen: %v", err)
+		}
+		if err := scr.Init(); err != nil {
+			t.Fatalf("failed to initialize screen: %v", err)
+		}
+		defer scr.Fini()
+
+		scr.PutStr(0, 0, "\x1bA\x07B")
+		if got, _, _ := scr.Get(0, 0); got != "A" {
+			t.Fatalf("unexpected sanitized cell content at 0,0: %q", got)
+		}
+		if got, _, _ := scr.Get(1, 0); got != "B" {
+			t.Fatalf("unexpected sanitized cell content at 1,0: %q", got)
+		}
+	})
+}
+
+func TestNewScreenSanitizeContentOption(t *testing.T) {
+	scr, err := NewScreen(OptSanitizeContent(true))
+	if err != nil {
+		t.Skipf("failed to get screen: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Skipf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+
+	scr.PutStr(0, 0, "\x1bA\x07B")
+	if got, _, _ := scr.Get(0, 0); got != "A" {
+		t.Fatalf("unexpected sanitized cell content at 0,0: %q", got)
+	}
+	if got, _, _ := scr.Get(1, 0); got != "B" {
+		t.Fatalf("unexpected sanitized cell content at 1,0: %q", got)
+	}
+}
+
+func TestNewScreenShimScreen(t *testing.T) {
+	_, scr := NewMockScreen(t)
+	ShimScreen(scr)
+
+	got, err := NewScreen()
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if got != scr {
+		t.Fatalf("unexpected shimmed screen: got %T, want %T", got, scr)
+	}
+}
+
 func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
 	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
 	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))

--- a/wscreen.go
+++ b/wscreen.go
@@ -27,10 +27,14 @@ import (
 	"github.com/gdamore/tcell/v3/tty"
 )
 
-// NewTerminfoScreen gets a screen.  The options are ignored for this platform.
-func NewTerminfoScreen(_ ...TerminfoScreenOption) (Screen, error) {
+// NewTerminfoScreen gets a screen.  Most options are ignored for this platform,
+// but shared CellBuffer options such as content sanitization are honored.
+func NewTerminfoScreen(opts ...TerminfoScreenOption) (Screen, error) {
 	t := &wScreen{}
 	t.fallback = make(map[rune]string)
+	for _, opt := range opts {
+		opt.apply(t)
+	}
 
 	return &baseScreen{screenImpl: t}, nil
 }
@@ -46,10 +50,14 @@ type TerminfoScreenOption interface{ apply(*wScreen) }
 type OptColors int
 type OptTerm string
 type OptAltScreen bool
+type OptSanitizeContent bool
 
 func (OptColors) apply(*wScreen)    {}
 func (OptTerm) apply(*wScreen)      {}
 func (OptAltScreen) apply(*wScreen) {}
+func (o OptSanitizeContent) apply(w *wScreen) {
+	w.cells.sanitizeContent = bool(o)
+}
 
 type wScreen struct {
 	w, h  int


### PR DESCRIPTION
…es #1067)

The security model for tcell is that the application should not give us content that is entirely untrustworthy (meaning the application should perform any data sanitization it needs), but there may be some applications that would prefer that tcell do this for them.

This comes at a performance cost for every update to the screen, so its not something that will ever be enabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime option to enable content sanitization; screen constructors accept options to turn it on.

* **Bug Fixes / Behavior**
  * Control/OSC sequences are now sanitized only when the option is enabled; titles, notifications, and cell writes respect this setting.
  * Sanitization avoids unnecessary work when no control bytes are present.

* **Tests**
  * New unit tests cover sanitization, cell behavior, and style helpers.

* **Performance**
  * Benchmarks updated to compare sanitized vs. unsanitized paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->