### PR TITLE
C1 handling improvements

### DIFF
--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -220,10 +220,25 @@ type Cell struct {
 	W int    // Display width (0, 1, or 2)
 }
 
+// EmulatorOpt configures an Emulator.
+type EmulatorOpt interface {
+	setEmulatorOpt(*emulator)
+}
+
+// EmulatorOpt8BitControls enables parsing of C1 controls, such as CSI and OSC,
+// when they are presented as raw 8-bit bytes or UTF-8 encoded C1 controls.
+// The default is to only accept the 7-bit ESC-prefixed forms.
+type EmulatorOpt8BitControls struct{}
+
+func (EmulatorOpt8BitControls) setEmulatorOpt(em *emulator) {
+	em.c1Allowed = true
+	em.c1Enabled = true
+}
+
 // NewEmulator creates an emulator instance on top of the given backend.
 // The input is relative to the emulator, so it receives data from the host,
 // whereas the emulator sends data to the application through the output.
-func NewEmulator(be Backend) Emulator {
+func NewEmulator(be Backend, opts ...EmulatorOpt) Emulator {
 	stopQ := make(chan bool)
 	defStyle := BaseStyle.WithFg(color.Silver).WithBg(color.Black)
 	em := &emulator{
@@ -248,6 +263,9 @@ func NewEmulator(be Backend) Emulator {
 			PmWin32Input:      ModeOff,
 		},
 		mouseReports: MouseDisabled,
+	}
+	for _, opt := range opts {
+		opt.setEmulatorOpt(em)
 	}
 	if _, ok := be.(Resizer); ok {
 		em.localModes[PmResizeReports] = ModeOff
@@ -297,7 +315,9 @@ type emulator struct {
 	pos            Coord
 	buffering      uint         // reference count - number of (re-entrant) buffering calls
 	autoWrap       bool         // next character will wrap (auto margin, deferred until char emitted)
-	sevenOnly      bool         // only allow 7-bit escapes (needed for KOI8, ShiftJIS, etc.)
+	c1Allowed      bool         // allow C1 controls in raw 8-bit and UTF-8 encodings
+	c1Enabled      bool         // C1 controls are currently enabled
+	c1Prefix       bool         // string parser has seen the first byte of a UTF-8 encoded C1 control
 	appKeyPad      bool         // use application key pad keys?
 	name           string       // name of this emulator (used for extended attributes)
 	vers           string       // version string of this emulator (used for extended attributes)
@@ -372,13 +392,13 @@ func (em *emulator) inbInit(b byte) {
 		return
 	}
 
-	// For 8-bit encodings, we treat these as Fe sequences.
-	// Basically the same as ESC followed by (b - 0x40).
-	// TODO: condition this so that we do not do this if
-	// the encoding cannot support it (UTF, 8859, and EUC encodings
-	// are all fine here, but others like ShiftJIS or KOI8 might not be).
-	if b >= 0x80 && b <= 0x9F && !em.sevenOnly {
-		em.inbEsc(b - 0x40)
+	// For C1 controls, the raw 8-bit form is the same as ESC followed by
+	// (b - 0x40). This is disabled by default because modern protocols
+	// generally treat these forms as insecure.
+	if b >= 0x80 && b <= 0x9f {
+		if em.c1Enabled {
+			em.inbEsc(b - 0x40)
+		}
 		return
 	}
 
@@ -529,6 +549,12 @@ func (em *emulator) inbNF(b byte) {
 		// case "(Q", "(9": // TODO: select G0 as French Canadian
 		// case "(R", "(f": // TODO: select G0 as French
 		// case "(Y": // TODO: select G0 as Italian
+	case " F": // S7C1T - send/use 7-bit C1 controls
+		em.c1Enabled = false
+	case " G": // S8C1T - send/use 8-bit C1 controls
+		if em.c1Allowed {
+			em.c1Enabled = true
+		}
 	}
 }
 
@@ -550,8 +576,17 @@ func (em *emulator) inbCSI(b byte) {
 
 // inbOSC handles bytes that are part of on OSC sequences (operating system command).
 func (em *emulator) inbOSC(b byte) {
+	if em.inbStringC1(b, em.processOSC) {
+		return
+	}
+
 	switch b {
-	case 0x9c, 0x07:
+	case 0x9c:
+		if em.c1Enabled {
+			em.inb = em.inbInit
+			em.processOSC()
+		}
+	case 0x07:
 		em.inb = em.inbInit
 		em.processOSC()
 	case '\\':
@@ -569,8 +604,16 @@ func (em *emulator) inbOSC(b byte) {
 
 // inbStr handles PM, SOS, and any other string we want to consume and discard.
 func (em *emulator) inbStr(b byte) {
+	if em.inbStringC1(b, nil) {
+		return
+	}
+
 	switch b {
-	case 0x9c, 0x07:
+	case 0x9c:
+		if em.c1Enabled {
+			em.inb = em.inbInit
+		}
+	case 0x07:
 		em.inb = em.inbInit
 	case '\\':
 		if buf := em.inBuf.Bytes(); len(buf) > 0 && buf[len(buf)-1] == 0x1b {
@@ -584,6 +627,27 @@ func (em *emulator) inbStr(b byte) {
 	}
 }
 
+func (em *emulator) inbStringC1(b byte, done func()) bool {
+	if em.c1Prefix {
+		em.c1Prefix = false
+		if b >= 0x80 && b <= 0x9f {
+			if em.c1Enabled && b == 0x9c {
+				em.inb = em.inbInit
+				if done != nil {
+					done()
+				}
+			}
+			return true
+		}
+		em.inBuf.WriteByte(0xc2)
+	}
+	if b == 0xc2 {
+		em.c1Prefix = true
+		return true
+	}
+	return false
+}
+
 // inbUTF handles continuation bytes for UTF-8 sequences.
 func (em *emulator) inbUTF(b byte) {
 	if b&0xC0 == 0x80 {
@@ -595,7 +659,13 @@ func (em *emulator) inbUTF(b byte) {
 			if err != nil {
 				em.beep()
 			} else {
-				em.putRune(r)
+				if r >= 0x80 && r <= 0x9f {
+					if em.c1Enabled {
+						em.inbEsc(byte(r) - 0x40)
+					}
+				} else {
+					em.putRune(r)
+				}
 			}
 		}
 	} else {

--- a/vt/key.go
+++ b/vt/key.go
@@ -15,7 +15,7 @@
 package vt
 
 // BaseKey is the Kitty protocol base key. These are kitty's representation of a scan code.
-// As the Kitty protocol is likely the extended keyboard protocol we care about, we use
+// As the Kitty protocol is likely the extended keyboard protocol we care most about, we use
 // this as the primary reporting mechanism. (It also helps that this may provide an easier
 // fallback for implementations that don't have raw scan codes and are willing to assume an
 // ANSI layout.)
@@ -198,7 +198,7 @@ func (k Key) ScanCode() ScanCode {
 }
 
 // WinVK represents a windows virtual key code.
-// These are similar to base keys, but a multiple scanned key codes
+// These are similar to base keys, but multiple scanned key codes
 // may result in the same virtual key.  This can also be sensitive to
 // the keyboard layout.
 type WinVK rune
@@ -346,7 +346,7 @@ const (
 
 var baseKeys map[Key]BaseKey
 
-// KittyBase returns the corresponding Kitty "base" key for the given USB cod.
+// KittyBase returns the corresponding Kitty "base" key for the given USB code.
 // If no corresponding value can be found, then zero is returned.  Note that
 // some keys (such as F1) are valid, and recognized by Kitty, but do not use the
 // base key encoding because they use another reporting format.
@@ -462,15 +462,16 @@ func init() {
 		KeyRAlt:         57449,
 		KeyRMeta:        57450,
 
-		// KeyHiragana:   0, // TBD
-		// KeyConvert:    0, // TBD
-		// KeyNonConvert: 0, // TD
+		// KeyHiragana:   0, // Later
+		// KeyConvert:    0, // Later
+		// KeyNonConvert: 0, // Later
 
 		// Windows uses a bunch of HID usages from
 		// the consumer page (0x0c) for media playback, and
 		// other applications. We just ignore them.
 	}
 
+	// Scan codes used by Windows.
 	scanCodes = map[Key]ScanCode{
 		KeyA:            0x1e,
 		KeyB:            0x30,

--- a/vt/mock.go
+++ b/vt/mock.go
@@ -247,13 +247,16 @@ func NewMockTerm(opts ...MockOpt) MockTerm {
 	mt := &mockTerm{}
 	mt.mb = NewMockBackend(opts...)
 	var be MockBackend = mt.mb
+	emOpts := []EmulatorOpt{}
 	for _, o := range opts {
 		switch o.(type) {
 		case MockOptNoBlit:
 			be = &noMockBlit{be, struct{}{}}
+		case MockOpt8BitControls:
+			emOpts = append(emOpts, EmulatorOpt8BitControls{})
 		}
 	}
-	mt.em = NewEmulator(be)
+	mt.em = NewEmulator(be, emOpts...)
 	mt.em.SetId("TCellMock", "1.0")
 	mt.ks = &KeyboardState{}
 	return mt
@@ -643,6 +646,12 @@ func (o MockOptColors) SetMockOpt(mb *mockBackend) { mb.colors = int(o) }
 type MockOptNoBlit struct{}
 
 func (MockOptNoBlit) SetMockOpt(mb *mockBackend) {}
+
+// MockOpt8BitControls enables raw 8-bit and UTF-8 encoded C1 controls in the
+// emulator. The default is to accept only 7-bit ESC-prefixed controls.
+type MockOpt8BitControls struct{}
+
+func (MockOpt8BitControls) SetMockOpt(mb *mockBackend) {}
 
 // NewMockBackend returns a MockBackend modified by the given options.
 // The default is a fully featured 256-color backend with initial size 80x24.

--- a/vt/tests/mock_test.go
+++ b/vt/tests/mock_test.go
@@ -771,11 +771,88 @@ func TestTitles(t *testing.T) {
 		t.Errorf("wrong title: %q", s)
 	}
 
-	// try using 8-bit sequence
+	// 8-bit C1 controls are disabled by default.
+	WriteF(t, term, "\x9d2;Eight Bits\x9c")
+	if s := term.GetTitle(); s != "Bell Ring" {
+		t.Errorf("wrong title: %q", s)
+	}
+
+	// ESC SP G cannot enable 8-bit C1 controls unless the emulator permits them.
+	WriteF(t, term, "\x1b G\x9d2;Eight Bits\x9c")
+	if s := term.GetTitle(); s != "Bell Ring" {
+		t.Errorf("wrong title: %q", s)
+	}
+}
+
+func Test8BitControls(t *testing.T) {
+	term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24}, vt.MockOpt8BitControls{})
+	defer MustClose(t, term)
+	MustStart(t, term)
+
 	WriteF(t, term, "\x9d2;Eight Bits\x9c")
 	if s := term.GetTitle(); s != "Eight Bits" {
 		t.Errorf("wrong title: %q", s)
 	}
+
+	WriteF(t, term, "\x1b F\x9d2;Disabled\x9c")
+	if s := term.GetTitle(); s != "Eight Bits" {
+		t.Errorf("wrong title: %q", s)
+	}
+
+	WriteF(t, term, "\x1b G\xc2\x9d2;UTF-8 Eight Bits\xc2\x9c")
+	if s := term.GetTitle(); s != "UTF-8 Eight Bits" {
+		t.Errorf("wrong title: %q", s)
+	}
+
+	WriteF(t, term, "\xc2\x9b2;3H")
+	CheckPos(t, term, 2, 1)
+
+	WriteF(t, term, "\x1b F\x1b[H\xc2\x9b3;4H")
+	CheckPos(t, term, 4, 0)
+
+	WriteF(t, term, "\x1b G\x9b4;5H")
+	CheckPos(t, term, 4, 3)
+}
+
+func Test8BitControlsInString(t *testing.T) {
+	t.Run("DefaultDisabled", func(t *testing.T) {
+		term := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 1})
+		defer MustClose(t, term)
+		MustStart(t, term)
+
+		WriteF(t, term, "\x1bPdiscard\x9cA\x07B")
+		CheckContent(t, term, 0, 0, "B")
+		CheckContent(t, term, 1, 0, "")
+
+		WriteF(t, term, "\x1b[H\x1bPdiscard\xc2\x9cC\x07D")
+		CheckContent(t, term, 0, 0, "D")
+		CheckContent(t, term, 1, 0, "")
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		term := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 1}, vt.MockOpt8BitControls{})
+		defer MustClose(t, term)
+		MustStart(t, term)
+
+		WriteF(t, term, "\x1bPdiscard\x9cA")
+		CheckContent(t, term, 0, 0, "A")
+
+		WriteF(t, term, "\x1b[H\x1bPdiscard\xc2\x9cB")
+		CheckContent(t, term, 0, 0, "B")
+	})
+
+	t.Run("RuntimeDisabled", func(t *testing.T) {
+		term := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 1}, vt.MockOpt8BitControls{})
+		defer MustClose(t, term)
+		MustStart(t, term)
+
+		WriteF(t, term, "\x1b F\x1bPdiscard\x9cA\x07B")
+		CheckContent(t, term, 0, 0, "B")
+		CheckContent(t, term, 1, 0, "")
+
+		WriteF(t, term, "\x1b G\x1b[H\x1bPdiscard\xc2\x9cC")
+		CheckContent(t, term, 0, 0, "C")
+	})
 }
 
 // TestResize tests resizing the terminal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional support for raw 8-bit C1 control sequences, opt-in while preserving default 7-bit ESC-prefixed behavior
  * Runtime toggles to enable/disable C1 handling (affects how control bytes are interpreted)

* **Behavior Changes**
  * C1 controls now affect string/OSC termination and cursor/title handling only when C1 is enabled

* **Tests**
  * Added tests covering enabled/disabled C1 behavior, in-string parsing, and cursor/title effects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->