### PR TITLE
fix: close OSC8 hyperlinks (fixes #1078)

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -898,6 +898,10 @@ func (t *tScreen) draw() {
 		}
 	}
 
+	if t.curstyle.url != nil {
+		t.emitUrl(urlInfo{})
+	}
+
 	// restore the cursor
 	t.showCursor()
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -243,6 +243,9 @@ func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
 	if link != "http://example.com/\\path" {
 		t.Fatalf("unexpected emitted URL payload: %q", link)
 	}
+	if _, afterLink, ok := strings.Cut(out, "X"); !ok || !strings.Contains(afterLink, "\x1b]8;;\x1b\\") {
+		t.Fatalf("missing OSC 8 link close sequence after linked content: %q", out)
+	}
 	for i := 0; i < len(link); i++ {
 		c := link[i]
 		if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where hyperlinks were not properly closed when the drawing cycle completed. URL states are now explicitly cleared after finishing a draw, ensuring hyperlink sequences are correctly terminated and do not carry over to subsequent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->