### PR TITLE
Limit inbound control strings

### DIFF
--- a/input.go
+++ b/input.go
@@ -59,33 +59,40 @@ const (
 	istXda  // extended device attributes (ESC P Ps ST)
 )
 
+// defaultControlStringLimit caps inbound OSC/XDA control-string payloads
+// before they can grow without bound while waiting for a string terminator.
+const defaultControlStringLimit = 64 * 1024
+
 func newInputParser(eq chan<- Event) *inputParser {
 	return &inputParser{
-		evch: eq,
-		buf:  make([]rune, 0, 128),
+		evch:             eq,
+		buf:              make([]rune, 0, 128),
+		controlStringMax: defaultControlStringLimit,
 	}
 }
 
 type inputParser struct {
-	buf        []rune       // bytes to process (ingest data)
-	utfBuf     []byte       // accrued UTF8 bytes
-	strBuf     []byte       // accrued string data (for ST, OSC, etc.)
-	csiParams  []byte       // accrued parameter bytes for CSI (and SS3)
-	csiInterm  []byte       // accrued intermediate bytes for CSI
-	escChar    byte         // last byte for escape
-	escaped    bool         // true if next key should be modified by ESC
-	btnsDown   ButtonMask   // mouse buttons down (excludes wheel buttons)
-	state      inputState   // tracks processor state
-	strState   inputState   // saved str state (needed for ST)
-	l          sync.Mutex   // protects local state
-	evch       chan<- Event // where events are routed
-	rows       int          // used for clipping mouse coordinates
-	cols       int          // used for clipping mouse coordinates
-	pixelMouse bool         // mouse reports in pixels (CSI ?1016h); skip cell clipping
-	keyTime    time.Time    // time of last key press / byte ingested
-	nested     *inputParser // for buggy win32-input-mode implementations
-	surrogate  rune         // high surrogate pair seen (for Win32 input mode)
-	advanced   bool         // use advanced key reporting semantics
+	buf              []rune       // bytes to process (ingest data)
+	utfBuf           []byte       // accrued UTF8 bytes
+	strBuf           []byte       // accrued string data (for ST, OSC, etc.)
+	csiParams        []byte       // accrued parameter bytes for CSI (and SS3)
+	csiInterm        []byte       // accrued intermediate bytes for CSI
+	escChar          byte         // last byte for escape
+	escaped          bool         // true if next key should be modified by ESC
+	btnsDown         ButtonMask   // mouse buttons down (excludes wheel buttons)
+	state            inputState   // tracks processor state
+	strState         inputState   // saved str state (needed for ST)
+	l                sync.Mutex   // protects local state
+	evch             chan<- Event // where events are routed
+	rows             int          // used for clipping mouse coordinates
+	cols             int          // used for clipping mouse coordinates
+	pixelMouse       bool         // mouse reports in pixels (CSI ?1016h); skip cell clipping
+	keyTime          time.Time    // time of last key press / byte ingested
+	nested           *inputParser // for buggy win32-input-mode implementations
+	surrogate        rune         // high surrogate pair seen (for Win32 input mode)
+	advanced         bool         // use advanced key reporting semantics
+	controlStringMax int          // maximum inbound OSC/XDA payload size; 0 means unlimited
+	discardString    bool         // drop the rest of an over-limit OSC/XDA sequence
 }
 
 func keyFromInt(n int) (Key, bool) {
@@ -561,6 +568,7 @@ func (ip *inputParser) scan() {
 			case ']':
 				ip.state = istOsc
 				ip.strBuf = nil
+				ip.discardString = false
 				ip.escChar = byte(r)
 			case 'N':
 				ip.state = istSs2 // no known uses
@@ -575,6 +583,7 @@ func (ip *inputParser) scan() {
 				ip.state = istXda
 				ip.csiParams = nil
 				ip.strBuf = nil
+				ip.discardString = false
 				ip.escChar = byte(r)
 			case 'X':
 				ip.state = istSos
@@ -688,9 +697,16 @@ func (ip *inputParser) scan() {
 				ip.strState = ip.state
 				ip.state = istSt
 			case '\x07':
-				ip.handleXda(string(ip.strBuf))
+				if ip.discardString {
+					ip.discardString = false
+					ip.state = istInit
+				} else {
+					ip.handleXda(string(ip.strBuf))
+				}
 			default:
-				ip.strBuf = append(ip.strBuf, byte(r&0x7f))
+				if !ip.discardString {
+					ip.appendStringBytes(byte(r & 0x7f))
+				}
 			}
 
 		case istOsc: // not sure if used
@@ -699,23 +715,36 @@ func (ip *inputParser) scan() {
 				ip.strState = ip.state
 				ip.state = istSt
 			case '\x07':
-				ip.handleOsc(string(ip.strBuf))
+				if ip.discardString {
+					ip.discardString = false
+					ip.state = istInit
+				} else {
+					ip.handleOsc(string(ip.strBuf))
+				}
 			default:
-				ip.strBuf = append(ip.strBuf, byte(r&0x7f))
+				if !ip.discardString {
+					ip.appendStringBytes(byte(r & 0x7f))
+				}
 			}
 		case istSt:
 			if r == '\\' || r == '\x07' {
 				ip.state = istInit
-				switch ip.strState {
-				case istOsc:
-					ip.handleOsc(string(ip.strBuf))
-				case istXda:
-					ip.handleXda(string(ip.strBuf))
-				case istPm, istApc, istSos, istDcs:
-					ip.state = istInit
+				if ip.discardString {
+					ip.discardString = false
+				} else {
+					switch ip.strState {
+					case istOsc:
+						ip.handleOsc(string(ip.strBuf))
+					case istXda:
+						ip.handleXda(string(ip.strBuf))
+					case istPm, istApc, istSos, istDcs:
+						ip.state = istInit
+					}
 				}
 			} else {
-				ip.strBuf = append(ip.strBuf, '\x1b', byte(r))
+				if !ip.discardString {
+					ip.appendStringBytes('\x1b', byte(r))
+				}
 				ip.state = ip.strState
 			}
 		case istLnx:
@@ -735,7 +764,17 @@ func (ip *inputParser) scan() {
 		}
 		// if we take too long between bytes, reset the state machine.
 		ip.state = istInit
+		ip.discardString = false
 	}
+}
+
+func (ip *inputParser) appendStringBytes(bs ...byte) {
+	if ip.controlStringMax > 0 && len(ip.strBuf)+len(bs) > ip.controlStringMax {
+		ip.strBuf = nil
+		ip.discardString = true
+		return
+	}
+	ip.strBuf = append(ip.strBuf, bs...)
 }
 
 func (ip *inputParser) handleOsc(str string) {
@@ -1012,11 +1051,12 @@ func (ip *inputParser) handleWinKey(P []int) {
 		if b, ok := asciiByteFromInt(P[2]); ok {
 			if ip.nested == nil {
 				ip.nested = &inputParser{
-					evch:       ip.evch,
-					rows:       ip.rows,
-					cols:       ip.cols,
-					advanced:   ip.advanced,
-					pixelMouse: ip.pixelMouse,
+					evch:             ip.evch,
+					rows:             ip.rows,
+					cols:             ip.cols,
+					advanced:         ip.advanced,
+					pixelMouse:       ip.pixelMouse,
+					controlStringMax: ip.controlStringMax,
 				}
 			}
 			ip.nested.ScanUTF8([]byte{b})

--- a/input_test.go
+++ b/input_test.go
@@ -18,6 +18,7 @@
 package tcell
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -770,6 +771,132 @@ func TestIgnoredSequences(t *testing.T) {
 				t.Fatal("Timeout")
 			}
 		})
+	}
+}
+
+func TestStringSequenceLimit(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+	}{
+		{"OSC", "\x1b]"},
+		{"XDA", "\x1bP"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evch := make(chan Event, 10)
+			ip := newInputParser(evch)
+
+			input := append([]byte(test.prefix), bytes.Repeat([]byte{'x'}, defaultControlStringLimit+1)...)
+			ip.ScanUTF8(input)
+
+			if ip.state == istInit {
+				t.Fatalf("parser state = %v, want string discard state", ip.state)
+			}
+			if len(ip.strBuf) != 0 {
+				t.Fatalf("string buffer length = %d, want 0", len(ip.strBuf))
+			}
+			if !ip.discardString {
+				t.Fatal("parser is not discarding over-limit string")
+			}
+
+			ip.ScanUTF8([]byte("tail\x07a"))
+			select {
+			case ev := <-evch:
+				kev, ok := ev.(*EventKey)
+				if !ok {
+					t.Fatalf("got %T, want *EventKey", ev)
+				}
+				if kev.Key() != KeyRune || kev.Str() != "a" {
+					t.Fatalf("got %v %q, want %v %q", kev.Key(), kev.Str(), KeyRune, "a")
+				}
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("timeout waiting for parser recovery")
+			}
+		})
+	}
+}
+
+func TestStringSequenceLimitAfterEmbeddedEscape(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+
+	input := append([]byte("\x1b]"), bytes.Repeat([]byte{'x'}, defaultControlStringLimit-1)...)
+	input = append(input, '\x1b', 'x')
+	ip.ScanUTF8(input)
+
+	if ip.state != istOsc {
+		t.Fatalf("parser state = %v, want %v", ip.state, istOsc)
+	}
+	if len(ip.strBuf) != 0 {
+		t.Fatalf("string buffer length = %d, want 0", len(ip.strBuf))
+	}
+	if !ip.discardString {
+		t.Fatal("parser is not discarding over-limit string")
+	}
+
+	ip.ScanUTF8([]byte("tail\x1b\\a"))
+	select {
+	case ev := <-evch:
+		kev, ok := ev.(*EventKey)
+		if !ok {
+			t.Fatalf("got %T, want *EventKey", ev)
+		}
+		if kev.Key() != KeyRune || kev.Str() != "a" {
+			t.Fatalf("got %v %q, want %v %q", kev.Key(), kev.Str(), KeyRune, "a")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for parser recovery")
+	}
+}
+
+func TestStringSequenceCustomLimit(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.controlStringMax = 4
+
+	ip.ScanUTF8([]byte("\x1b]12345"))
+
+	if ip.state != istOsc {
+		t.Fatalf("parser state = %v, want %v", ip.state, istOsc)
+	}
+	if len(ip.strBuf) != 0 {
+		t.Fatalf("string buffer length = %d, want 0", len(ip.strBuf))
+	}
+	if !ip.discardString {
+		t.Fatal("parser is not discarding over-limit string")
+	}
+}
+
+func TestStringSequenceExactLimit(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.controlStringMax = 4
+
+	ip.ScanUTF8([]byte("\x1b]1234"))
+
+	if ip.state != istOsc {
+		t.Fatalf("parser state = %v, want %v", ip.state, istOsc)
+	}
+	if got := string(ip.strBuf); got != "1234" {
+		t.Fatalf("string buffer = %q, want %q", got, "1234")
+	}
+}
+
+func TestStringSequenceUnlimited(t *testing.T) {
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.controlStringMax = 0
+
+	payload := bytes.Repeat([]byte{'x'}, defaultControlStringLimit+1)
+	ip.ScanUTF8(append([]byte("\x1b]"), payload...))
+
+	if ip.state != istOsc {
+		t.Fatalf("parser state = %v, want %v", ip.state, istOsc)
+	}
+	if !bytes.Equal(ip.strBuf, payload) {
+		t.Fatalf("string buffer length = %d, want %d", len(ip.strBuf), len(payload))
 	}
 }
 

--- a/tscreen.go
+++ b/tscreen.go
@@ -103,6 +103,17 @@ func (o OptAdvancedKeys) apply(t *tScreen) {
 	t.advancedKeys = bool(o)
 }
 
+// OptControlStringLimit sets the maximum inbound control-string payload size
+// accepted from the terminal before the parser drops the sequence. This limits
+// OSC and XDA strings, including OSC 52 clipboard strings; OSC 52 is the
+// protocol used for writing clipboard data through the terminal. The default is
+// 64 KiB; a value of 0 disables the limit.
+type OptControlStringLimit int
+
+func (o OptControlStringLimit) apply(t *tScreen) {
+	t.controlStringLimit = max(int(o), 0)
+}
+
 // Some terminal escapes that are basically universal.
 // We would really like to be able to use private mode queries for some of
 // these but generally we've found that support for queries is not always present,
@@ -164,7 +175,11 @@ const (
 // is presumed, at least on UNIX hosts. (Windows hosts will typically fail this
 // call altogether.)
 func NewTerminfoScreenFromTty(tty Tty, opts ...TerminfoScreenOption) (Screen, error) {
-	t := &tScreen{tty: tty, altScreen: true}
+	t := &tScreen{
+		tty:                tty,
+		altScreen:          true,
+		controlStringLimit: defaultControlStringLimit,
+	}
 
 	t.prepareCursorStyles()
 	t.prepareExtendedOSC()
@@ -181,72 +196,73 @@ func NewTerminfoScreenFromTty(tty Tty, opts ...TerminfoScreenOption) (Screen, er
 
 // tScreen represents a screen backed by a terminfo implementation.
 type tScreen struct {
-	tty           Tty
-	h             int
-	w             int
-	fini          bool
-	cells         CellBuffer
-	buffering     bool // true if we are collecting writes to buf instead of sending directly to out
-	buf           bytes.Buffer
-	curstyle      Style
-	style         Style
-	resizeQ       chan bool
-	quit          chan struct{}
-	keyQ          chan []byte
-	cx            int
-	cy            int
-	cls           bool // clear screen
-	cursorx       int
-	cursory       int
-	acs           map[rune]string
-	charset       string
-	encoder       transform.Transformer
-	decoder       transform.Transformer
-	fallback      map[rune]string
-	ncolor        int
-	colors        map[color.Color]color.Color
-	palette       []color.Color
-	truecolor     bool
-	noColor       bool
-	legacy        bool
-	hasClipboard  bool // true if OSC 52 reported via DA1
-	finiOnce      sync.Once
-	enterUrl      string
-	exitUrl       string
-	setWinSize    string
-	cursorStyles  map[CursorStyle]string
-	cursorStyle   CursorStyle
-	cursorColor   color.Color
-	cursorRGB     string
-	cursorFg      string
-	stopQ         chan struct{}
-	eventQ        chan Event
-	initQ         chan Event
-	initted       bool
-	running       bool
-	startTime     time.Time
-	wg            sync.WaitGroup
-	mouseFlags    MouseFlags
-	pasteEnabled  bool
-	focusEnabled  bool
-	setTitle      string
-	saveTitle     string
-	restoreTitle  string
-	title         string
-	setClipboard  string
-	notifyDesktop string
-	termName      string
-	termVers      string
-	term          string // value from $TERM
-	altScreen     bool
-	inlineResize  bool
-	haveMouse     bool
-	haveMouseSgr  bool
-	haveKittyKbd  bool
-	haveWin32Kbd  bool
-	haveXTermKbd  bool
-	advancedKeys  bool
-	input         *inputParser
+	tty                Tty
+	h                  int
+	w                  int
+	fini               bool
+	cells              CellBuffer
+	buffering          bool // true if we are collecting writes to buf instead of sending directly to out
+	buf                bytes.Buffer
+	curstyle           Style
+	style              Style
+	resizeQ            chan bool
+	quit               chan struct{}
+	keyQ               chan []byte
+	cx                 int
+	cy                 int
+	cls                bool // clear screen
+	cursorx            int
+	cursory            int
+	acs                map[rune]string
+	charset            string
+	encoder            transform.Transformer
+	decoder            transform.Transformer
+	fallback           map[rune]string
+	ncolor             int
+	colors             map[color.Color]color.Color
+	palette            []color.Color
+	truecolor          bool
+	noColor            bool
+	legacy             bool
+	hasClipboard       bool // true if OSC 52 reported via DA1
+	finiOnce           sync.Once
+	enterUrl           string
+	exitUrl            string
+	setWinSize         string
+	cursorStyles       map[CursorStyle]string
+	cursorStyle        CursorStyle
+	cursorColor        color.Color
+	cursorRGB          string
+	cursorFg           string
+	stopQ              chan struct{}
+	eventQ             chan Event
+	initQ              chan Event
+	initted            bool
+	running            bool
+	startTime          time.Time
+	wg                 sync.WaitGroup
+	mouseFlags         MouseFlags
+	pasteEnabled       bool
+	focusEnabled       bool
+	setTitle           string
+	saveTitle          string
+	restoreTitle       string
+	title              string
+	setClipboard       string
+	notifyDesktop      string
+	termName           string
+	termVers           string
+	term               string // value from $TERM
+	altScreen          bool
+	inlineResize       bool
+	haveMouse          bool
+	haveMouseSgr       bool
+	haveKittyKbd       bool
+	haveWin32Kbd       bool
+	haveXTermKbd       bool
+	advancedKeys       bool
+	controlStringLimit int
+	input              *inputParser
 	sync.Mutex
 }
 
@@ -335,6 +351,7 @@ func (t *tScreen) Init() error {
 	t.eventQ = make(chan Event, 128)
 	t.input = newInputParser(t.filterEvents())
 	t.input.advanced = t.advancedKeys
+	t.input.controlStringMax = t.controlStringLimit
 
 	t.Lock()
 	t.cx = -1

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -138,6 +138,62 @@ func TestOptAdvancedKeys(t *testing.T) {
 	}
 }
 
+func TestOptControlStringLimit(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt, OptControlStringLimit(4096))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if ts.controlStringLimit != 4096 {
+		t.Fatalf("control string limit = %d, want %d", ts.controlStringLimit, 4096)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+	if ts.input.controlStringMax != 4096 {
+		t.Fatalf("input parser control string limit = %d, want %d", ts.input.controlStringMax, 4096)
+	}
+}
+
+func TestOptControlStringLimitUnlimited(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt, OptControlStringLimit(0))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+
+	payload := bytes.Repeat([]byte{'x'}, defaultControlStringLimit+1)
+	ts.input.ScanUTF8(append([]byte("\x1b]"), payload...))
+
+	if ts.input.state != istOsc {
+		t.Fatalf("parser state = %v, want %v", ts.input.state, istOsc)
+	}
+	if !bytes.Equal(ts.input.strBuf, payload) {
+		t.Fatalf("string buffer length = %d, want %d", len(ts.input.strBuf), len(payload))
+	}
+}
+
 func TestOptSanitizeContent(t *testing.T) {
 	t.Run("disabled by default", func(t *testing.T) {
 		mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})


### PR DESCRIPTION
## Summary
- cap inbound OSC/XDA control-string payloads at 64 KiB by default
- add `OptControlStringLimit` so callers can tune or disable the cap
- discard oversized control strings through their real terminator so payload tails never re-enter normal key parsing

## Validation
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum size for control-string payloads (OSC/XDA); default 64 KiB and option to disable.
  * Over-limit control strings are discarded to protect parsing and resources; limit is applied consistently across nested parsing.

* **Bug Fixes**
  * Parser now reliably recovers and resumes normal input processing after over-limit control sequences terminate.

* **Tests**
  * Added coverage for limit behavior, boundary cases, unlimited mode, and recovery after embedded escapes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->