### PR TITLE
clean stale pixels

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -82,7 +82,13 @@ func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 					cb.SetDirty(x-i, y, true)
 				}
 			}
+			// Use the larger of the new and previous widths so wide -> narrow
+			// transitions still mark all cells the previous glyph could have
+			// painted.
 			n := width
+			if c.width > n {
+				n = c.width
+			}
 			if n < 1 {
 				n = 1
 			}
@@ -236,6 +242,14 @@ func (cb *CellBuffer) Fill(r rune, style Style) {
 				if x-d >= 0 {
 					cb.cells[i-d].setDirty(true)
 				}
+			}
+			// Fill writes width 1, so the right-side cleanup span depends
+			// on whatever the previous glyph at this cell could have painted.
+			n := c.width
+			if n < 1 {
+				n = 1
+			}
+			for d := 1; d < n+adjacentRadius; d++ {
 				if x+d < cb.w {
 					cb.cells[i+d].setDirty(true)
 				}

--- a/cell.go
+++ b/cell.go
@@ -72,16 +72,24 @@ func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 			str = str[len(cluster):]
 		}
 
-		// Wide characters: we want to mark the "wide" cells
-		// dirty as well as the base cell, to make sure we consider
-		// both cells as dirty together.  We only need to do this
-		// if we're changing content
-		if width > 1 && cl != c.currStr {
-			// Prevent unnecessary bounds checks for first cell, since we already
-			// received that one.
+		// Mark adjacent cells dirty on content change to handle terminals
+		// painting glyphs outside tcell's tracked cell.
+		const adjacentRadius = 2
+		if cl != c.currStr {
 			c.setDirty(true)
-			for i := 1; i < width; i++ {
-				cb.SetDirty(x+i, y, true)
+			for i := 1; i <= adjacentRadius; i++ {
+				if x-i >= 0 {
+					cb.SetDirty(x-i, y, true)
+				}
+			}
+			n := width
+			if n < 1 {
+				n = 1
+			}
+			for i := 1; i < n+adjacentRadius; i++ {
+				if x+i < cb.w {
+					cb.SetDirty(x+i, y, true)
+				}
 			}
 		}
 
@@ -218,9 +226,22 @@ func (cb *CellBuffer) Resize(w, h int) {
 // If either the foreground or background are ColorNone, then the respective
 // color is unchanged.
 func (cb *CellBuffer) Fill(r rune, style Style) {
+	cl := string(r)
+	const adjacentRadius = 2
 	for i := range cb.cells {
 		c := &cb.cells[i]
-		c.currStr = string(r)
+		if c.currStr != cl {
+			x := i % cb.w
+			for d := 1; d <= adjacentRadius; d++ {
+				if x-d >= 0 {
+					cb.cells[i-d].setDirty(true)
+				}
+				if x+d < cb.w {
+					cb.cells[i+d].setDirty(true)
+				}
+			}
+		}
+		c.currStr = cl
 		cs := style
 		if cs.fg == ColorNone {
 			cs.fg = c.currStyle.fg


### PR DESCRIPTION
tcells redraw skips cells whose buffer state matches the last drawn state, but terminals can paint glyphs outside the cell tcell tracked them in like combining or prepended marks or font-rendered widths disagreeing with displaywidth. When that happens, stale pixels remain visible in adjacent cells across frames because CellBuffer.put only marks adjacent cells dirty for width > 1 content, and Fill never marks adjacent cells dirty at all. This patch marks adjacent cells (radius 2) dirty on content change in both put and Fill.

related issue: https://github.com/gokcehan/lf/pull/2556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen refresh so adjacent characters update reliably when text content or character widths change.
  * Fixed cases where wide characters turning into narrower ones left visual artifacts.
  * Made bulk fill operations update neighboring cells correctly to prevent stale or inconsistent glyph rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->