### PR TITLE
vt: ignore malformed SGR parameters

### DIFF
--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -800,7 +800,7 @@ func (em *emulator) processSgr(str string) {
 		v, err := strconv.Atoi(word)
 		if err != nil {
 			// just swallow it for now
-			return
+			continue
 		}
 		switch v {
 		case 0:

--- a/vt/tests/mock_test.go
+++ b/vt/tests/mock_test.go
@@ -663,6 +663,20 @@ func TestSgrColor8(t *testing.T) {
 	CheckColors(t, term, 3, 0, color.Silver, color.Black)
 }
 
+// TestSgrMalformedParam verifies that malformed SGR parameters are ignored
+// individually without dropping the rest of the sequence.
+func TestSgrMalformedParam(t *testing.T) {
+	term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})
+	defer MustClose(t, term)
+	MustStart(t, term)
+
+	WriteF(t, term, "\x1b[31;<mA")
+	CheckColors(t, term, 0, 0, color.Maroon, color.Black)
+
+	WriteF(t, term, "\x1b[31;<;32mB")
+	CheckColors(t, term, 1, 0, color.Green, color.Black)
+}
+
 // TestSgrColor256 tests simple ECMA 48 ANSI color (256 possible color values.)
 func TestSgrColor256(t *testing.T) {
 	term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24}, vt.MockOptColors(256))


### PR DESCRIPTION
## Summary
- ignore malformed SGR parameters individually so later parameters still apply
- add regression coverage for malformed SGR tokens before and between valid colors

## Testing
- go test ./...

Fixes #1099


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of malformed parameters in terminal control sequences. Invalid parameters are now skipped individually instead of breaking the entire sequence.

* **Tests**
  * Added test coverage for malformed parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->