### PR TITLE
fix: complete sanitation

### DIFF
--- a/style.go
+++ b/style.go
@@ -59,7 +59,8 @@ func stripOSCControls(s string) string {
 			i++
 			continue
 		}
-		if r <= 0x1f || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+		if r <= 0x1f || r == 0x7f || (r >= 0x80 && r <= 0x9f) ||
+			(r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069) {
 			i += size
 			continue
 		}

--- a/style_test.go
+++ b/style_test.go
@@ -135,4 +135,22 @@ func TestStyleUrlStripsOSCControls(t *testing.T) {
 	if url != "http://example.com/\u3042" {
 		t.Fatalf("unexpected sanitized UTF-8 url: %q", url)
 	}
+
+	s = StyleDefault.
+		Url("http://exa\u202emple.com/\u2068path").
+		UrlId("id\u202a\u202b\u202c\u202d\u2066\u2067\u2068\u2069end")
+
+	id, url = s.GetUrl()
+	combined = id + url
+	for _, r := range combined {
+		if (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069) {
+			t.Fatalf("BiDi formatting characters survived sanitization: id=%q url=%q", id, url)
+		}
+	}
+	if id != "idend" {
+		t.Fatalf("unexpected sanitized BiDi id: %q", id)
+	}
+	if url != "http://example.com/path" {
+		t.Fatalf("unexpected sanitized BiDi url: %q", url)
+	}
 }

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -225,7 +225,7 @@ func TestSetTitleStripsOSCControls(t *testing.T) {
 		t.Fatalf("failed to get terminal: %v", err)
 	}
 
-	scr.SetTitle("good\x07title\x1b\\end")
+	scr.SetTitle("good\x07ti\u202etle\u2068\x1b\\end")
 	if err := scr.Init(); err != nil {
 		t.Fatalf("failed to initialize screen: %v", err)
 	}
@@ -248,11 +248,14 @@ func TestShowNotificationStripsOSCControls(t *testing.T) {
 	defer scr.Fini()
 
 	before := mt.Output()
-	scr.ShowNotification("tit\x07le", "bo\x1b\\dy")
+	scr.ShowNotification("tit\x07le\u202d", "\u2066bo\x1b\\dy")
 	delta := mt.Output()[len(before):]
 
 	if strings.Contains(delta, "tit\x07le") || strings.Contains(delta, "bo\x1b\\dy") {
 		t.Fatalf("notification payload still contains control characters: %q", delta)
+	}
+	if strings.ContainsAny(delta, "\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069") {
+		t.Fatalf("notification payload still contains BiDi formatting: %q", delta)
 	}
 	if !strings.Contains(delta, "title") || !strings.Contains(delta, "bo\\dy") {
 		t.Fatalf("notification payload missing sanitized strings: %q", delta)


### PR DESCRIPTION
Extends stripOSCControls to also cover Unicode BiDi sequences U+202A-U+202E and U+2066-U+2069 which can be used for spoofing in some terminals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced text sanitization to remove additional Unicode control and formatting characters that could interfere with proper text display or create security concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->