### PR TITLE
feat: support pixel-precision mouse reporting (CSI ?1016h)

### DIFF
--- a/input.go
+++ b/input.go
@@ -125,14 +125,16 @@ func (ip *inputParser) Waiting() bool {
 // SetPixelMouse toggles whether SGR mouse reports are interpreted as
 // pixel coordinates (CSI ?1016h) rather than character cells (CSI ?1006h).
 // When enabled, mouse coordinates are not clipped to the screen size.
+// The setting is also forwarded to the lazily-created nested parser used
+// for win32-input-mode, if one exists, so both stay in sync.
 func (ip *inputParser) SetPixelMouse(on bool) {
-	if ip.nested != nil {
-		ip.nested.SetPixelMouse(on)
-		return
-	}
 	ip.l.Lock()
 	ip.pixelMouse = on
+	nested := ip.nested
 	ip.l.Unlock()
+	if nested != nil {
+		nested.SetPixelMouse(on)
+	}
 }
 
 func (ip *inputParser) SetSize(w, h int) {

--- a/input.go
+++ b/input.go
@@ -67,24 +67,25 @@ func newInputParser(eq chan<- Event) *inputParser {
 }
 
 type inputParser struct {
-	buf       []rune       // bytes to process (ingest data)
-	utfBuf    []byte       // accrued UTF8 bytes
-	strBuf    []byte       // accrued string data (for ST, OSC, etc.)
-	csiParams []byte       // accrued parameter bytes for CSI (and SS3)
-	csiInterm []byte       // accrued intermediate bytes for CSI
-	escChar   byte         // last byte for escape
-	escaped   bool         // true if next key should be modified by ESC
-	btnsDown  ButtonMask   // mouse buttons down (excludes wheel buttons)
-	state     inputState   // tracks processor state
-	strState  inputState   // saved str state (needed for ST)
-	l         sync.Mutex   // protects local state
-	evch      chan<- Event // where events are routed
-	rows      int          // used for clipping mouse coordinates
-	cols      int          // used for clipping mouse coordinates
-	keyTime   time.Time    // time of last key press / byte ingested
-	nested    *inputParser // for buggy win32-input-mode implementations
-	surrogate rune         // high surrogate pair seen (for Win32 input mode)
-	advanced  bool         // use advanced key reporting semantics
+	buf        []rune       // bytes to process (ingest data)
+	utfBuf     []byte       // accrued UTF8 bytes
+	strBuf     []byte       // accrued string data (for ST, OSC, etc.)
+	csiParams  []byte       // accrued parameter bytes for CSI (and SS3)
+	csiInterm  []byte       // accrued intermediate bytes for CSI
+	escChar    byte         // last byte for escape
+	escaped    bool         // true if next key should be modified by ESC
+	btnsDown   ButtonMask   // mouse buttons down (excludes wheel buttons)
+	state      inputState   // tracks processor state
+	strState   inputState   // saved str state (needed for ST)
+	l          sync.Mutex   // protects local state
+	evch       chan<- Event // where events are routed
+	rows       int          // used for clipping mouse coordinates
+	cols       int          // used for clipping mouse coordinates
+	pixelMouse bool         // mouse reports in pixels (CSI ?1016h); skip cell clipping
+	keyTime    time.Time    // time of last key press / byte ingested
+	nested     *inputParser // for buggy win32-input-mode implementations
+	surrogate  rune         // high surrogate pair seen (for Win32 input mode)
+	advanced   bool         // use advanced key reporting semantics
 }
 
 func keyFromInt(n int) (Key, bool) {
@@ -119,6 +120,19 @@ func (ip *inputParser) Waiting() bool {
 	ip.l.Lock()
 	defer ip.l.Unlock()
 	return ip.state != istInit
+}
+
+// SetPixelMouse toggles whether SGR mouse reports are interpreted as
+// pixel coordinates (CSI ?1016h) rather than character cells (CSI ?1006h).
+// When enabled, mouse coordinates are not clipped to the screen size.
+func (ip *inputParser) SetPixelMouse(on bool) {
+	if ip.nested != nil {
+		ip.nested.SetPixelMouse(on)
+		return
+	}
+	ip.l.Lock()
+	ip.pixelMouse = on
+	ip.l.Unlock()
 }
 
 func (ip *inputParser) SetSize(w, h int) {
@@ -880,9 +894,15 @@ func (ip *inputParser) handleMouse(mode rune, params []int) {
 	btn := params[0]
 	// Some terminals will report mouse coordinates outside the
 	// screen, especially with click-drag events.  Clip the coordinates
-	// to the screen in that case.
-	x := max(min(params[1]-1, ip.cols-1), 0)
-	y := max(min(params[2]-1, ip.rows-1), 0)
+	// to the screen in that case.  In pixel-reporting mode (CSI ?1016h)
+	// the values are already pixels rather than cells, so skip the clip
+	// and pass them through unchanged for the application to interpret.
+	x := params[1] - 1
+	y := params[2] - 1
+	if !ip.pixelMouse {
+		x = max(min(x, ip.cols-1), 0)
+		y = max(min(y, ip.rows-1), 0)
+	}
 
 	button := ButtonNone
 	mod := ModNone

--- a/input.go
+++ b/input.go
@@ -1010,10 +1010,11 @@ func (ip *inputParser) handleWinKey(P []int) {
 		if b, ok := asciiByteFromInt(P[2]); ok {
 			if ip.nested == nil {
 				ip.nested = &inputParser{
-					evch:     ip.evch,
-					rows:     ip.rows,
-					cols:     ip.cols,
-					advanced: ip.advanced,
+					evch:       ip.evch,
+					rows:       ip.rows,
+					cols:       ip.cols,
+					advanced:   ip.advanced,
+					pixelMouse: ip.pixelMouse,
 				}
 			}
 			ip.nested.ScanUTF8([]byte{b})

--- a/input_test.go
+++ b/input_test.go
@@ -1168,3 +1168,73 @@ func TestEscDuringSs3ResetsParser(t *testing.T) {
 		t.Errorf("expected KeyDown, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
 	}
 }
+
+// firstMouse drains the next EventMouse off the channel.
+func firstMouse(ch <-chan Event) *EventMouse {
+	for {
+		select {
+		case ev := <-ch:
+			if me, ok := ev.(*EventMouse); ok {
+				return me
+			}
+		case <-time.After(100 * time.Millisecond):
+			return nil
+		}
+	}
+}
+
+// TestInputMouseSgrClipsToScreen verifies that legacy SGR mouse reports
+// (CSI ?1006h) have their coordinates clamped to the cell-based screen
+// size, matching long-standing tcell behavior for terminals that report
+// out-of-range coordinates during click-drag.
+func TestInputMouseSgrClipsToScreen(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.cols = 80
+	ip.rows = 24
+
+	// SGR press at column 500, row 300 (well off-screen) — should clip.
+	ip.ScanUTF8([]byte("\x1b[<0;500;300M"))
+
+	me := firstMouse(evch)
+	if me == nil {
+		t.Fatal("expected a mouse event")
+	}
+	if x, y := me.Position(); x != 79 || y != 23 {
+		t.Errorf("expected clipped position (79,23), got (%d,%d)", x, y)
+	}
+}
+
+// TestInputMouseSgrPixelNoClip verifies that when the input parser is
+// in pixel-reporting mode (CSI ?1016h), mouse coordinates pass through
+// unchanged so applications can resolve sub-cell positions.
+func TestInputMouseSgrPixelNoClip(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.cols = 80
+	ip.rows = 24
+	ip.SetPixelMouse(true)
+
+	// Same press at pixel (500, 300). Screen is 80x24 cells, so cell-mode
+	// would clip; pixel-mode must not.
+	ip.ScanUTF8([]byte("\x1b[<0;500;300M"))
+
+	me := firstMouse(evch)
+	if me == nil {
+		t.Fatal("expected a mouse event")
+	}
+	if x, y := me.Position(); x != 499 || y != 299 {
+		t.Errorf("expected unclipped position (499,299), got (%d,%d)", x, y)
+	}
+
+	// Toggling pixel mode off should restore clipping behavior.
+	ip.SetPixelMouse(false)
+	ip.ScanUTF8([]byte("\x1b[<0;500;300M"))
+	me = firstMouse(evch)
+	if me == nil {
+		t.Fatal("expected a mouse event after disabling pixel mode")
+	}
+	if x, y := me.Position(); x != 79 || y != 23 {
+		t.Errorf("expected re-clipped position (79,23), got (%d,%d)", x, y)
+	}
+}

--- a/mouse.go
+++ b/mouse.go
@@ -49,8 +49,9 @@ func (ev *EventMouse) Modifiers() ModMask {
 	return ev.mod
 }
 
-// Position returns the mouse position in character cells.  The origin
-// 0, 0 is at the upper left corner.
+// Position returns the mouse position.  The origin 0, 0 is at the upper
+// left corner.  The unit is character cells unless the screen was started
+// with MousePixelEvents, in which case the unit is terminal pixels.
 func (ev *EventMouse) Position() (int, int) {
 	return ev.x, ev.y
 }

--- a/screen.go
+++ b/screen.go
@@ -300,6 +300,15 @@ const (
 	MouseButtonEvents = MouseFlags(1) // Click events only
 	MouseDragEvents   = MouseFlags(2) // Click-drag events (includes button events)
 	MouseMotionEvents = MouseFlags(4) // All mouse events (includes click and drag events)
+	// MousePixelEvents requests that mouse coordinates be reported in
+	// terminal pixels rather than character cells (xterm SGR-Pixel mode,
+	// CSI ?1016h). It is a modifier on the other mouse flags: at least one
+	// of MouseButtonEvents, MouseDragEvents, or MouseMotionEvents must also
+	// be set for any events to be delivered. When this mode is active,
+	// EventMouse.Position() returns coordinates in pixels; the application
+	// is responsible for mapping those to its own grid (e.g. via the
+	// terminal's reported cell-pixel size).
+	MousePixelEvents = MouseFlags(8)
 )
 
 // CursorStyle represents a given cursor style, which can include the shape and

--- a/tscreen.go
+++ b/tscreen.go
@@ -943,6 +943,10 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 	t.Print(vt.PmMouseDrag.Disable())
 	t.Print(vt.PmMouseMotion.Disable())
 	t.Print(vt.PmMouseSgr.Disable())
+	t.Print(vt.PmMouseSgrPixel.Disable())
+
+	pixel := f&MousePixelEvents != 0
+	t.input.SetPixelMouse(pixel)
 
 	if f&(MouseButtonEvents|MouseDragEvents|MouseMotionEvents) != 0 {
 		t.Print(vt.PmMouseButton.Enable())
@@ -954,7 +958,11 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 		t.Print(vt.PmMouseMotion.Enable())
 	}
 	if f&(MouseButtonEvents|MouseDragEvents|MouseMotionEvents) != 0 {
-		t.Print(vt.PmMouseSgr.Enable())
+		if pixel {
+			t.Print(vt.PmMouseSgrPixel.Enable())
+		} else {
+			t.Print(vt.PmMouseSgr.Enable())
+		}
 	}
 }
 


### PR DESCRIPTION
## Demo

<img width="960" height="540" alt="demo" src="https://github.com/user-attachments/assets/7db94eda-6e0d-4388-9384-9b8e28fe6cac" />

This is from [glife](https://github.com/ImGajeed76/glife), a Conway's Game of Life renderer that uses braille (2x4 dots per cell) for its grid. With pixel mouse mode the cursor resolves to the individual dot under it instead of snapping to a whole cell. This PR is the upstream counterpart of a local patch that glife had been carrying to make this work.

## Motivation

xterm's SGR-Pixel mouse mode (`CSI ?1016h`, `PmMouseSgrPixel`) reports mouse coordinates in terminal pixels rather than character cells. It is the only way for an application to resolve where the cursor is *within* a cell, which is useful for things like braille-grid drawing tools, mouse-driven sub-cell selection, and pixel-accurate widgets in terminals that report `xpixel`/`ypixel` via `TIOCGWINSZ`.

`tcell` already knows the mode exists; `PmMouseSgrPixel` is defined in `vt/mode.go`. But `Screen` has no way to ask for it, and the input parser unconditionally clamps mouse coordinates to the cell-based screen size in `handleMouse`, which destroys pixel coordinates before the app ever sees them. Today, applications that want this have to either fork tcell or emit `CSI ?1016h` themselves and live with the clip silently breaking drag events outside the visible grid.

Supported by Kitty, WezTerm, iTerm2, Konsole, recent xterm, VS Code's integrated terminal, Alacritty, and Ghostty. tmux and older terminals fall back to cell coordinates, so the existing flags continue to work unchanged in those cases.

## Change

Adds a new `MouseFlags` value, `MousePixelEvents`, that acts as a modifier on top of the existing `MouseButtonEvents`, `MouseDragEvents`, and `MouseMotionEvents`. When set:

- `tScreen.enableMouse` emits `PmMouseSgrPixel` instead of `PmMouseSgr`.
- The input parser skips its cell-size clamp for mouse reports, so pixel coordinates pass through to `EventMouse.Position()` unchanged.
- `EnableMouse` and `DisableMouse` also disable `PmMouseSgrPixel` on reset, mirroring the existing handling for `PmMouseSgr`.

The flag is purely additive (value `8`, no overlap with the existing flags) and does nothing on its own. At least one of the other mouse flags must still be set for any events to be delivered. Default behavior is unchanged.

`EventMouse.Position()` documents that the unit is pixels when the screen was started with `MousePixelEvents`, otherwise cells (today's behavior).

## Usage

```go
screen.EnableMouse(
    tcell.MouseButtonEvents,
    tcell.MouseDragEvents,
    tcell.MousePixelEvents,
)
// ev.Position() now returns terminal pixels
```

## Tests

Two new tests in `input_test.go`:

- `TestInputMouseSgrClipsToScreen` pins the existing clip behavior as a regression guard.
- `TestInputMouseSgrPixelNoClip` exercises `SetPixelMouse(true)` with a 1006-format SGR report whose coordinates exceed the screen, and verifies they pass through unchanged. It also toggles the flag back off and confirms clipping resumes.

`go test ./...` is green across all packages.

## Note on the VT emulator

The `vt` terminal emulator used by `mouse_test.go`'s integration tests currently has no branch for `PmMouseSgrPixel`; it always emits 1006-style cell coordinates, even when 1016 is enabled. Because of that, exercising the new flag end-to-end through `MockScreen` would require the emulator to track a synthetic cell-pixel size, which felt out of scope for this PR. The unit-level tests above cover both code paths in the input parser directly. Happy to extend the emulator in a follow-up if you would prefer richer integration coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for mouse pixel-event reporting and a runtime toggle to switch pixel vs. cell reporting.

* **Behavior**
  * With pixel mode enabled, coordinates are reported in terminal pixels; when disabled, coordinates are clamped to character-cell bounds. Reporting is consistent across input paths.

* **Documentation**
  * Clarified coordinate origin and unit behavior for mouse events.

* **Tests**
  * Added tests for SGR mouse coordinate handling in both modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->