### PR TITLE
vt: prune tab stops after resize

### DIFF
--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -2403,6 +2403,7 @@ func (em *emulator) ResizeEvent(size Coord) {
 func (em *emulator) applyResize(size Coord) {
 	// resize clobbers our content, until it is redrawn
 	em.size = size
+	em.tabStops = slices.DeleteFunc(em.tabStops, func(x Col) bool { return x >= em.size.X })
 	// resizing resets the margins
 	em.topMargin = 0
 	em.botMargin = em.size.Y - 1

--- a/vt/emulate_internal_test.go
+++ b/vt/emulate_internal_test.go
@@ -132,6 +132,25 @@ func TestMockBackendHelpers(t *testing.T) {
 	MockOptNoBlit{}.SetMockOpt(mb)
 }
 
+func TestApplyResizePrunesTabStops(t *testing.T) {
+	em := NewEmulator(NewMockBackend(MockOptSize{X: 80, Y: 24})).(*emulator)
+	em.tabStops = []Col{8, 16, 24, 32, 40, 48}
+
+	em.applyResize(Coord{X: 32, Y: 24})
+
+	if got, want := em.tabStops, []Col{8, 16, 24}; !slices.Equal(got, want) {
+		t.Fatalf("unexpected tab stops after resize: got %v, want %v", got, want)
+	}
+
+	em.setPosition(Coord{X: 0, Y: 0})
+	for _, want := range []Col{8, 16, 24, 31} {
+		em.nextTab()
+		if got := em.getPosition().X; got != want {
+			t.Fatalf("unexpected tab position after resize: got %d, want %d", got, want)
+		}
+	}
+}
+
 func TestPutRuneGraphemeExtensions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #1101.

Prune custom tab stops that fall outside the terminal after a resize so stale stops cannot interfere with later tab navigation. Add a regression test covering resize-time pruning and the remaining valid tab sequence. Validated with `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal emulator now properly removes tab stop positions that extend beyond the resized screen width, preventing stale references from persisting after resize operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->