### PR TITLE
perf(simscreen): drop allocs

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -248,9 +248,12 @@ func (cb *CellBuffer) Resize(w, h int) {
 // If either the foreground or background are ColorNone, then the respective
 // color is unchanged.
 func (cb *CellBuffer) Fill(r rune, style Style) {
+	// PERF: convert the rune to a string once. all cells share the same
+	// underlying value so a single allocation suffices.
+	s := string(r)
 	for i := range cb.cells {
 		c := &cb.cells[i]
-		c.currStr = string(r)
+		c.currStr = s
 		cs := style
 		if cs.fg == ColorNone {
 			cs.fg = c.currStyle.fg

--- a/sim_bench_test.go
+++ b/sim_bench_test.go
@@ -1,0 +1,129 @@
+// benchmarks for SimulationScreen. run with:
+//
+//	go test -run '^$' -bench '^BenchmarkSimulation' -benchmem .
+//
+// to attribute allocations:
+//
+//	go test -run '^$' -bench '^BenchmarkSimulationShow_FullDirty$' \
+//	    -benchmem -memprofile=mem.pprof .
+//	go tool pprof -alloc_objects -top -cum mem.pprof
+
+package tcell
+
+import (
+	"fmt"
+	"testing"
+)
+
+// fillScreen writes a deterministic pattern into every cell. used by
+// the benchmarks to mark every cell dirty before the next Show.
+func fillScreen(s SimulationScreen, w, h int) {
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			r := rune('a' + ((x + y) % 26))
+			s.SetContent(x, y, r, nil, StyleDefault)
+		}
+	}
+}
+
+// BenchmarkSimulationShow_FullDirty exercises Show with every cell
+// dirty since the last Show, so drawCell runs for every cell. surfaces
+// the per-cell allocs in drawCell -- atm append([]rune{mainc}, combc...)
+// plus the two make([]byte, 12) encode buffers.
+func BenchmarkSimulationShow_FullDirty(b *testing.B) {
+	for _, dim := range []struct{ w, h int }{
+		{80, 24},
+		{200, 60},
+	} {
+		name := fmt.Sprintf("%dx%d", dim.w, dim.h)
+		b.Run(name, func(b *testing.B) {
+			s := NewSimulationScreen("UTF-8")
+			if err := s.Init(); err != nil {
+				b.Fatalf("init: %v", err)
+			}
+			defer s.Fini()
+			s.SetSize(dim.w, dim.h)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				// rewrite every cell so they're all dirty for this Show.
+				fillScreen(s, dim.w, dim.h)
+				s.Show()
+				_ = i
+			}
+		})
+	}
+}
+
+// BenchmarkSimulationShow_Clean exercises Show when nothing's changed
+// since the previous Show. drawCell short-circuits via the !Dirty check,
+// so this isolates the per-cell loop overhead from the per-cell allocs.
+func BenchmarkSimulationShow_Clean(b *testing.B) {
+	for _, dim := range []struct{ w, h int }{
+		{80, 24},
+		{200, 60},
+	} {
+		name := fmt.Sprintf("%dx%d", dim.w, dim.h)
+		b.Run(name, func(b *testing.B) {
+			s := NewSimulationScreen("UTF-8")
+			if err := s.Init(); err != nil {
+				b.Fatalf("init: %v", err)
+			}
+			defer s.Fini()
+			s.SetSize(dim.w, dim.h)
+			fillScreen(s, dim.w, dim.h)
+			s.Show() // prime: clear all dirty bits
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				s.Show()
+			}
+		})
+	}
+}
+
+// BenchmarkSimulationClear exercises the Clear+Show path. Clear marks
+// every cell dirty so Show then redraws all cells. mirrors the per-frame
+// pattern in apps that issue a Clear at the start of each render tick.
+func BenchmarkSimulationClear(b *testing.B) {
+	for _, dim := range []struct{ w, h int }{
+		{80, 24},
+		{200, 60},
+	} {
+		name := fmt.Sprintf("%dx%d", dim.w, dim.h)
+		b.Run(name, func(b *testing.B) {
+			s := NewSimulationScreen("UTF-8")
+			if err := s.Init(); err != nil {
+				b.Fatalf("init: %v", err)
+			}
+			defer s.Fini()
+			s.SetSize(dim.w, dim.h)
+			fillScreen(s, dim.w, dim.h)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				s.Clear()
+				s.Show()
+			}
+		})
+	}
+}
+
+// BenchmarkSimulationSetContent isolates the SetContent path itself
+// (no Show) so changes there can be tracked independently of drawCell.
+func BenchmarkSimulationSetContent(b *testing.B) {
+	const w, h = 200, 60
+	s := NewSimulationScreen("UTF-8")
+	if err := s.Init(); err != nil {
+		b.Fatalf("init: %v", err)
+	}
+	defer s.Fini()
+	s.SetSize(w, h)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		x := i % w
+		y := (i / w) % h
+		s.SetContent(x, y, 'x', nil, StyleDefault)
+	}
+}

--- a/simulation.go
+++ b/simulation.go
@@ -107,13 +107,6 @@ type simscreen struct {
 	title     string
 	clipboard []byte
 
-	// PERF: scratch buffers for drawCell's per-cell utf8.EncodeRune +
-	// encoder.Transform. lifted to fields so a full-dirty Show doesn't
-	// allocate two 12-byte slices per cell. drawCell only runs under
-	// s.Lock, so no race.
-	lbuf [12]byte
-	ubuf [12]byte
-
 	Screen
 	sync.Mutex
 }
@@ -200,8 +193,8 @@ func (s *simscreen) drawCell(x, y int) int {
 		return width
 	}
 
-	lbuf := s.lbuf[:]
-	ubuf := s.ubuf[:]
+	lbuf := make([]byte, 12)
+	ubuf := make([]byte, 12)
 	nout := 0
 
 	for _, r := range simc.Runes {

--- a/simulation.go
+++ b/simulation.go
@@ -107,6 +107,13 @@ type simscreen struct {
 	title     string
 	clipboard []byte
 
+	// PERF: scratch buffers for drawCell's per-cell utf8.EncodeRune +
+	// encoder.Transform. lifted to fields so a full-dirty Show doesn't
+	// allocate two 12-byte slices per cell. drawCell only runs under
+	// s.Lock, so no race.
+	lbuf [12]byte
+	ubuf [12]byte
+
 	Screen
 	sync.Mutex
 }
@@ -193,8 +200,8 @@ func (s *simscreen) drawCell(x, y int) int {
 		return width
 	}
 
-	lbuf := make([]byte, 12)
-	ubuf := make([]byte, 12)
+	lbuf := s.lbuf[:]
+	ubuf := s.ubuf[:]
 	nout := 0
 
 	for _, r := range simc.Runes {


### PR DESCRIPTION
... :expressionless: i've spend so long writing such a nice writeup for this, and then the page refreshed and its gone...

short version: i found this wile working on some other projects. run `bencstat` and got a lovely:

```
SimulationClear/80x24-12             1920.000 ± 0%      1.000 ± 0%  -99.95% (p=0.000 n=10)
SimulationClear/200x60-12            12028.50 ± 0%      11.00 ± 9%  -99.91% (p=0.000 n=10)
```

for allocs and a driveby bump in speed too.

i've tried [`1ccc145`](https://github.com/gdamore/tcell/pull/1084/commits/1ccc14513636326f1a9b35d00a428bf169d948b0) which also worked but has some potentially statistically significant, very small slowdowns, so i left it out with a revert commit. ff to re-add if you want. the key slowdowns were:

```
SimulationShow_FullDirty/200x60-12    946.9µ ± 12%   1021.5µ ± 11%   +7.88% (p=0.035 n=10)
SimulationShow_Clean/80x24-12         30.77µ ±  2%    31.57µ ±  2%   +2.61% (p=0.002 n=10)
SimulationShow_Clean/200x60-12        190.5µ ±  4%    199.8µ ±  3%   +4.90% (p=0.023 n=10)
```