### PR TITLE
feat: Add reporting of keyboard protocol (fixes #967)

### DIFF
--- a/key.go
+++ b/key.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The TCell Authors
+// Copyright 2026 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,6 +73,19 @@ func (ev *EventKey) Key() Key {
 func (ev *EventKey) Modifiers() ModMask {
 	return ev.mod
 }
+
+// KeyProtocol identifies the keyboard reporting protocol that the terminal
+// is currently using.  More capable protocols allow disambiguating modifier
+// combinations, distinguishing key release events, etc.
+type KeyProtocol int
+
+// These are the keyboard protocols that tcell can report.
+const (
+	LegacyKeyboard KeyProtocol = iota // basic VT100 style reports
+	KittyKeyboard                     // kitty supports events, unambiguous keys modulo left/right modifiers
+	Win32Keyboard                     // win32 supports the full feature set
+	XTermKeyboard                     // xterm modify other keys, disambiguation only, no release events
+)
 
 // KeyNames holds the written names of special keys. Useful to echo back a key
 // name, or to look up a key from a string value.

--- a/screen.go
+++ b/screen.go
@@ -249,6 +249,9 @@ type Screen interface {
 	// supports it.  Right now only terminals supporting OSC 777 support this.
 	ShowNotification(title string, body string)
 
+	// KeyboardProtocol returns the keyboard protocol currently in use.
+	KeyboardProtocol() KeyProtocol
+
 	// Terminal returns the terminal name and version if known.  If either of these
 	// are unknown, then empty strings are returned in their place.  This is intended
 	// to facilitate debug, and also applications that wish to enable very specific
@@ -345,6 +348,7 @@ type screenImpl interface {
 	GetClipboard()
 	HasClipboard() bool
 	ShowNotification(string, string)
+	KeyboardProtocol() KeyProtocol
 	Terminal() (string, string)
 
 	// Following methods are not part of the Screen api, but are used for interaction with

--- a/tscreen.go
+++ b/tscreen.go
@@ -1441,3 +1441,18 @@ func (t *tScreen) Terminal() (string, string) {
 	defer t.Unlock()
 	return t.termName, t.termVers
 }
+
+func (t *tScreen) KeyboardProtocol() KeyProtocol {
+	t.Lock()
+	defer t.Unlock()
+	if t.haveWin32Kbd {
+		return Win32Keyboard
+	}
+	if t.haveKittyKbd {
+		return KittyKeyboard
+	}
+	if t.haveXTermKbd {
+		return XTermKeyboard
+	}
+	return LegacyKeyboard
+}

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The TCell Authors
+// Copyright 2026 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,6 +148,138 @@ func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
 		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
 			t.Fatalf("control characters survived in emitted URL payload: %q", link)
 		}
+	}
+}
+
+func TestKeyboardProtocol(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*tScreen)
+		want  KeyProtocol
+	}{
+		{
+			name: "Legacy",
+			want: LegacyKeyboard,
+		},
+		{
+			name: "Xterm",
+			setup: func(s *tScreen) {
+				s.haveXTermKbd = true
+			},
+			want: XTermKeyboard,
+		},
+		{
+			name: "Kitty",
+			setup: func(s *tScreen) {
+				s.haveKittyKbd = true
+			},
+			want: KittyKeyboard,
+		},
+		{
+			name: "Win32",
+			setup: func(s *tScreen) {
+				s.haveWin32Kbd = true
+			},
+			want: Win32Keyboard,
+		},
+		{
+			name: "KittyBeforeXterm",
+			setup: func(s *tScreen) {
+				s.haveKittyKbd = true
+				s.haveXTermKbd = true
+			},
+			want: KittyKeyboard,
+		},
+		{
+			name: "Win32BeforeKittyAndXterm",
+			setup: func(s *tScreen) {
+				s.haveWin32Kbd = true
+				s.haveKittyKbd = true
+				s.haveXTermKbd = true
+			},
+			want: Win32Keyboard,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &tScreen{}
+			if tt.setup != nil {
+				tt.setup(s)
+			}
+			if got := s.KeyboardProtocol(); got != tt.want {
+				t.Fatalf("KeyboardProtocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessInitQKeyboardProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		evs  []Event
+		want KeyProtocol
+	}{
+		{
+			name: "Legacy",
+			want: LegacyKeyboard,
+		},
+		{
+			name: "Xterm",
+			evs:  []Event{&eventXTermKbdMode{Mode: XtermKbdModeExt}},
+			want: XTermKeyboard,
+		},
+		{
+			name: "Kitty",
+			evs:  []Event{&eventKittyKbdMode{Mode: KittyKbdModeBase}},
+			want: KittyKeyboard,
+		},
+		{
+			name: "Win32",
+			evs:  []Event{&eventPrivateMode{Mode: vt.PmWin32Input, Status: vt.ModeOff}},
+			want: Win32Keyboard,
+		},
+		{
+			name: "KittyPreferredOverXterm",
+			evs: []Event{
+				&eventXTermKbdMode{Mode: XtermKbdModeExt},
+				&eventKittyKbdMode{Mode: KittyKbdModeBase},
+			},
+			want: KittyKeyboard,
+		},
+		{
+			name: "Win32PreferredOverKittyAndXterm",
+			evs: []Event{
+				&eventXTermKbdMode{Mode: XtermKbdModeExt},
+				&eventKittyKbdMode{Mode: KittyKbdModeBase},
+				&eventPrivateMode{Mode: vt.PmWin32Input, Status: vt.ModeOff},
+			},
+			want: Win32Keyboard,
+		},
+		{
+			name: "UnchangeableWin32IsIgnored",
+			evs:  []Event{&eventPrivateMode{Mode: vt.PmWin32Input, Status: vt.ModeNA}},
+			want: LegacyKeyboard,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &tScreen{
+				initQ: make(chan Event, len(tt.evs)+1),
+			}
+			for _, ev := range tt.evs {
+				s.initQ <- ev
+			}
+			s.initQ <- &eventPrimaryAttributes{}
+			s.Lock()
+			s.processInitQ()
+			s.Unlock()
+
+			if got := s.KeyboardProtocol(); got != tt.want {
+				t.Fatalf("KeyboardProtocol() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/wscreen.go
+++ b/wscreen.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The TCell Authors
+// Copyright 2026 The TCell Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -624,6 +624,10 @@ var curStyleClasses = map[CursorStyle]string{
 	CursorStyleSteadyUnderline:   "cursor-steady-underline",
 	CursorStyleBlinkingBar:       "cursor-blinking-bar",
 	CursorStyleSteadyBar:         "cursor-steady-bar",
+}
+
+func (*wScreen) KeyboardProtocol() KeyProtocol {
+	return XTermKeyboard // not really but we report keys unambiguously
 }
 
 func (*wScreen) Terminal() (string, string) { return "Tcell-WebASM", "" }


### PR DESCRIPTION
This is just the first step towards enabling access to advanced keyboard protocols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can detect and report the active keyboard reporting protocol (Legacy, Kitty, Win32, xterm).
  * Screen API extended so callers can query the current keyboard protocol; different screen backends report appropriate defaults and precedence.

* **Tests**
  * Added tests covering protocol detection, precedence, fallback behavior, and init-time mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->