### PR TITLE
tscreen: prevent terminal mutation after Fini

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -520,6 +520,9 @@ func (t *tScreen) Fini() {
 }
 
 func (t *tScreen) finish() {
+	t.Lock()
+	t.fini = true
+	t.Unlock()
 	close(t.quit)
 	t.finalize()
 }

--- a/tscreen.go
+++ b/tscreen.go
@@ -789,6 +789,10 @@ func (t *tScreen) drawCell(x, y int) int {
 
 func (t *tScreen) ShowCursor(x, y int) {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.cursorx = x
 	t.cursory = y
 	t.Unlock()
@@ -796,6 +800,10 @@ func (t *tScreen) ShowCursor(x, y int) {
 
 func (t *tScreen) SetCursor(cs CursorStyle, cc Color) {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.cursorStyle = cs
 	t.cursorColor = cc
 	t.Unlock()
@@ -941,6 +949,10 @@ func (t *tScreen) EnableMouse(flags ...MouseFlags) {
 	}
 
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.mouseFlags = f
 	t.enableMouse(f)
 	t.Unlock()
@@ -993,6 +1005,10 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 
 func (t *tScreen) DisableMouse() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.mouseFlags = 0
 	t.enableMouse(0)
 	t.Unlock()
@@ -1000,6 +1016,10 @@ func (t *tScreen) DisableMouse() {
 
 func (t *tScreen) EnablePaste() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.pasteEnabled = true
 	t.enablePasting(true)
 	t.Unlock()
@@ -1007,6 +1027,10 @@ func (t *tScreen) EnablePaste() {
 
 func (t *tScreen) DisablePaste() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.pasteEnabled = false
 	t.enablePasting(false)
 	t.Unlock()
@@ -1026,6 +1050,10 @@ func (t *tScreen) enablePasting(on bool) {
 
 func (t *tScreen) EnableFocus() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.focusEnabled = true
 	t.enableFocusReporting()
 	t.Unlock()
@@ -1033,6 +1061,10 @@ func (t *tScreen) EnableFocus() {
 
 func (t *tScreen) DisableFocus() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.focusEnabled = false
 	t.disableFocusReporting()
 	t.Unlock()
@@ -1246,7 +1278,9 @@ func (t *tScreen) UnregisterRuneFallback(orig rune) {
 func (t *tScreen) SetSize(w, h int) {
 	t.Lock()
 	defer t.Unlock()
-
+	if t.fini {
+		return
+	}
 	if t.setWinSize != "" {
 		t.Printf(t.setWinSize, w, h)
 	}
@@ -1257,11 +1291,23 @@ func (t *tScreen) SetSize(w, h int) {
 func (t *tScreen) Resize(int, int, int, int) {}
 
 func (t *tScreen) Suspend() error {
+	t.Lock()
+	fini := t.fini
+	t.Unlock()
+	if fini {
+		return nil
+	}
 	t.disengage()
 	return nil
 }
 
 func (t *tScreen) Resume() error {
+	t.Lock()
+	fini := t.fini
+	t.Unlock()
+	if fini {
+		return nil
+	}
 	return t.engage()
 }
 
@@ -1441,6 +1487,12 @@ func (t *tScreen) disengage() {
 
 // Beep emits a beep to the terminal.
 func (t *tScreen) Beep() error {
+	t.Lock()
+	fini := t.fini
+	t.Unlock()
+	if fini {
+		return nil
+	}
 	t.Print(string(byte(7)))
 	return nil
 }
@@ -1467,6 +1519,10 @@ func (t *tScreen) GetCells() *CellBuffer {
 
 func (t *tScreen) SetTitle(title string) {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.title = stripOSCControlsIfNeeded(title)
 	if t.setTitle != "" && t.running {
 		t.Printf(t.setTitle, t.title)
@@ -1477,6 +1533,10 @@ func (t *tScreen) SetTitle(title string) {
 func (t *tScreen) SetClipboard(data []byte) {
 	// Post binary data to the system clipboard.  It might be UTF-8, it might not be.
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	if t.setClipboard != "" {
 		encoded := base64.StdEncoding.EncodeToString(data)
 		t.Printf(t.setClipboard, encoded)
@@ -1486,6 +1546,10 @@ func (t *tScreen) SetClipboard(data []byte) {
 
 func (t *tScreen) GetClipboard() {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	if t.setClipboard != "" {
 		t.Printf(t.setClipboard, "?")
 	}
@@ -1498,6 +1562,10 @@ func (t *tScreen) HasClipboard() bool {
 
 func (t *tScreen) ShowNotification(title string, body string) {
 	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return
+	}
 	t.Printf(t.notifyDesktop, stripOSCControlsIfNeeded(title), stripOSCControlsIfNeeded(body))
 	t.Unlock()
 }

--- a/tscreen.go
+++ b/tscreen.go
@@ -1292,23 +1292,25 @@ func (t *tScreen) Resize(int, int, int, int) {}
 
 func (t *tScreen) Suspend() error {
 	t.Lock()
-	fini := t.fini
-	t.Unlock()
-	if fini {
+	if t.fini {
+		t.Unlock()
 		return nil
 	}
-	t.disengage()
+	finish := t.disengageLocked()
+	t.Unlock()
+	if finish {
+		t.finishDisengage()
+	}
 	return nil
 }
 
 func (t *tScreen) Resume() error {
 	t.Lock()
-	fini := t.fini
-	t.Unlock()
-	if fini {
+	defer t.Unlock()
+	if t.fini {
 		return nil
 	}
-	return t.engage()
+	return t.engageLocked()
 }
 
 func (t *tScreen) Tty() (Tty, bool) {
@@ -1321,6 +1323,11 @@ func (t *tScreen) Tty() (Tty, bool) {
 func (t *tScreen) engage() error {
 	t.Lock()
 	defer t.Unlock()
+	return t.engageLocked()
+}
+
+// engageLocked is engage's implementation when t's lock is already held.
+func (t *tScreen) engageLocked() error {
 	if t.tty == nil {
 		return ErrNoScreen
 	}
@@ -1423,11 +1430,19 @@ func (t *tScreen) engage() error {
 // can take over the terminal interface.  This restores the TTY mode that was
 // present when the application was first started.
 func (t *tScreen) disengage() {
-
 	t.Lock()
+	finish := t.disengageLocked()
+	t.Unlock()
+	if finish {
+		t.finishDisengage()
+	}
+}
+
+// disengageLocked starts a disengage operation while t's lock is already held.
+// It returns true when finishDisengage must be called after releasing the lock.
+func (t *tScreen) disengageLocked() bool {
 	if !t.running {
-		t.Unlock()
-		return
+		return false
 	}
 
 	t.running = false
@@ -1439,8 +1454,12 @@ func (t *tScreen) disengage() {
 	stopQ := t.stopQ
 	close(stopQ)
 	_ = t.tty.Drain()
-	t.Unlock()
+	return true
+}
 
+// finishDisengage completes a disengage operation after disengageLocked has
+// released the running loops.
+func (t *tScreen) finishDisengage() {
 	// wait for everything to shut down
 	t.wg.Wait()
 
@@ -1488,9 +1507,8 @@ func (t *tScreen) disengage() {
 // Beep emits a beep to the terminal.
 func (t *tScreen) Beep() error {
 	t.Lock()
-	fini := t.fini
-	t.Unlock()
-	if fini {
+	defer t.Unlock()
+	if t.fini {
 		return nil
 	}
 	t.Print(string(byte(7)))

--- a/tscreen.go
+++ b/tscreen.go
@@ -1296,10 +1296,10 @@ func (t *tScreen) Suspend() error {
 		t.Unlock()
 		return nil
 	}
-	finish := t.disengageLocked()
+	finish := t.disengageStart()
 	t.Unlock()
 	if finish {
-		t.finishDisengage()
+		t.disengageFinish()
 	}
 	return nil
 }
@@ -1431,16 +1431,16 @@ func (t *tScreen) engageLocked() error {
 // present when the application was first started.
 func (t *tScreen) disengage() {
 	t.Lock()
-	finish := t.disengageLocked()
+	finish := t.disengageStart()
 	t.Unlock()
 	if finish {
-		t.finishDisengage()
+		t.disengageFinish()
 	}
 }
 
-// disengageLocked starts a disengage operation while t's lock is already held.
-// It returns true when finishDisengage must be called after releasing the lock.
-func (t *tScreen) disengageLocked() bool {
+// disengageStart begins a disengage operation while t's lock is already held.
+// It returns true when disengageFinish must be called after releasing the lock.
+func (t *tScreen) disengageStart() bool {
 	if !t.running {
 		return false
 	}
@@ -1457,9 +1457,9 @@ func (t *tScreen) disengageLocked() bool {
 	return true
 }
 
-// finishDisengage completes a disengage operation after disengageLocked has
+// disengageFinish completes a disengage operation after disengageStart has
 // released the running loops.
-func (t *tScreen) finishDisengage() {
+func (t *tScreen) disengageFinish() {
 	// wait for everything to shut down
 	t.wg.Wait()
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -112,6 +112,40 @@ func TestOptAltScreenDefault(t *testing.T) {
 	}
 }
 
+func TestFiniPreventsSetStyleMutation(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt)
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+
+	before := StyleDefault.Foreground(ColorRed)
+	after := StyleDefault.Foreground(ColorBlue)
+	scr.SetStyle(before)
+	scr.Fini()
+	scr.SetStyle(after)
+
+	ts.Lock()
+	defer ts.Unlock()
+	if !ts.fini {
+		t.Fatal("screen was not marked finished")
+	}
+	if ts.style != before {
+		t.Fatal("SetStyle mutated the screen after Fini")
+	}
+}
+
 func TestOptAdvancedKeys(t *testing.T) {
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
 	scr, err := NewTerminfoScreenFromTty(mt, OptAdvancedKeys(true))

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -146,6 +146,85 @@ func TestFiniPreventsSetStyleMutation(t *testing.T) {
 	}
 }
 
+func TestFiniPreventsFurtherTerminalMutation(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
+	scr, err := NewTerminfoScreenFromTty(tty)
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+
+	scr.ShowCursor(1, 1)
+	scr.SetCursorStyle(CursorStyleSteadyBlock, ColorRed)
+	scr.EnableMouse()
+	scr.EnablePaste()
+	scr.EnableFocus()
+	scr.Fini()
+
+	beforeOutput := tty.Output()
+	ts.Lock()
+	beforeCursorX, beforeCursorY := ts.cursorx, ts.cursory
+	beforeCursorStyle, beforeCursorColor := ts.cursorStyle, ts.cursorColor
+	beforeMouseFlags := ts.mouseFlags
+	beforePasteEnabled, beforeFocusEnabled := ts.pasteEnabled, ts.focusEnabled
+	ts.Unlock()
+
+	scr.ShowCursor(2, 1)
+	scr.SetCursorStyle(CursorStyleBlinkingBar, ColorBlue)
+	scr.EnableMouse(MouseMotionEvents)
+	scr.DisableMouse()
+	scr.EnablePaste()
+	scr.DisablePaste()
+	scr.EnableFocus()
+	scr.DisableFocus()
+	scr.SetSize(20, 10)
+	if err := scr.Suspend(); err != nil {
+		t.Fatalf("Suspend after Fini failed: %v", err)
+	}
+	if err := scr.Resume(); err != nil {
+		t.Fatalf("Resume after Fini failed: %v", err)
+	}
+	if err := scr.Beep(); err != nil {
+		t.Fatalf("Beep after Fini failed: %v", err)
+	}
+	scr.SetTitle("after")
+	scr.SetClipboard([]byte("after"))
+	scr.GetClipboard()
+	scr.ShowNotification("after", "after")
+
+	if got := tty.Output(); got != beforeOutput {
+		t.Fatal("terminal output changed after Fini")
+	}
+
+	ts.Lock()
+	defer ts.Unlock()
+	if ts.cursorx != beforeCursorX || ts.cursory != beforeCursorY {
+		t.Fatal("cursor position changed after Fini")
+	}
+	if ts.cursorStyle != beforeCursorStyle || ts.cursorColor != beforeCursorColor {
+		t.Fatal("cursor style changed after Fini")
+	}
+	if ts.mouseFlags != beforeMouseFlags {
+		t.Fatal("mouse flags changed after Fini")
+	}
+	if ts.pasteEnabled != beforePasteEnabled {
+		t.Fatal("paste state changed after Fini")
+	}
+	if ts.focusEnabled != beforeFocusEnabled {
+		t.Fatal("focus state changed after Fini")
+	}
+}
+
 func TestOptAdvancedKeys(t *testing.T) {
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
 	scr, err := NewTerminfoScreenFromTty(mt, OptAdvancedKeys(true))


### PR DESCRIPTION
## Summary
- mark terminfo screens finished before shutdown begins so existing post-`Fini()` guards become effective
- prevent the remaining public terminal-mutating methods from changing state or emitting output after `Fini()`
- add regression coverage for both the original shutdown flag bug and the broader post-shutdown no-op behavior

## Validation
- `go test ./...`
- `go test -race ./...`

Fixes #1091


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations after screen shutdown are now reliably blocked from changing state or emitting output, including cursor/display, mouse, paste, focus reporting, resize, suspend/resume, beep, window title/clipboard, notifications, and style updates — preventing post-shutdown side effects.

* **Tests**
  * Added tests verifying shutdown prevents further terminal mutations and that prior terminal output and internal state remain unchanged after finalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->