### PR TITLE
fix: lock SetSize screen mutations

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1241,6 +1241,9 @@ func (t *tScreen) UnregisterRuneFallback(orig rune) {
 }
 
 func (t *tScreen) SetSize(w, h int) {
+	t.Lock()
+	defer t.Unlock()
+
 	if t.setWinSize != "" {
 		t.Printf(t.setWinSize, w, h)
 	}

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -138,6 +138,33 @@ func TestOptAdvancedKeys(t *testing.T) {
 	}
 }
 
+func TestSetSizeTakesScreenLock(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	ts := &tScreen{tty: mt, w: 8, h: 2}
+
+	done := make(chan struct{})
+	ts.Lock()
+	go func() {
+		ts.SetSize(8, 2)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		ts.Unlock()
+		t.Fatal("SetSize returned while the screen lock was held")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	ts.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SetSize did not return after the screen lock was released")
+	}
+}
+
 func TestOptControlStringLimit(t *testing.T) {
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
 	scr, err := NewTerminfoScreenFromTty(mt, OptControlStringLimit(4096))


### PR DESCRIPTION
## Summary
- lock `tScreen.SetSize` while it writes resize escapes and mutates screen state
- add a regression test proving `SetSize` waits on the screen mutex

## Why
`SetSize` could race with rendering and interleave direct TTY writes because it touched shared state without the same lock used by `Show` and `Sync`.

## Validation
- `go test ./...`
- `go test -race ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thread safety of screen resize operations by implementing proper synchronization mechanisms, ensuring consistent behavior when accessed by multiple concurrent operations. This enhancement strengthens the overall reliability and stability of window resizing.

* **Tests**
  * Added test case to validate screen resize functionality works correctly when accessed concurrently, confirming operations complete as expected once synchronization locks are released.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->