### PR TITLE
feat(keys): Add support for advanced key reporting

### DIFF
--- a/_demos/mouse.go
+++ b/_demos/mouse.go
@@ -32,6 +32,10 @@ import (
 
 var defStyle tcell.Style
 
+func isCtrlRune(ev *tcell.EventKey, r string) bool {
+	return ev.Key() == tcell.KeyRune && ev.Str() == r && ev.Modifiers()&tcell.ModCtrl != 0
+}
+
 func drawBox(s tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, r rune) {
 	rs := string(r)
 
@@ -98,7 +102,7 @@ func main() {
 		}
 	}
 
-	s, e := tcell.NewScreen()
+	s, e := tcell.NewScreen(tcell.OptAdvancedKeys(true))
 	if e != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", e)
 		os.Exit(1)
@@ -126,6 +130,8 @@ func main() {
 	termFmt := "Term: %s (%s)"
 	style := tcell.StyleDefault.
 		Foreground(color.MidnightBlue).Background(color.LightCoral)
+	keyDownStyle := style.Foreground(color.Green)
+	keyUpStyle := style
 
 	mx, my := -1, -1
 	ox, oy := -1, -1
@@ -140,13 +146,15 @@ func main() {
 	ecnt := 0
 	pasting := false
 	focus := true // assume we are focused when we start
+	keyStyle := keyUpStyle
 
 	for {
 		drawBox(s, 1, 1, 42, 9, style, ' ')
 		s.PutStrStyled(2, 2, "Press Ctrl-Q to Quit, C to clear.", style)
 		s.PutStrStyled(2, 3, fmt.Sprintf(posfmt, mx, my), style)
 		s.PutStrStyled(2, 4, fmt.Sprintf(btnfmt, bstr), style)
-		s.PutStrStyled(2, 5, fmt.Sprintf(keyfmt, lks), style)
+		s.PutStrStyled(2, 5, fmt.Sprintf(keyfmt, ""), style)
+		s.PutStrStyled(8, 5, lks, keyStyle)
 
 		ps := pstr
 		if len(ps) > 26 {
@@ -182,13 +190,24 @@ func main() {
 			s.Sync()
 			s.Put(w-1, h-1, "R", st)
 		case *tcell.EventKey:
+			s.Put(w-2, h-2, ev.Str(), st)
+			if !ev.Pressed() {
+				pstr = ""
+				lks = ev.Name()
+				keyStyle = keyUpStyle
+				for x := range w - 1 {
+					s.Put(x, h-1, " ", tcell.StyleDefault)
+				}
+				s.Put(w-1, h-1, "U", st)
+				continue
+			}
+			keyStyle = keyDownStyle
 			if ev.Name() == lkey {
 				kcnt++
 			} else {
 				lkey = ev.Name()
 				kcnt = 1
 			}
-			s.Put(w-2, h-2, ev.Str(), st)
 			if pasting {
 				s.Put(w-1, h-1, "P", st)
 				if ev.Key() == tcell.KeyRune {
@@ -207,12 +226,12 @@ func main() {
 					s.Fini()
 					os.Exit(0)
 				}
-			} else if ev.Key() == tcell.KeyCtrlL {
+			} else if ev.Key() == tcell.KeyCtrlL || isCtrlRune(ev, "l") {
 				s.Sync()
-			} else if ev.Key() == tcell.KeyCtrlQ {
+			} else if ev.Key() == tcell.KeyCtrlQ || isCtrlRune(ev, "q") {
 				s.Fini()
 				os.Exit(0)
-			} else if ev.Key() == tcell.KeyCtrlZ {
+			} else if ev.Key() == tcell.KeyCtrlZ || isCtrlRune(ev, "z") {
 				// CtrlZ doesn't really suspend the process, but we use it to execute a subshell.
 				if err := s.Suspend(); err == nil {
 					fmt.Printf("Executing shell (%s -l)...\n", shell)

--- a/input.go
+++ b/input.go
@@ -84,6 +84,28 @@ type inputParser struct {
 	keyTime   time.Time    // time of last key press / byte ingested
 	nested    *inputParser // for buggy win32-input-mode implementations
 	surrogate rune         // high surrogate pair seen (for Win32 input mode)
+	advanced  bool         // use advanced key reporting semantics
+}
+
+func keyFromInt(n int) (Key, bool) {
+	if n < 0 || n > 32767 {
+		return 0, false
+	}
+	return Key(n), true
+}
+
+func keyFromRune(r rune) (Key, bool) {
+	if r < 0 || r > 32767 {
+		return 0, false
+	}
+	return Key(r), true
+}
+
+func asciiByteFromInt(n int) (byte, bool) {
+	if n <= 0 || n >= 0x80 {
+		return 0, false
+	}
+	return byte(n), true
 }
 
 // Waiting returns true if the processor is waiting for
@@ -116,7 +138,7 @@ func (ip *inputParser) post(ev Event) {
 	if ip.escaped {
 		ip.escaped = false
 		if ke, ok := ev.(*EventKey); ok {
-			ev = NewEventKey(ke.Key(), ke.Str(), ke.Modifiers()|ModAlt)
+			ev = ip.newKey(ke.Key(), ke.Str(), ke.Modifiers()|ModAlt, ke.Pressed(), ke.Physical(), ke.Repeat())
 		}
 	} else if ke, ok := ev.(*EventKey); ok {
 		switch ke.Key() {
@@ -128,6 +150,31 @@ func (ip *inputParser) post(ev Event) {
 	}
 
 	ip.evch <- ev
+}
+
+func (ip *inputParser) newKey(k Key, str string, mod ModMask, pressed bool, physical Key, repeat int) *EventKey {
+	if ip.advanced {
+		return NewEventKeyEx(k, str, mod, pressed, physical, repeat)
+	}
+	return NewEventKey(k, str, mod)
+}
+
+func (ip *inputParser) postKey(k Key, str string, mod ModMask) {
+	ip.post(ip.newKey(k, str, mod, true, 0, 1))
+}
+
+func (ip *inputParser) postKeyEx(k Key, str string, mod ModMask, pressed bool, physical Key, repeat int) {
+	ip.post(ip.newKey(k, str, mod, pressed, physical, repeat))
+}
+
+func (ip *inputParser) postControlKey(r rune, mod ModMask) {
+	if r == 0 {
+		ip.postKeyEx(KeyRune, " ", mod|ModCtrl, true, Key(' '), 1)
+	} else if ip.advanced && r >= 1 && r <= 26 {
+		ip.postKeyEx(KeyRune, string('a'+r-1), mod|ModCtrl, true, Key('a'+r-1), 1)
+	} else {
+		ip.postKey(KeyRune, string(r+0x40), mod|ModCtrl)
+	}
 }
 
 type csiParamMode struct {
@@ -358,6 +405,14 @@ var csiUKeys = map[int]keyMap{
 	57425: {Key: KeyInsert},          // KP_INSERT
 	57426: {Key: KeyDelete},          // KP_DELETE
 	// 57427: {Key: KeyBegin},          // KP_BEGIN
+	57441: {Key: KeyShift}, // LEFT_SHIFT
+	57442: {Key: KeyCtrl},  // LEFT_CONTROL
+	57443: {Key: KeyAlt},   // LEFT_ALT
+	57444: {Key: KeyMeta},  // LEFT_SUPER
+	57447: {Key: KeyShift}, // RIGHT_SHIFT
+	57448: {Key: KeyCtrl},  // RIGHT_CONTROL
+	57449: {Key: KeyAlt},   // RIGHT_ALT
+	57450: {Key: KeyMeta},  // RIGHT_SUPER
 
 	// TODO: Media keys
 }
@@ -447,7 +502,8 @@ func (ip *inputParser) scan() {
 		if r >= 0xA0 {
 			// 8-bit extended Unicode we just treat as such - this will swallow anything else queued up
 			ip.state = istInit
-			ip.post(NewEventKey(KeyRune, string(r), ModNone))
+			physical, _ := keyFromRune(r)
+			ip.postKeyEx(KeyRune, string(r), ModNone, true, physical, 1)
 			continue
 		} else if r >= 0x80 {
 			// ISO 2022 control chars
@@ -463,19 +519,20 @@ func (ip *inputParser) scan() {
 				ip.state = istEsc
 				ip.escChar = 0
 			case '\t':
-				ip.post(NewEventKey(KeyTab, "", ModNone))
+				ip.postKey(KeyTab, "", ModNone)
 			case '\b', '\x7F':
-				ip.post(NewEventKey(KeyBackspace, "", ModNone))
+				ip.postKey(KeyBackspace, "", ModNone)
 			case '\r':
-				ip.post(NewEventKey(KeyEnter, "", ModNone))
+				ip.postKey(KeyEnter, "", ModNone)
 			default:
 				// Control keys - legacy handling
 				if r == 0 {
-					ip.post(NewEventKey(KeyRune, " ", ModCtrl))
+					ip.postControlKey(r, ModNone)
 				} else if r < ' ' {
-					ip.post(NewEventKey(KeyRune, string(r+0x40), ModCtrl))
+					ip.postControlKey(r, ModNone)
 				} else {
-					ip.post(NewEventKey(KeyRune, string(r), ModNone))
+					physical, _ := keyFromRune(r)
+					ip.postKeyEx(KeyRune, string(r), ModNone, true, physical, 1)
 				}
 			}
 		case istEsc:
@@ -521,7 +578,7 @@ func (ip *inputParser) scan() {
 			case '\t':
 				// Linux console only, does not conform to ECMA
 				ip.state = istInit
-				ip.post(NewEventKey(KeyBacktab, "", ModNone))
+				ip.postKey(KeyBacktab, "", ModNone)
 			default:
 				if r == '\x1b' {
 					// leading ESC to capture alt
@@ -535,7 +592,8 @@ func (ip *inputParser) scan() {
 						mod |= ModCtrl
 						r += 0x60
 					}
-					ip.post(NewEventKey(KeyRune, string(r), mod))
+					physical, _ := keyFromRune(r)
+					ip.postKeyEx(KeyRune, string(r), mod, true, physical, 1)
 				}
 			}
 		case istCsi:
@@ -585,16 +643,16 @@ func (ip *inputParser) scan() {
 				// parameters that do not match one of these forms, we just discard it.
 				if len(ip.csiParams) == 0 {
 					// simple SS3 case
-					ip.post(NewEventKey(k, "", ModNone))
+					ip.postKey(k, "", ModNone)
 				} else if parts := strings.Split(string(ip.csiParams), ";"); len(parts) >= 1 {
 					// SS3 with modifier (old style).  Note old terminfo would declare these as high
 					// numbered function keys, but we encode as modified since that's how they are entered.
 					if len(parts) >= 2 {
 						if m, err := strconv.Atoi(parts[1]); err == nil && (parts[0] == "1" || parts[0] == "") {
-							ip.post(NewEventKey(k, "", calcModifier(m)))
+							ip.postKey(k, "", calcModifier(m))
 						}
 					} else if m, err := strconv.Atoi(parts[0]); err == nil {
-						ip.post(NewEventKey(k, "", calcModifier(m)))
+						ip.postKey(k, "", calcModifier(m))
 					}
 				}
 			}
@@ -647,7 +705,7 @@ func (ip *inputParser) scan() {
 		case istLnx:
 			// linux console does not follow ECMA
 			if k, ok := linuxFKeys[r]; ok {
-				ip.post(NewEventKey(k, "", ModNone))
+				ip.postKey(k, "", ModNone)
 			}
 			ip.state = istInit
 		}
@@ -655,9 +713,9 @@ func (ip *inputParser) scan() {
 
 	if ip.state != istInit && time.Since(ip.keyTime) > time.Millisecond*50 {
 		if ip.state == istEsc {
-			ip.post(NewEventKey(KeyEscape, "", ModNone))
+			ip.postKey(KeyEscape, "", ModNone)
 		} else if ec := ip.escChar; ec != 0 {
-			ip.post(NewEventKey(KeyRune, string(ec), ModAlt))
+			ip.postKey(KeyRune, string(ec), ModAlt)
 		}
 		// if we take too long between bytes, reset the state machine.
 		ip.state = istInit
@@ -715,6 +773,89 @@ func calcModifier(n int) ModMask {
 	// num_lock  0b10000000  (128)
 
 	return m
+}
+
+func calcWinModifier(n int, advanced bool) ModMask {
+	m := ModNone
+	if n&0x010 != 0 {
+		m |= ModShift
+	}
+	if advanced {
+		if n&0x0008 != 0 {
+			m |= ModLCtrl
+		}
+		if n&0x0004 != 0 {
+			m |= ModRCtrl
+		}
+		if n&0x0002 != 0 {
+			m |= ModLAlt
+		}
+		if n&0x0001 != 0 {
+			m |= ModRAlt
+		}
+	} else {
+		if n&0x000c != 0 {
+			m |= ModCtrl
+		}
+		if n&0x0003 != 0 {
+			m |= ModAlt
+		}
+	}
+	return m
+}
+
+func winModifierKey(vk int) (Key, ModMask, bool) {
+	switch vk {
+	case 0x10:
+		return KeyShift, ModShift, true
+	case 0xa0:
+		return KeyShift, ModLShift, true
+	case 0xa1:
+		return KeyShift, ModRShift, true
+	case 0x11:
+		return KeyCtrl, ModCtrl, true
+	case 0xa2:
+		return KeyCtrl, ModLCtrl, true
+	case 0xa3:
+		return KeyCtrl, ModRCtrl, true
+	case 0x12:
+		return KeyAlt, ModAlt, true
+	case 0xa4:
+		return KeyAlt, ModLAlt, true
+	case 0xa5:
+		return KeyAlt, ModRAlt, true
+	case 0x5b:
+		return KeyMeta, ModLMeta, true
+	case 0x5c:
+		return KeyMeta, ModRMeta, true
+	case 0x14:
+		return KeyCapsLock, ModNone, true
+	default:
+		return 0, ModNone, false
+	}
+}
+
+func kittyModifierKey(code int) ModMask {
+	switch code {
+	case 57441:
+		return ModLShift
+	case 57447:
+		return ModRShift
+	case 57442:
+		return ModLCtrl
+	case 57448:
+		return ModRCtrl
+	case 57443:
+		return ModLAlt
+	case 57449:
+		return ModRAlt
+	case 57444:
+		return ModLMeta
+	case 57450:
+		return ModRMeta
+	default:
+		return ModNone
+	}
 }
 
 func (ip *inputParser) handleMouse(mode rune, params []int) {
@@ -827,7 +968,7 @@ func (ip *inputParser) handleWinKey(P []int) {
 	for len(P) < 6 {
 		P = append(P, 0) // ensure sufficient length
 	}
-	if P[3] == 0 {
+	if P[3] == 0 && !ip.advanced {
 		// key up event ignore ignore
 		return
 	}
@@ -835,32 +976,53 @@ func (ip *inputParser) handleWinKey(P []int) {
 	// these terminals never send ambiguous escapes
 	ip.escaped = false
 
-	if P[0] == 0 && P[1] == 0 && P[2] > 0 && P[2] < 0x80 { // only ASCII in win32-input-mode
-		if ip.nested == nil {
-			ip.nested = &inputParser{
-				evch: ip.evch,
-				rows: ip.rows,
-				cols: ip.cols,
+	if P[0] == 0 && P[1] == 0 { // only ASCII in win32-input-mode
+		if b, ok := asciiByteFromInt(P[2]); ok {
+			if ip.nested == nil {
+				ip.nested = &inputParser{
+					evch:     ip.evch,
+					rows:     ip.rows,
+					cols:     ip.cols,
+					advanced: ip.advanced,
+				}
 			}
+			ip.nested.ScanUTF8([]byte{b})
+			return
 		}
-		if P[2] > 0 {
-			ip.nested.ScanUTF8([]byte{byte(P[2])})
-		}
-		return
 	}
 
 	key := KeyRune
 	chr := rune(P[2])
 	mod := ModNone
 	rpt := max(1, P[5])
+	decoded := false
 	if k1, ok := winKeys[P[0]]; ok {
 		chr = 0
 		key = k1
+		decoded = true
+	} else if ip.advanced {
+		if k1, mod1, ok := winModifierKey(P[0]); ok {
+			key = k1
+			mod = mod1
+			chr = 0
+			decoded = true
+		}
+	}
+	if decoded {
+		// Already decoded.
 	} else if chr == 0 && P[0] >= 0x30 && P[0] <= 0x39 {
 		chr = rune(P[0])
 	} else if chr < ' ' && P[0] >= 0x41 && P[0] <= 0x5a {
-		key = Key(P[0])
-		chr = 0
+		if ip.advanced {
+			key = KeyRune
+			chr = rune(P[0] + 0x20)
+		} else {
+			var ok bool
+			if key, ok = keyFromInt(P[0]); !ok {
+				return
+			}
+			chr = 0
+		}
 	} else if chr >= 0xD800 && chr <= 0xDBFF {
 		// high surrogate pair
 		ip.surrogate = chr
@@ -868,25 +1030,16 @@ func (ip *inputParser) handleWinKey(P []int) {
 	} else if chr >= 0xDC00 && chr <= 0xDFFF {
 		// low surrogate pair
 		chr = utf16.DecodeRune(ip.surrogate, chr)
-	} else if P[0] == 0x10 || P[0] == 0x11 || P[0] == 0x12 || P[0] == 0x14 {
-		// lone modifiers
+	} else if _, _, ok := winModifierKey(P[0]); ok {
+		// Lone modifier releases are ignored unless advanced mode is enabled.
 		ip.surrogate = 0
 		return
 	}
 
 	ip.surrogate = 0
 
-	// Modifiers
-	if P[4]&0x010 != 0 {
-		mod |= ModShift
-	}
-	if P[4]&0x000c != 0 {
-		mod |= ModCtrl
-	}
-	if P[4]&0x0003 != 0 {
-		mod |= ModAlt
-	}
-	if key == KeyRune && chr > ' ' && mod == ModShift {
+	mod |= calcWinModifier(P[4], ip.advanced)
+	if key == KeyRune && chr > ' ' && mod == ModShift && !ip.advanced {
 		// filter out lone shift for printable chars
 		mod = ModNone
 	}
@@ -895,12 +1048,17 @@ func (ip *inputParser) handleWinKey(P []int) {
 		mod = ModNone
 	}
 
-	for range rpt {
-		if key != KeyRune {
-			ip.post(NewEventKey(key, "", mod))
-		} else if chr != 0 {
-			ip.post(NewEventKey(KeyRune, string(chr), mod))
+	physical := key
+	if key == KeyRune && chr != 0 {
+		physical, _ = keyFromRune(chr)
+		if ip.advanced && P[0] >= 0x41 && P[0] <= 0x5a {
+			physical, _ = keyFromInt(P[0] + 0x20)
 		}
+	}
+	if key != KeyRune {
+		ip.postKeyEx(key, "", mod, P[3] != 0, physical, rpt)
+	} else if chr != 0 {
+		ip.postKeyEx(KeyRune, string(chr), mod, P[3] != 0, physical, rpt)
 	}
 }
 
@@ -978,6 +1136,7 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 
 	var parts []string
 	var P []int
+	var PSubs [][]int
 	hasLT := false
 	hasQM := false
 	hasGT := false
@@ -997,13 +1156,27 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 	if pstr != "" && pstr[0] >= '0' && pstr[0] <= '9' {
 		parts = strings.Split(pstr, ";")
 		for i := range parts {
-			if parts[i] != "" {
-				if n, e := strconv.ParseInt(parts[i], 10, 32); e == nil {
+			subparts := strings.Split(parts[i], ":")
+			if subparts[0] != "" {
+				if n, e := strconv.ParseInt(subparts[0], 10, 32); e == nil {
 					P = append(P, int(n))
+				} else {
+					P = append(P, 0)
 				}
 			} else {
 				P = append(P, 0)
 			}
+			subs := []int{}
+			for _, sub := range subparts[1:] {
+				if sub != "" {
+					if n, e := strconv.ParseInt(sub, 10, 32); e == nil {
+						subs = append(subs, int(n))
+					}
+				} else {
+					subs = append(subs, 0)
+				}
+			}
+			PSubs = append(PSubs, subs)
 		}
 	}
 	var P0 int
@@ -1076,10 +1249,37 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 			if len(P) > 1 {
 				mod = calcModifier(P[1])
 			}
+			if mod1 := kittyModifierKey(P0); mod1 != ModNone {
+				mod |= mod1
+			}
+			pressed := true
+			repeat := 1
+			if len(PSubs) > 1 && len(PSubs[1]) > 0 {
+				switch PSubs[1][0] {
+				case 2:
+					repeat = 2
+				case 3:
+					pressed = false
+				}
+			}
+			physical := key
+			if len(PSubs) > 0 && len(PSubs[0]) > 0 {
+				base := PSubs[0][0]
+				if baseKey, ok := csiUKeys[base]; ok {
+					physical = baseKey.Key
+					if physical == KeyRune && baseKey.Rune != 0 {
+						physical, _ = keyFromRune(baseKey.Rune)
+					}
+				} else if base != 0 {
+					physical, _ = keyFromInt(base)
+				}
+			} else if key == KeyRune && chr != 0 {
+				physical, _ = keyFromRune(chr)
+			}
 			if key != KeyRune {
-				ip.post(NewEventKey(key, "", mod))
+				ip.postKeyEx(key, "", mod, pressed, physical, repeat)
 			} else if chr != 0 {
-				ip.post(NewEventKey(KeyRune, string(chr), mod))
+				ip.postKeyEx(KeyRune, string(chr), mod, pressed, physical, repeat)
 			}
 			return
 		}
@@ -1114,14 +1314,17 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 		if len(P) >= 2 {
 			mod := calcModifier(P[1])
 			if ks, ok := csiAllKeys[csiParamMode{M: mode, P: P0}]; ok {
-				ip.post(NewEventKey(ks.Key, "", mod))
+				ip.postKey(ks.Key, "", mod)
 				return
 			}
 			if P0 == 27 && len(P) > 2 && P[2] > 0 && P[2] <= 0xff {
 				if P[2] < ' ' || P[2] == 0x7F {
-					ip.post(NewEventKey(Key(P[2]), "", mod))
+					if key, ok := keyFromInt(P[2]); ok {
+						ip.postKey(key, "", mod)
+					}
 				} else {
-					ip.post(NewEventKey(KeyRune, string(rune(P[2])), mod))
+					physical, _ := keyFromInt(P[2])
+					ip.postKeyEx(KeyRune, string(rune(P[2])), mod, true, physical, 1)
 				}
 				return
 			}
@@ -1135,13 +1338,13 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 		} else if mode == 'P' && os.Getenv("TERM") == "aixterm" {
 			ks.Key = KeyDelete // aixterm hack - conflicts with kitty protocol
 		}
-		ip.post(NewEventKey(ks.Key, "", ks.Mod))
+		ip.postKey(ks.Key, "", ks.Mod)
 		return
 	}
 
 	// this might have been an SS3 style key with modifiers applied
 	if k, ok := ss3Keys[mode]; ok && P0 == 1 && len(P) > 1 {
-		ip.post(NewEventKey(k, "", calcModifier(P[1])))
+		ip.postKey(k, "", calcModifier(P[1]))
 		return
 	}
 	// if we got here we just swallow the unknown sequence

--- a/input_test.go
+++ b/input_test.go
@@ -844,6 +844,278 @@ func firstKey(evch chan Event) *EventKey {
 	return got
 }
 
+func nextKey(evch chan Event) *EventKey {
+	for {
+		select {
+		case ev := <-evch:
+			if kev, ok := ev.(*EventKey); ok {
+				return kev
+			}
+		case <-time.After(100 * time.Millisecond):
+			return nil
+		}
+	}
+}
+
+func TestAdvancedControlKeys(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte{0x01, '\t'})
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Ctrl-A event")
+	}
+	if got.Key() != KeyRune || got.Str() != "a" || got.Modifiers() != ModCtrl || got.Physical() != Key('a') {
+		t.Fatalf("expected Ctrl-A as KeyRune a + ModCtrl, got key=%v str=%q mod=%v physical=%v", got.Key(), got.Str(), got.Modifiers(), got.Physical())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Tab event")
+	}
+	if got.Key() != KeyTab || got.Modifiers() != ModNone {
+		t.Fatalf("expected ambiguous Ctrl-I/Tab to remain Tab, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+	}
+}
+
+func TestAdvancedKittyKeyMetadata(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("\x1b[65:97;2u\x1b[65:97;2:3u\x1b[57448;1:3u"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected shifted A press")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Modifiers() != ModShift || got.Physical() != Key('a') || !got.Pressed() || got.Repeat() != 1 {
+		t.Fatalf("unexpected shifted A press: key=%v str=%q mod=%v physical=%v pressed=%v repeat=%v", got.Key(), got.Str(), got.Modifiers(), got.Physical(), got.Pressed(), got.Repeat())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected shifted A release")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Modifiers() != ModShift || got.Physical() != Key('a') || got.Pressed() {
+		t.Fatalf("unexpected shifted A release: key=%v str=%q mod=%v physical=%v pressed=%v", got.Key(), got.Str(), got.Modifiers(), got.Physical(), got.Pressed())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected right Ctrl release")
+	}
+	if got.Key() != KeyCtrl || got.Modifiers()&ModRCtrl != ModRCtrl || got.Modifiers()&ModCtrl == 0 || got.Pressed() {
+		t.Fatalf("unexpected right Ctrl release: key=%v mod=%v pressed=%v", got.Key(), got.Modifiers(), got.Pressed())
+	}
+}
+
+func TestAdvancedKittyParameterParseErrorKeepsSubparametersAligned(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("\x1b[65;999999999999999999999999999999999:3u"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected key event")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Pressed() {
+		t.Fatalf("expected shifted A release despite malformed modifier parameter, got key=%v str=%q pressed=%v", got.Key(), got.Str(), got.Pressed())
+	}
+}
+
+func TestKeyConversionBounds(t *testing.T) {
+	if key, ok := keyFromInt(32767); !ok || key != Key(32767) {
+		t.Fatalf("keyFromInt max = %v, %v", key, ok)
+	}
+	if _, ok := keyFromInt(32768); ok {
+		t.Fatal("keyFromInt accepted overflow")
+	}
+	if _, ok := keyFromInt(-1); ok {
+		t.Fatal("keyFromInt accepted negative")
+	}
+	if key, ok := keyFromRune(32767); !ok || key != Key(32767) {
+		t.Fatalf("keyFromRune max = %v, %v", key, ok)
+	}
+	if _, ok := keyFromRune(32768); ok {
+		t.Fatal("keyFromRune accepted overflow")
+	}
+	if b, ok := asciiByteFromInt(0x7f); !ok || b != 0x7f {
+		t.Fatalf("asciiByteFromInt max = %v, %v", b, ok)
+	}
+	if _, ok := asciiByteFromInt(0); ok {
+		t.Fatal("asciiByteFromInt accepted zero")
+	}
+	if _, ok := asciiByteFromInt(0x80); ok {
+		t.Fatal("asciiByteFromInt accepted non-ASCII")
+	}
+}
+
+func TestAdvancedPhysicalKeyOverflowIsUnknown(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("\x1b[65:40000;2u"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected key event")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Physical() != 0 {
+		t.Fatalf("expected overflow physical key to be unknown, got key=%v str=%q physical=%v", got.Key(), got.Str(), got.Physical())
+	}
+}
+
+func TestLargeUnicodePhysicalKeyIsUnknown(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("😀"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected key event")
+	}
+	if got.Key() != KeyRune || got.Str() != "😀" || got.Physical() != 0 {
+		t.Fatalf("expected large Unicode physical key to be unknown, got key=%v str=%q physical=%v", got.Key(), got.Str(), got.Physical())
+	}
+}
+
+func TestAdvancedWinKeyMetadata(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("\x1b[65;0;65;1;16;3_\x1b[65;0;65;0;16;1_\x1b[17;0;0;1;8;1_\x1b[65;0;1;1;4;1_\x1b[160;0;0;1;20;1_"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 shifted A press")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Modifiers() != ModShift || got.Physical() != Key('a') || !got.Pressed() || got.Repeat() != 3 {
+		t.Fatalf("unexpected Win32 shifted A press: key=%v str=%q mod=%v physical=%v pressed=%v repeat=%v", got.Key(), got.Str(), got.Modifiers(), got.Physical(), got.Pressed(), got.Repeat())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 shifted A release")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Modifiers() != ModShift || got.Physical() != Key('a') || got.Pressed() {
+		t.Fatalf("unexpected Win32 shifted A release: key=%v str=%q mod=%v physical=%v pressed=%v", got.Key(), got.Str(), got.Modifiers(), got.Physical(), got.Pressed())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 Ctrl modifier press")
+	}
+	if got.Key() != KeyCtrl || got.Modifiers()&ModLCtrl != ModLCtrl || got.Modifiers()&ModCtrl == 0 || !got.Pressed() {
+		t.Fatalf("unexpected Win32 Ctrl press: key=%v mod=%v pressed=%v", got.Key(), got.Modifiers(), got.Pressed())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 right-Ctrl A press")
+	}
+	if got.Key() != KeyRune || got.Str() != "a" || got.Modifiers()&ModRCtrl != ModRCtrl || got.Modifiers()&ModCtrl == 0 {
+		t.Fatalf("unexpected Win32 right-Ctrl A press: key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+	}
+
+	got = nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 left-Shift press with right-Ctrl held")
+	}
+	if got.Key() != KeyShift || got.Modifiers()&ModLShift != ModLShift ||
+		got.Modifiers()&ModRCtrl != ModRCtrl || got.Modifiers()&ModCtrl == 0 {
+		t.Fatalf("unexpected Win32 left-Shift press with right-Ctrl held: key=%v mod=%v", got.Key(), got.Modifiers())
+	}
+}
+
+func TestWinKeyASCIIFallbackRangeCheck(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+
+	ip.ScanUTF8([]byte("\x1b[0;0;65;1;0;1_"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected Win32 ASCII fallback key")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" {
+		t.Fatalf("unexpected Win32 ASCII fallback key: key=%v str=%q", got.Key(), got.Str())
+	}
+
+	ip.ScanUTF8([]byte("\x1b[0;0;0;1;0;1_"))
+
+	if got = nextKey(evch); got != nil {
+		t.Fatalf("unexpected Win32 NUL fallback key: key=%v str=%q", got.Key(), got.Str())
+	}
+}
+
+func TestAdvancedModifierHelpers(t *testing.T) {
+	winCases := []struct {
+		vk      int
+		wantKey Key
+		wantMod ModMask
+	}{
+		{0x10, KeyShift, ModShift},
+		{0xa0, KeyShift, ModLShift},
+		{0xa1, KeyShift, ModRShift},
+		{0x11, KeyCtrl, ModCtrl},
+		{0xa2, KeyCtrl, ModLCtrl},
+		{0xa3, KeyCtrl, ModRCtrl},
+		{0x12, KeyAlt, ModAlt},
+		{0xa4, KeyAlt, ModLAlt},
+		{0xa5, KeyAlt, ModRAlt},
+		{0x5b, KeyMeta, ModLMeta},
+		{0x5c, KeyMeta, ModRMeta},
+		{0x14, KeyCapsLock, ModNone},
+	}
+	for _, tt := range winCases {
+		key, mod, ok := winModifierKey(tt.vk)
+		if !ok || key != tt.wantKey || mod != tt.wantMod {
+			t.Fatalf("winModifierKey(%#x) = %v, %v, %v; want %v, %v, true", tt.vk, key, mod, ok, tt.wantKey, tt.wantMod)
+		}
+	}
+	if _, _, ok := winModifierKey(0xff); ok {
+		t.Fatal("winModifierKey accepted unknown key")
+	}
+
+	kittyCases := map[int]ModMask{
+		57441: ModLShift,
+		57447: ModRShift,
+		57442: ModLCtrl,
+		57448: ModRCtrl,
+		57443: ModLAlt,
+		57449: ModRAlt,
+		57444: ModLMeta,
+		57450: ModRMeta,
+	}
+	for code, want := range kittyCases {
+		if got := kittyModifierKey(code); got != want {
+			t.Fatalf("kittyModifierKey(%d) = %v, want %v", code, got, want)
+		}
+	}
+	if got := kittyModifierKey(12345); got != ModNone {
+		t.Fatalf("kittyModifierKey unknown = %v, want ModNone", got)
+	}
+}
+
+func TestWinModifierState(t *testing.T) {
+	if got := calcWinModifier(0x1f, true); got != ModShift|ModLCtrl|ModRCtrl|ModLAlt|ModRAlt {
+		t.Fatalf("advanced win modifier state = %v", got)
+	}
+	if got := calcWinModifier(0x1f, false); got != ModShift|ModCtrl|ModAlt {
+		t.Fatalf("legacy win modifier state = %v", got)
+	}
+}
+
 // TestEscDuringCsiResetsParser verifies that an ESC byte received while
 // the parser is in CSI state correctly transitions to escape state per
 // ECMA-48 §5.3.1, rather than being swallowed as a "bad parse".

--- a/key.go
+++ b/key.go
@@ -45,9 +45,12 @@ import (
 // specific keys.
 type EventKey struct {
 	EventTime
-	mod ModMask
-	key Key
-	str string // string for key, usually just one character, but may be composed sequence
+	mod      ModMask
+	key      Key
+	physical Key
+	str      string // string for key, usually just one character, but may be composed sequence
+	pressed  bool
+	repeat   int
 }
 
 // Str returns the string corresponding to the key press, if it makes sense.
@@ -64,6 +67,38 @@ func (ev *EventKey) Str() string {
 // using the Str() function.
 func (ev *EventKey) Key() Key {
 	return ev.key
+}
+
+// Physical returns the physical key that was pressed, when known.
+//
+// This is different from Key() and Str(), which describe the logical key result
+// delivered to the application.  For example, on a US keyboard Shift-/ may
+// produce Str() == "?", while Physical() reports KeySlash.  Most applications
+// should use Key() and Str(); Physical is intended for layout-independent uses
+// such as keyboard remappers, embedded terminal emulators, and games that care
+// about key location rather than the printed character.
+//
+// For letter keys, compare physical values against the lowercase aliases
+// KeyA through KeyZ.  The legacy KeyCtrlA through KeyCtrlZ constants occupy
+// the same numeric range as Key('A') through Key('Z'), so Key('A') is not a
+// physical "A" key identifier.
+//
+// If the physical key is unknown, this returns zero.
+func (ev *EventKey) Physical() Key {
+	return ev.physical
+}
+
+// Pressed returns true for key press events, and false for key release events.
+// Legacy keyboard reporting only reports presses.
+func (ev *EventKey) Pressed() bool {
+	return ev.pressed
+}
+
+// Repeat returns the repeat count for this key event.  Legacy keyboard
+// reporting synthesizes repeated key presses as separate events, so this will
+// normally be 1.
+func (ev *EventKey) Repeat() int {
+	return ev.repeat
 }
 
 // Modifiers returns the modifiers that were present with the key press.  Note
@@ -184,6 +219,11 @@ var KeyNames = map[Key]string{
 	KeyCapsLock:   "CapsLock",
 	KeyScrollLock: "ScrollLock",
 	KeyNumLock:    "NumLock",
+	KeyShift:      "Shift",
+	KeyCtrl:       "Ctrl",
+	KeyAlt:        "Alt",
+	KeyMeta:       "Meta",
+	KeyHyper:      "Hyper",
 	KeyCtrlA:      "Ctrl-A",
 	KeyCtrlB:      "Ctrl-B",
 	KeyCtrlC:      "Ctrl-C",
@@ -217,19 +257,49 @@ var KeyNames = map[Key]string{
 func (ev *EventKey) Name() string {
 	s := ""
 	m := []string{}
-	if ev.mod&ModShift != 0 {
+	if ev.mod&modLShift != 0 {
+		m = append(m, "LeftShift")
+	}
+	if ev.mod&modRShift != 0 {
+		m = append(m, "RightShift")
+	}
+	if ev.mod&ModShift != 0 && ev.mod&(modLShift|modRShift) == 0 {
 		m = append(m, "Shift")
 	}
-	if ev.mod&ModAlt != 0 {
+	if ev.mod&modLAlt != 0 {
+		m = append(m, "LeftAlt")
+	}
+	if ev.mod&modRAlt != 0 {
+		m = append(m, "RightAlt")
+	}
+	if ev.mod&ModAlt != 0 && ev.mod&(modLAlt|modRAlt) == 0 {
 		m = append(m, "Alt")
 	}
-	if ev.mod&ModMeta != 0 {
+	if ev.mod&modLMeta != 0 {
+		m = append(m, "LeftMeta")
+	}
+	if ev.mod&modRMeta != 0 {
+		m = append(m, "RightMeta")
+	}
+	if ev.mod&ModMeta != 0 && ev.mod&(modLMeta|modRMeta) == 0 {
 		m = append(m, "Meta")
 	}
-	if ev.mod&ModCtrl != 0 {
+	if ev.mod&modLCtrl != 0 {
+		m = append(m, "LeftCtrl")
+	}
+	if ev.mod&modRCtrl != 0 {
+		m = append(m, "RightCtrl")
+	}
+	if ev.mod&ModCtrl != 0 && ev.mod&(modLCtrl|modRCtrl) == 0 {
 		m = append(m, "Ctrl")
 	}
-	if ev.mod&ModHyper != 0 {
+	if ev.mod&modLHyper != 0 {
+		m = append(m, "LeftHyper")
+	}
+	if ev.mod&modRHyper != 0 {
+		m = append(m, "RightHyper")
+	}
+	if ev.mod&ModHyper != 0 && ev.mod&(modLHyper|modRHyper) == 0 {
 		m = append(m, "Hyper")
 	}
 
@@ -242,6 +312,28 @@ func (ev *EventKey) Name() string {
 		}
 	}
 	if len(m) != 0 {
+		switch ev.key {
+		case KeyShift:
+			if ev.mod&(modLShift|modRShift|ModShift) != 0 {
+				return strings.Join(m, "+")
+			}
+		case KeyCtrl:
+			if ev.mod&(modLCtrl|modRCtrl|ModCtrl) != 0 {
+				return strings.Join(m, "+")
+			}
+		case KeyAlt:
+			if ev.mod&(modLAlt|modRAlt|ModAlt) != 0 {
+				return strings.Join(m, "+")
+			}
+		case KeyMeta:
+			if ev.mod&(modLMeta|modRMeta|ModMeta) != 0 {
+				return strings.Join(m, "+")
+			}
+		case KeyHyper:
+			if ev.mod&(modLHyper|modRHyper|ModHyper) != 0 {
+				return strings.Join(m, "+")
+			}
+		}
 		if ev.mod&ModCtrl != 0 && strings.HasPrefix(s, "Ctrl-") {
 			s = s[5:]
 		}
@@ -255,9 +347,24 @@ func (ev *EventKey) Name() string {
 // has more precise information it should set that specifically.  Callers
 // that aren't sure about modifier state (most) should just pass ModNone.
 func NewEventKey(k Key, str string, mod ModMask) *EventKey {
+	return newEventKey(k, str, mod, true, 0, 1, false)
+}
+
+// NewEventKeyEx creates an extended key event with press/release, physical key,
+// and repeat metadata.  It also uses the newer key normalization rules: ASCII
+// control letters are reported as KeyRune plus ModCtrl instead of legacy
+// KeyCtrlA through KeyCtrlZ values.
+func NewEventKeyEx(k Key, str string, mod ModMask, pressed bool, physical Key, repeat int) *EventKey {
+	return newEventKey(k, str, mod, pressed, physical, repeat, true)
+}
+
+func newEventKey(k Key, str string, mod ModMask, pressed bool, physical Key, repeat int, advanced bool) *EventKey {
 	ch := rune(0)
 	if len(str) == 1 {
 		ch = []rune(str)[0]
+	}
+	if repeat <= 0 {
+		repeat = 1
 	}
 
 	if k == KeyRune {
@@ -280,7 +387,7 @@ func NewEventKey(k Key, str string, mod ModMask) *EventKey {
 
 		// For legacy reasons, if Ctrl is pressed with an ASCII alphabetic, then we
 		// emit it as a KeyCtrlXX symbol.
-		if mod == ModCtrl {
+		if mod == ModCtrl && !advanced {
 			// We don't do Ctrl-[ or backslash or those specially.
 			if ch >= 'A' && ch <= 'Z' { // upper case
 				k = KeyCtrlA + Key(ch-'A')
@@ -293,7 +400,7 @@ func NewEventKey(k Key, str string, mod ModMask) *EventKey {
 
 		// Windows reports ModShift for shifted keys.  This is inconsistent
 		// with UNIX, lets harmonize this.
-		if mod == ModShift && str != "" {
+		if mod == ModShift && str != "" && !advanced {
 			mod = ModNone
 		}
 	}
@@ -304,18 +411,18 @@ func NewEventKey(k Key, str string, mod ModMask) *EventKey {
 	}
 
 	// Shift-Tab should be Backtab.
-	if k == KeyTab && (mod&ModShift) != 0 {
+	if k == KeyTab && (mod&ModShift) != 0 && !advanced {
 		k = KeyBacktab
 		mod &^= ModShift
 	}
-	ev := &EventKey{key: k, str: str, mod: mod}
+	ev := &EventKey{key: k, str: str, mod: mod, pressed: pressed, physical: physical, repeat: repeat}
 	ev.SetEventNow()
 	return ev
 }
 
 // ModMask is a mask of modifier keys.  Note that it will not always be
 // possible to report modifier keys.
-type ModMask int16
+type ModMask int32
 
 // These are the modifiers keys that can be sent either with a key press,
 // or a mouse event.  Note that as of now, due to the confusion associated
@@ -329,6 +436,103 @@ const (
 	ModMeta
 	ModHyper
 	ModNone ModMask = 0
+)
+
+const (
+	modLShift ModMask = 1 << (iota + 5)
+	modRShift
+	modLCtrl
+	modRCtrl
+	modLAlt
+	modRAlt
+	modLMeta
+	modRMeta
+	modLHyper
+	modRHyper
+)
+
+// These modifiers identify a specific side when the keyboard protocol reports
+// one.  They include the aggregate modifier bit, so ModLCtrl also satisfies
+// checks for ModCtrl.
+const (
+	ModLShift = ModShift | modLShift
+	ModRShift = ModShift | modRShift
+	ModLCtrl  = ModCtrl | modLCtrl
+	ModRCtrl  = ModCtrl | modRCtrl
+	ModLAlt   = ModAlt | modLAlt
+	ModRAlt   = ModAlt | modRAlt
+	ModLMeta  = ModMeta | modLMeta
+	ModRMeta  = ModMeta | modRMeta
+	ModLHyper = ModHyper | modLHyper
+	ModRHyper = ModHyper | modRHyper
+)
+
+// These keys are aliases for printable physical keys.  They are primarily
+// useful with EventKey.Physical, which may report a base key location separately
+// from the generated text.
+//
+// These names identify the unshifted base key on a US-style keyboard layout.
+// They do not identify logical characters produced by modifiers or other
+// layouts.  For example, the physical key named KeySlash may produce "/" or
+// "?" on a US keyboard depending on Shift, and may produce different text on
+// other layouts.  Applications interested in the logical key sequence should
+// use EventKey.Key and EventKey.Str instead.
+const (
+	KeySpace Key = ' '
+	Key0     Key = '0'
+	Key1     Key = '1'
+	Key2     Key = '2'
+	Key3     Key = '3'
+	Key4     Key = '4'
+	Key5     Key = '5'
+	Key6     Key = '6'
+	Key7     Key = '7'
+	Key8     Key = '8'
+	Key9     Key = '9'
+
+	KeyGrave      Key = '`'
+	KeyBacktick   Key = KeyGrave
+	KeyMinus      Key = '-'
+	KeyEqual      Key = '='
+	KeyLBrace     Key = '['
+	KeyLBracket   Key = KeyLBrace
+	KeyRBrace     Key = ']'
+	KeyRBracket   Key = KeyRBrace
+	KeyBackslash  Key = '\\'
+	KeySemi       Key = ';'
+	KeySemicolon  Key = KeySemi
+	KeyQuote      Key = '\''
+	KeyApostrophe Key = KeyQuote
+	KeyComma      Key = ','
+	KeyPeriod     Key = '.'
+	KeySlash      Key = '/'
+
+	KeyA Key = 'a'
+	KeyB Key = 'b'
+	KeyC Key = 'c'
+	KeyD Key = 'd'
+	KeyE Key = 'e'
+	KeyF Key = 'f'
+	KeyG Key = 'g'
+	KeyH Key = 'h'
+	KeyI Key = 'i'
+	KeyJ Key = 'j'
+	KeyK Key = 'k'
+	KeyL Key = 'l'
+	KeyM Key = 'm'
+	KeyN Key = 'n'
+	KeyO Key = 'o'
+	KeyP Key = 'p'
+	KeyQ Key = 'q'
+	KeyR Key = 'r'
+	KeyS Key = 's'
+	KeyT Key = 't'
+	KeyU Key = 'u'
+	KeyV Key = 'v'
+	KeyW Key = 'w'
+	KeyX Key = 'x'
+	KeyY Key = 'y'
+	KeyZ Key = 'z'
 )
 
 // Key is a generic value for representing keys, and especially special
@@ -433,6 +637,11 @@ const (
 	KeyCapsLock
 	KeyScrollLock
 	KeyNumLock
+	KeyShift
+	KeyCtrl
+	KeyAlt
+	KeyMeta
+	KeyHyper
 )
 
 const (
@@ -445,6 +654,10 @@ const (
 // rune (lower case) and control modifier.  If the shift key
 // or other modifiers are present then these will *NOT* be reported,
 // but reported instead as KeyRune.
+//
+// Note that these are not reported in advanced key reporting mode.
+// Instead, for advanced keys, expect KeyRune and a modifier with the
+// associated rune to be sent.
 const (
 	KeyCtrlA Key = iota + 65
 	KeyCtrlB
@@ -479,6 +692,10 @@ const (
 
 // These are the defined ASCII values for key codes.  They generally match
 // with KeyCtrl values.
+//
+// Most of these will not be reported in advanced key reporting mode, as they
+// are not possible to type directly. Some notable exceptions are KeyESC, KeyBS,
+// KeyTAB, and KeyCR, which have aliases below.
 const (
 	KeyNUL Key = iota
 	KeySOH

--- a/key_test.go
+++ b/key_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import "testing"
+
+func TestEventKeyNameSidedModifiers(t *testing.T) {
+	tests := []struct {
+		key  Key
+		mod  ModMask
+		want string
+	}{
+		{KeyShift, ModLShift, "LeftShift"},
+		{KeyShift, ModRShift, "RightShift"},
+		{KeyCtrl, ModLCtrl, "LeftCtrl"},
+		{KeyCtrl, ModRCtrl, "RightCtrl"},
+		{KeyAlt, ModLAlt, "LeftAlt"},
+		{KeyAlt, ModRAlt, "RightAlt"},
+		{KeyMeta, ModLMeta, "LeftMeta"},
+		{KeyMeta, ModRMeta, "RightMeta"},
+		{KeyHyper, ModLHyper, "LeftHyper"},
+		{KeyHyper, ModRHyper, "RightHyper"},
+		{KeyShift, ModShift, "Shift"},
+		{KeyCtrl, ModCtrl, "Ctrl"},
+		{KeyAlt, ModAlt, "Alt"},
+		{KeyMeta, ModMeta, "Meta"},
+		{KeyHyper, ModHyper, "Hyper"},
+	}
+
+	for _, tt := range tests {
+		ev := NewEventKeyEx(tt.key, "", tt.mod, true, tt.key, 1)
+		if got := ev.Name(); got != tt.want {
+			t.Errorf("Name() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestEventKeyAdvancedNormalization(t *testing.T) {
+	tests := []struct {
+		name         string
+		ev           *EventKey
+		wantKey      Key
+		wantStr      string
+		wantMod      ModMask
+		wantPressed  bool
+		wantPhysical Key
+		wantRepeat   int
+	}{
+		{
+			name:         "advanced ctrl letter",
+			ev:           NewEventKeyEx(KeyRune, "a", ModCtrl, false, KeyA, 0),
+			wantKey:      KeyRune,
+			wantStr:      "a",
+			wantMod:      ModCtrl,
+			wantPressed:  false,
+			wantPhysical: KeyA,
+			wantRepeat:   1,
+		},
+		{
+			name:         "advanced shift tab",
+			ev:           NewEventKeyEx(KeyTab, "", ModShift, true, KeyTab, 2),
+			wantKey:      KeyTab,
+			wantStr:      "",
+			wantMod:      ModShift,
+			wantPressed:  true,
+			wantPhysical: KeyTab,
+			wantRepeat:   2,
+		},
+		{
+			name:         "backspace alias",
+			ev:           NewEventKeyEx(KeyBackspace2, "", ModNone, true, KeyBackspace2, 1),
+			wantKey:      KeyBackspace,
+			wantStr:      "",
+			wantMod:      ModNone,
+			wantPressed:  true,
+			wantPhysical: KeyBackspace2,
+			wantRepeat:   1,
+		},
+		{
+			name:         "legacy shift printable normalizes",
+			ev:           NewEventKey(KeyRune, "A", ModShift),
+			wantKey:      KeyRune,
+			wantStr:      "A",
+			wantMod:      ModNone,
+			wantPressed:  true,
+			wantPhysical: 0,
+			wantRepeat:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ev.Key() != tt.wantKey || tt.ev.Str() != tt.wantStr ||
+				tt.ev.Modifiers() != tt.wantMod || tt.ev.Pressed() != tt.wantPressed ||
+				tt.ev.Physical() != tt.wantPhysical || tt.ev.Repeat() != tt.wantRepeat {
+				t.Fatalf("unexpected event: key=%v str=%q mod=%v pressed=%v physical=%v repeat=%v",
+					tt.ev.Key(), tt.ev.Str(), tt.ev.Modifiers(), tt.ev.Pressed(), tt.ev.Physical(), tt.ev.Repeat())
+			}
+		})
+	}
+}
+
+func TestPhysicalKeyAliases(t *testing.T) {
+	if KeyA != Key('a') || KeyZ != Key('z') || Key0 != Key('0') || Key9 != Key('9') || KeySpace != Key(' ') {
+		t.Fatalf("physical key aliases do not match their rune values")
+	}
+	tests := []struct {
+		name string
+		key  Key
+		want Key
+	}{
+		{"grave", KeyGrave, Key('`')},
+		{"minus", KeyMinus, Key('-')},
+		{"equal", KeyEqual, Key('=')},
+		{"left bracket", KeyLBracket, Key('[')},
+		{"right bracket", KeyRBracket, Key(']')},
+		{"backslash", KeyBackslash, Key('\\')},
+		{"semicolon", KeySemicolon, Key(';')},
+		{"quote", KeyQuote, Key('\'')},
+		{"comma", KeyComma, Key(',')},
+		{"period", KeyPeriod, Key('.')},
+		{"slash", KeySlash, Key('/')},
+	}
+	for _, tt := range tests {
+		if tt.key != tt.want {
+			t.Fatalf("%s key alias = %v, want %v", tt.name, tt.key, tt.want)
+		}
+	}
+}
+
+func TestPhysicalKeySlashLogicalText(t *testing.T) {
+	unshifted := NewEventKeyEx(KeyRune, "/", ModNone, true, KeySlash, 1)
+	if unshifted.Str() != "/" || unshifted.Physical() != KeySlash {
+		t.Fatalf("unshifted slash: str=%q physical=%v", unshifted.Str(), unshifted.Physical())
+	}
+
+	shifted := NewEventKeyEx(KeyRune, "?", ModShift, true, KeySlash, 1)
+	if shifted.Str() != "?" || shifted.Physical() != KeySlash {
+		t.Fatalf("shifted slash: str=%q physical=%v", shifted.Str(), shifted.Physical())
+	}
+}

--- a/tscreen.go
+++ b/tscreen.go
@@ -92,6 +92,16 @@ func (o OptSanitizeContent) apply(t *tScreen) {
 	t.cells.sanitizeContent = bool(o)
 }
 
+// OptAdvancedKeys enables richer key reporting where supported.  In this mode
+// key events may include release state, repeat counts, and physical keys, and
+// ASCII control letters are reported as KeyRune with ModCtrl instead of
+// KeyCtrlA through KeyCtrlZ.
+type OptAdvancedKeys bool
+
+func (o OptAdvancedKeys) apply(t *tScreen) {
+	t.advancedKeys = bool(o)
+}
+
 // Some terminal escapes that are basically universal.
 // We would really like to be able to use private mode queries for some of
 // these but generally we've found that support for queries is not always present,
@@ -141,6 +151,7 @@ const (
 	notifyDesktop777  = "\x1b]777;notify;%s;%s\x1b\\"       // Most commonly supported
 	queryKittyKbd     = "\x1b[?u"                           // Query for Kitty keyboard support
 	enableKittyKbd    = "\x1b[=1u"                          // Technically this pushes
+	enableKittyKbdAdv = "\x1b[=15u"                         // disambiguation, events, alternate keys, all keys
 	disableKittyKbd   = "\x1b[=0u"                          // Technically this means pop previous mode
 	queryXTermKbd     = "\x1b[?4m"                          // Query for XTerm modify other keys support
 	enableXTermKbd    = "\x1b[>4;2m"                        // Enable modify other keys protocol
@@ -233,6 +244,7 @@ type tScreen struct {
 	haveKittyKbd  bool
 	haveWin32Kbd  bool
 	haveXTermKbd  bool
+	advancedKeys  bool
 	input         *inputParser
 	sync.Mutex
 }
@@ -321,6 +333,7 @@ func (t *tScreen) Init() error {
 	t.initQ = make(chan Event, 32)
 	t.eventQ = make(chan Event, 128)
 	t.input = newInputParser(t.filterEvents())
+	t.input.advanced = t.advancedKeys
 
 	t.Lock()
 	t.cx = -1
@@ -1273,7 +1286,11 @@ func (t *tScreen) engage() error {
 	if t.haveWin32Kbd {
 		t.Print(vt.PmWin32Input.Enable())
 	} else if t.haveKittyKbd {
-		t.Print(enableKittyKbd)
+		if t.advancedKeys {
+			t.Print(enableKittyKbdAdv)
+		} else {
+			t.Print(enableKittyKbd)
+		}
 	} else if t.haveXTermKbd {
 		t.Print(enableXTermKbd)
 	}
@@ -1302,7 +1319,11 @@ func (t *tScreen) engage() error {
 		// should be benign there.  As another note, we have observed that at least Alacritty
 		// and WezTerm do not properly handle the primaryDA query on these platforms.
 		// (WezTerm performs much better when running a remote shell or on macOS.)
-		t.Print(enableKittyKbd)
+		if t.advancedKeys {
+			t.Print(enableKittyKbdAdv)
+		} else {
+			t.Print(enableKittyKbd)
+		}
 		t.Print(vt.PmWin32Input.Enable())
 	}
 	t.Print(requestWindowSize)

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -112,6 +112,32 @@ func TestOptAltScreenDefault(t *testing.T) {
 	}
 }
 
+func TestOptAdvancedKeys(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt, OptAdvancedKeys(true))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if !ts.advancedKeys {
+		t.Fatal("advanced keys option was not applied")
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+	if !ts.input.advanced {
+		t.Fatal("advanced keys option was not propagated to input parser")
+	}
+}
+
 func TestOptSanitizeContent(t *testing.T) {
 	t.Run("disabled by default", func(t *testing.T) {
 		mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})

--- a/wscreen.go
+++ b/wscreen.go
@@ -51,10 +51,12 @@ type OptColors int
 type OptTerm string
 type OptAltScreen bool
 type OptSanitizeContent bool
+type OptAdvancedKeys bool
 
-func (OptColors) apply(*wScreen)    {}
-func (OptTerm) apply(*wScreen)      {}
-func (OptAltScreen) apply(*wScreen) {}
+func (OptColors) apply(*wScreen)       {}
+func (OptTerm) apply(*wScreen)         {}
+func (OptAltScreen) apply(*wScreen)    {}
+func (OptAdvancedKeys) apply(*wScreen) {}
 func (o OptSanitizeContent) apply(w *wScreen) {
 	w.cells.sanitizeContent = bool(o)
 }


### PR DESCRIPTION
This adds an opt-in mode where applications can receive more advanced information including physical key mapping data, key releases, and repeat events, if the underlying keyboard protocol supports it.  Modern emulators generally support either the Kitty or Win32 input modes. Even when those modes are not supported, the protocol provides for more unified reporting of some keys.  This generally requires somewhat more sophistication on the part of the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in advanced key mode: richer keyboard events with press/release state, repeat counts, physical-key identity, and left/right modifier awareness; new option to enable it and updated terminal protocol handling (including Kitty and Windows).

* **UI**
  * Demo UI now shows immediate press/release rendering, toggles pressed vs released styling, clears paste text on release, and updates the displayed key.

* **Tests**
  * Expanded coverage for advanced parsing, sided modifiers, press/release, repeat behavior, and protocol metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->