### PR TITLE
Preserve orphaned UTF-16 surrogates on Windows

### DIFF
--- a/input.go
+++ b/input.go
@@ -1058,11 +1058,20 @@ func (ip *inputParser) handleWinKey(P []int) {
 		}
 	} else if chr >= 0xD800 && chr <= 0xDBFF {
 		// high surrogate pair
+		if ip.surrogate != 0 {
+			ip.postKeyEx(KeyRune, string(utf8.RuneError), mod, P[3] != 0, 0, rpt)
+		}
 		ip.surrogate = chr
 		return
 	} else if chr >= 0xDC00 && chr <= 0xDFFF {
 		// low surrogate pair
-		chr = utf16.DecodeRune(ip.surrogate, chr)
+		if ip.surrogate == 0 {
+			chr = utf8.RuneError
+		} else {
+			chr = utf16.DecodeRune(ip.surrogate, chr)
+		}
+	} else if ip.surrogate != 0 {
+		ip.postKeyEx(KeyRune, string(utf8.RuneError), mod, P[3] != 0, 0, rpt)
 	} else if _, _, ok := winModifierKey(P[0]); ok {
 		// Lone modifier releases are ignored unless advanced mode is enabled.
 		ip.surrogate = 0

--- a/input_test.go
+++ b/input_test.go
@@ -1096,6 +1096,42 @@ func TestWinKeyASCIIFallbackRangeCheck(t *testing.T) {
 	}
 }
 
+func TestWinKeySurrogateErrorsArePreserved(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+
+	ip.ScanUTF8([]byte("\x1b[1;0;55357;1;0;1_\x1b[1;0;32;1;0;1_"))
+
+	first := nextKey(evch)
+	if first == nil || first.Str() != "�" {
+		t.Fatalf("expected orphaned high surrogate as replacement rune, got %#v", first)
+	}
+
+	second := nextKey(evch)
+	if second == nil || second.Str() != " " {
+		t.Fatalf("expected following BMP rune to be preserved, got %#v", second)
+	}
+
+	ip.ScanUTF8([]byte("\x1b[1;0;56832;1;0;1_"))
+
+	third := nextKey(evch)
+	if third == nil || third.Str() != "�" {
+		t.Fatalf("expected orphaned low surrogate as replacement rune, got %#v", third)
+	}
+
+	ip.ScanUTF8([]byte("\x1b[1;0;55357;1;0;1_\x1b[1;0;55357;1;0;1_\x1b[1;0;56832;1;0;1_"))
+
+	fourth := nextKey(evch)
+	if fourth == nil || fourth.Str() != "�" {
+		t.Fatalf("expected superseded high surrogate as replacement rune, got %#v", fourth)
+	}
+
+	fifth := nextKey(evch)
+	if fifth == nil || fifth.Str() != "😀" {
+		t.Fatalf("expected replacement high surrogate to pair with following low surrogate, got %#v", fifth)
+	}
+}
+
 func TestAdvancedModifierHelpers(t *testing.T) {
 	winCases := []struct {
 		vk      int

--- a/tty/tty_win.go
+++ b/tty/tty_win.go
@@ -209,22 +209,15 @@ func (w *winTty) getConsoleInput() error {
 			case keyEvent:
 				// we normally only expect to see ascii, but paste data may come in as UTF-16.
 				wc := rune(binary.LittleEndian.Uint16(ir.data[10:]))
-				if wc >= 0xD800 && wc <= 0xDBFF {
-					// if it was a high surrogate, which happens for pasted UTF-16,
-					// then save it until we get the low and can decode it.
-					w.surrogate = wc
-					continue
-				} else if wc >= 0xDC00 && wc <= 0xDFFF {
-					wc = utf16.DecodeRune(w.surrogate, wc)
-				}
-				w.surrogate = 0
-				for _, chr := range []byte(string(wc)) {
-					// We normally expect only to see ASCII (win32-input-mode),
-					// but apparently pasted data can arrive in UTF-16 here.
-					select {
-					case w.buf <- chr:
-					case <-w.stopQ:
-						break loop
+				for _, decoded := range decodeUTF16Rune(&w.surrogate, wc) {
+					for _, chr := range []byte(string(decoded)) {
+						// We normally expect only to see ASCII (win32-input-mode),
+						// but apparently pasted data can arrive in UTF-16 here.
+						select {
+						case w.buf <- chr:
+						case <-w.stopQ:
+							break loop
+						}
 					}
 				}
 

--- a/tty/utf16.go
+++ b/tty/utf16.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tty
+
+import (
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// decodeUTF16Rune decodes one UTF-16 code unit at a time while preserving
+// malformed input as replacement characters instead of silently discarding it.
+func decodeUTF16Rune(surrogate *rune, wc rune) []rune {
+	switch {
+	case wc >= 0xD800 && wc <= 0xDBFF:
+		if *surrogate != 0 {
+			*surrogate = wc
+			return []rune{utf8.RuneError}
+		}
+		*surrogate = wc
+		return nil
+	case wc >= 0xDC00 && wc <= 0xDFFF:
+		if *surrogate == 0 {
+			return []rune{utf8.RuneError}
+		}
+		decoded := utf16.DecodeRune(*surrogate, wc)
+		*surrogate = 0
+		return []rune{decoded}
+	default:
+		if *surrogate != 0 {
+			*surrogate = 0
+			return []rune{utf8.RuneError, wc}
+		}
+		return []rune{wc}
+	}
+}

--- a/tty/utf16_test.go
+++ b/tty/utf16_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tty
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeUTF16Rune(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []rune
+		want []rune
+	}{
+		{
+			name: "bmp rune",
+			in:   []rune{'A'},
+			want: []rune{'A'},
+		},
+		{
+			name: "valid surrogate pair",
+			in:   []rune{0xD83D, 0xDE00},
+			want: []rune{'😀'},
+		},
+		{
+			name: "orphaned high before bmp",
+			in:   []rune{0xD83D, ' '},
+			want: []rune{'�', ' '},
+		},
+		{
+			name: "orphaned high before high",
+			in:   []rune{0xD83D, 0xD83D, 0xDE00},
+			want: []rune{'�', '😀'},
+		},
+		{
+			name: "orphaned low",
+			in:   []rune{0xDE00},
+			want: []rune{'�'},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var surrogate rune
+			var got []rune
+			for _, wc := range tt.in {
+				got = append(got, decodeUTF16Rune(&surrogate, wc)...)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("decodeUTF16Rune(%U) = %U, want %U", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Preserve malformed UTF-16 input on Windows instead of silently discarding orphaned surrogate code units. The Windows TTY path now routes UTF-16 decoding through a helper that emits U+FFFD for orphaned high or low surrogates, and the Win32 input parser follows the same behavior. Added regression tests for valid pairs, orphaned highs, orphaned lows, and superseded high surrogates. Validated with `go test ./...` and `GOOS=windows go test -c ./tty`; fixes #1103.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for special characters and emoji on Windows by enhancing UTF-16 surrogate pair processing, ensuring proper error recovery for malformed character sequences.

* **Tests**
  * Added comprehensive tests to validate keyboard input handling for edge cases and invalid character sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->