### PR TITLE
fix: cells should be marked dirty even if they have no content (fixes…

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -25,7 +25,15 @@ type cell struct {
 
 func (c *cell) setDirty(dirty bool) {
 	if dirty {
-		c.lastStr = ""
+		// Empty cells use currStr == "" until they are first drawn, at which
+		// point SetDirty(false) normalizes them to a space.  Using "" as the
+		// dirty marker for an untouched empty cell would therefore leave
+		// lastStr == currStr and fail to force a redraw.
+		if c.currStr == "" {
+			c.lastStr = " "
+		} else {
+			c.lastStr = ""
+		}
 	} else {
 		if c.currStr == "" {
 			c.currStr = " "
@@ -126,7 +134,7 @@ func (cb *CellBuffer) Size() (int, int) {
 // Invalidate marks all characters within the buffer as dirty.
 func (cb *CellBuffer) Invalidate() {
 	for i := range cb.cells {
-		cb.cells[i].lastStr = ""
+		cb.cells[i].setDirty(true)
 	}
 }
 

--- a/cell_test.go
+++ b/cell_test.go
@@ -144,6 +144,17 @@ func TestCellBufferLockResizeFill(t *testing.T) {
 	}
 }
 
+func TestCellBufferUnlockUntouchedCellMarksDirty(t *testing.T) {
+	cb := &CellBuffer{w: 1, h: 1, cells: make([]cell, 1)}
+
+	cb.LockCell(0, 0)
+	cb.UnlockCell(0, 0)
+
+	if !cb.Dirty(0, 0) {
+		t.Fatalf("unlocking an untouched blank cell should mark it dirty")
+	}
+}
+
 func TestCellBufferOutOfRangeAndResizeNoop(t *testing.T) {
 	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -212,6 +212,20 @@ func TestNewScreenShimScreen(t *testing.T) {
 	}
 }
 
+func TestUnlockRegionRedrawsUntouchedBlankCell(t *testing.T) {
+	mt, scr := NewMockScreen(t, vt.MockOptSize{X: 1, Y: 1})
+	defer scr.Fini()
+
+	mt.Backend().Put(vt.Coord{X: 0, Y: 0}, vt.Cell{C: "X", S: vt.BaseStyle, W: 1})
+	scr.LockRegion(0, 0, 1, 1, true)
+	scr.LockRegion(0, 0, 1, 1, false)
+	scr.Show()
+
+	if got := mt.GetCell(vt.Coord{X: 0, Y: 0}); got.C != " " || got.W != 1 {
+		t.Fatalf("unlocking an untouched blank cell should repaint a space, got %#v", got)
+	}
+}
+
 func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
 	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
 	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))


### PR DESCRIPTION
… #1089)

The problem here was that when a cell was unlocked, we didn't mark it dirty properly because it had never had any content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty cell rendering behavior during buffer invalidation and region unlock operations, ensuring untouched empty cells redraw consistently.

* **Tests**
  * Added tests to verify proper cell state management and redraw behavior for empty cells.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->