### PR TITLE
feat: KeyBacktab updates for advanced mode (fixes #1018)

### DIFF
--- a/CHANGESv3.md
+++ b/CHANGESv3.md
@@ -45,6 +45,10 @@ the associated lower case rune (e.g. "a", "b", etc.) and `ModCtrl`.
 The `KeyBackspace2` key is no longer delivered, but is converted to
 `KeyBackspace`. (This resolves some inconsistency around e.g. CTRL-H vs DELETE.)
 
+When advanced key reporting is enabled, Shift-Tab is reported as `KeyTab` with
+`ModShift`, not as `KeyBacktab`.  Legacy key reporting still reports Shift-Tab
+as `KeyBacktab`.
+
 ### Termbox Compatibility Removed
 
 The `termbox` compatibility package is removed. Few applications were using it,

--- a/input_test.go
+++ b/input_test.go
@@ -881,6 +881,35 @@ func TestAdvancedControlKeys(t *testing.T) {
 	}
 }
 
+func TestAdvancedBacktabReportsShiftTab(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"CSI-Z", []byte("\x1b[Z")},
+		{"ESC-Tab", []byte{'\x1b', '\t'}},
+		{"XTerm-Shift-Tab", []byte("\x1b[27;2;9~")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evch := make(chan Event, 10)
+			ip := newInputParser(evch)
+			ip.advanced = true
+
+			ip.ScanUTF8(tt.input)
+
+			got := nextKey(evch)
+			if got == nil {
+				t.Fatal("expected Shift-Tab event")
+			}
+			if got.Key() != KeyTab || got.Modifiers() != ModShift {
+				t.Fatalf("expected KeyTab + ModShift, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+			}
+		})
+	}
+}
+
 func TestAdvancedKittyKeyMetadata(t *testing.T) {
 	evch := make(chan Event, 10)
 	ip := newInputParser(evch)

--- a/key.go
+++ b/key.go
@@ -410,6 +410,16 @@ func newEventKey(k Key, str string, mod ModMask, pressed bool, physical Key, rep
 		k = KeyBackspace
 	}
 
+	// Advanced key reporting exposes Shift-Tab directly.  Backtab is a legacy
+	// alias from terminals that cannot distinguish a physical Backtab key.
+	if k == KeyBacktab && advanced {
+		k = KeyTab
+		mod |= ModShift
+		if physical == 0 || physical == KeyBacktab {
+			physical = KeyTab
+		}
+	}
+
 	// Shift-Tab should be Backtab.
 	if k == KeyTab && (mod&ModShift) != 0 && !advanced {
 		k = KeyBacktab
@@ -568,6 +578,8 @@ const (
 	KeyCancel
 	KeyPrint
 	KeyPause
+	// KeyBacktab is used for legacy Shift-Tab reporting.  In advanced key
+	// reporting mode, Shift-Tab is reported as KeyTab with ModShift instead.
 	KeyBacktab
 	KeyF1
 	KeyF2

--- a/key_test.go
+++ b/key_test.go
@@ -79,6 +79,16 @@ func TestEventKeyAdvancedNormalization(t *testing.T) {
 			wantRepeat:   2,
 		},
 		{
+			name:         "advanced backtab normalizes to shift tab",
+			ev:           NewEventKeyEx(KeyBacktab, "", ModNone, true, KeyBacktab, 1),
+			wantKey:      KeyTab,
+			wantStr:      "",
+			wantMod:      ModShift,
+			wantPressed:  true,
+			wantPhysical: KeyTab,
+			wantRepeat:   1,
+		},
+		{
 			name:         "backspace alias",
 			ev:           NewEventKeyEx(KeyBackspace2, "", ModNone, true, KeyBackspace2, 1),
 			wantKey:      KeyBackspace,

--- a/tscreen.go
+++ b/tscreen.go
@@ -95,7 +95,8 @@ func (o OptSanitizeContent) apply(t *tScreen) {
 // OptAdvancedKeys enables richer key reporting where supported.  In this mode
 // key events may include release state, repeat counts, and physical keys, and
 // ASCII control letters are reported as KeyRune with ModCtrl instead of
-// KeyCtrlA through KeyCtrlZ.
+// KeyCtrlA through KeyCtrlZ.  Shift-Tab is reported as KeyTab with ModShift,
+// rather than KeyBacktab.
 type OptAdvancedKeys bool
 
 func (o OptAdvancedKeys) apply(t *tScreen) {


### PR DESCRIPTION
In advanced, KeyBacktab should be reported as ModShift + KeyTab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Shift-Tab key behavior in advanced key reporting mode.

* **Bug Fixes**
  * Fixed Shift-Tab interpretation in advanced key reporting mode for consistent behavior across legacy and modern reporting.

* **Tests**
  * Added test coverage for Shift-Tab in advanced key reporting mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->