### PR TITLE
fix(input): accept Unicode modifyOtherKeys codepoints

### DIFF
--- a/input.go
+++ b/input.go
@@ -1350,13 +1350,13 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 				ip.postKey(ks.Key, "", mod)
 				return
 			}
-			if P0 == 27 && len(P) > 2 && P[2] > 0 && P[2] <= 0xff {
+			if P0 == 27 && len(P) > 2 && P[2] > 0 && P[2] <= utf8.MaxRune {
 				if P[2] < ' ' || P[2] == 0x7F {
 					if key, ok := keyFromInt(P[2]); ok {
 						ip.postKey(key, "", mod)
 					}
 				} else {
-					physical, _ := keyFromInt(P[2])
+					physical, _ := keyFromRune(rune(P[2]))
 					ip.postKeyEx(KeyRune, string(rune(P[2])), mod, true, physical, 1)
 				}
 				return

--- a/input_test.go
+++ b/input_test.go
@@ -592,6 +592,7 @@ func TestSpecialKeys(t *testing.T) {
 		{"Alt-F7", []byte{'\x1b', '[', '1', '8', ';', '3', '~'}, KeyF7, ModAlt, ""},
 		{"XTerm-Shift-Tab", []byte{'\x1b', '[', '2', '7', ';', '2', ';', '9', '~'}, KeyBacktab, ModNone, ""}, // modifyOtherKeys == 2
 		{"XTerm-Space", []byte{'\x1b', '[', '2', '7', ';', '1', ';', '3', '2', '~'}, KeyRune, ModNone, " "},  // modifyOtherKeys == 3
+		{"XTerm-Alt-CJK", []byte{'\x1b', '[', '2', '7', ';', '3', ';', '2', '0', '3', '2', '0', '~'}, KeyRune, ModAlt, "你"},
 		{"Kitty-Esc", []byte{'\x1b', '[', '2', '7', 'u'}, KeyEsc, ModNone, ""},
 		{"Kitty-Control-I", []byte{'\x1b', '[', '1', '0', '5', ';', '5', 'u'}, 'I', ModCtrl, ""},
 		{"Win-Shift-A", []byte{'\x1b', '[', '6', '5', ';', '0', ';', '6', '5', ';', '1', ';', '1', '6', '_'}, KeyRune, ModNone, "A"},


### PR DESCRIPTION
xterm modifyOtherKeys reports ordinary-key codepoints as decimal Unicode values in CSI 27;mod;code~. The parser capped code at 0xff, so modified non-Latin characters were ignored.

- Allow valid Unicode scalar values and keep invalid values rejected.
- Add coverage alongside the existing xterm modifyOtherKeys cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced keyboard input support to properly handle CJK (Chinese, Japanese, Korean) characters combined with keyboard modifiers.

* **Tests**
  * Added test coverage for CJK character input with modifier keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->