### PR TITLE
Avoid extra keyboard protocols on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ than respecting themes. For other cases, such as typical text apps that
 only use a few colors, its more desirable to respect the themes that
 the user has established.)
 
+## Terminal Overrides
+
+_Tcell_ normally negotiates terminal capabilities automatically, but some
+terminal emulators answer those queries incorrectly. These environment
+variables provide user escape hatches when the automatic path is not reliable:
+
+- `TCELL_KEYBOARD_PROTOCOL=auto|legacy|kitty|win32|xterm` forces the keyboard
+  reporting protocol.
+- `TCELL_NEGOTIATE=auto|disable` disables startup capability negotiation when
+  terminal responses themselves are problematic.
+- `TCELL_MOUSE=auto|disable` prevents applications from enabling terminal mouse
+  reporting.
+
+Applications can also choose a keyboard protocol with `OptKeyboardProtocol` or
+disable startup negotiation with `OptNegotiation`. Environment variables take
+precedence so users can recover from bad terminal behavior without modifying an
+application.
+
 ## Performance
 
 Reasonable attempts have been made to minimize sending data to terminals,

--- a/_demos/mouse.go
+++ b/_demos/mouse.go
@@ -36,6 +36,21 @@ func isCtrlRune(ev *tcell.EventKey, r string) bool {
 	return ev.Key() == tcell.KeyRune && ev.Str() == r && ev.Modifiers()&tcell.ModCtrl != 0
 }
 
+func keyboardProtocolName(p tcell.KeyProtocol) string {
+	switch p {
+	case tcell.LegacyKeyboard:
+		return "Legacy"
+	case tcell.KittyKeyboard:
+		return "Kitty"
+	case tcell.Win32Keyboard:
+		return "Win32"
+	case tcell.XTermKeyboard:
+		return "XTerm"
+	default:
+		return "Unknown"
+	}
+}
+
 func drawBox(s tcell.Screen, x1, y1, x2, y2 int, style tcell.Style, r rune) {
 	rs := string(r)
 
@@ -128,6 +143,7 @@ func main() {
 	pastefmt := "Paste: [%d] %s"
 	focusfmt := "Focus: %s"
 	termFmt := "Term: %s (%s)"
+	kbdFmt := "Keyboard: %s"
 	style := tcell.StyleDefault.
 		Foreground(color.MidnightBlue).Background(color.LightCoral)
 	keyDownStyle := style.Foreground(color.Green)
@@ -149,7 +165,7 @@ func main() {
 	keyStyle := keyUpStyle
 
 	for {
-		drawBox(s, 1, 1, 42, 9, style, ' ')
+		drawBox(s, 1, 1, 42, 10, style, ' ')
 		s.PutStrStyled(2, 2, "Press Ctrl-Q to Quit, C to clear.", style)
 		s.PutStrStyled(2, 3, fmt.Sprintf(posfmt, mx, my), style)
 		s.PutStrStyled(2, 4, fmt.Sprintf(btnfmt, bstr), style)
@@ -170,6 +186,7 @@ func main() {
 
 		n, v := s.Terminal()
 		s.PutStrStyled(2, 8, fmt.Sprintf(termFmt, n, v), style)
+		s.PutStrStyled(2, 9, fmt.Sprintf(kbdFmt, keyboardProtocolName(s.KeyboardProtocol())), style)
 
 		s.Show()
 		bstr = ""

--- a/tscreen.go
+++ b/tscreen.go
@@ -1273,6 +1273,8 @@ func (t *tScreen) applyKnownTerminalProfile(goos, termProgram string) bool {
 		// support modern mouse reporting.
 		t.haveMouse = true
 		t.haveMouseSgr = true
+		t.termName = "Terminal.app"
+		t.termVers = os.Getenv("TERM_PROGRAM_VERSION")
 		return true
 	case "WezTerm":
 		if goos == "windows" {
@@ -1284,6 +1286,8 @@ func (t *tScreen) applyKnownTerminalProfile(goos, termProgram string) bool {
 			t.haveMouse = true
 			t.haveMouseSgr = true
 			t.initted = true
+			t.termName = "WezTerm"
+			t.termVers = os.Getenv("TERM_PROGRAM_VERSION")
 			return true
 		}
 	}

--- a/tscreen.go
+++ b/tscreen.go
@@ -103,6 +103,22 @@ func (o OptAdvancedKeys) apply(t *tScreen) {
 	t.advancedKeys = bool(o)
 }
 
+// OptKeyboardProtocol forces the keyboard reporting protocol instead of using
+// startup negotiation. The zero value forces legacy keyboard reporting.
+type OptKeyboardProtocol KeyProtocol
+
+func (o OptKeyboardProtocol) apply(t *tScreen) {
+	t.forceKeyboardProtocol(KeyProtocol(o))
+}
+
+// OptNegotiation controls whether terminal capabilities are negotiated during
+// startup. The default is true.
+type OptNegotiation bool
+
+func (o OptNegotiation) apply(t *tScreen) {
+	t.negotiate = bool(o)
+}
+
 // OptControlStringLimit sets the maximum inbound control-string payload size
 // accepted from the terminal before the parser drops the sequence. This limits
 // OSC and XDA strings, including OSC 52 clipboard strings; OSC 52 is the
@@ -178,6 +194,7 @@ func NewTerminfoScreenFromTty(tty Tty, opts ...TerminfoScreenOption) (Screen, er
 	t := &tScreen{
 		tty:                tty,
 		altScreen:          true,
+		negotiate:          true,
 		controlStringLimit: defaultControlStringLimit,
 	}
 
@@ -260,6 +277,10 @@ type tScreen struct {
 	haveKittyKbd       bool
 	haveWin32Kbd       bool
 	haveXTermKbd       bool
+	forcedKbd          KeyProtocol
+	forceKbd           bool
+	negotiate          bool
+	mouseDisabled      bool
 	advancedKeys       bool
 	controlStringLimit int
 	input              *inputParser
@@ -268,6 +289,69 @@ type tScreen struct {
 
 func (t *tScreen) useAltScreen() bool {
 	return t.altScreen && os.Getenv("TCELL_ALTSCREEN") != "disable"
+}
+
+func validKeyboardProtocol(p KeyProtocol) bool {
+	switch p {
+	case LegacyKeyboard, KittyKeyboard, Win32Keyboard, XTermKeyboard:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseKeyboardProtocol(s string) (KeyProtocol, bool) {
+	switch s {
+	case "legacy":
+		return LegacyKeyboard, true
+	case "kitty":
+		return KittyKeyboard, true
+	case "win32":
+		return Win32Keyboard, true
+	case "xterm":
+		return XTermKeyboard, true
+	default:
+		return LegacyKeyboard, false
+	}
+}
+
+func (t *tScreen) forceKeyboardProtocol(p KeyProtocol) bool {
+	if !validKeyboardProtocol(p) {
+		return false
+	}
+	t.forcedKbd = p
+	t.forceKbd = true
+	return true
+}
+
+func (t *tScreen) applyKeyboardProtocolOverride() {
+	if !t.forceKbd {
+		return
+	}
+	t.haveKittyKbd = t.forcedKbd == KittyKeyboard
+	t.haveWin32Kbd = t.forcedKbd == Win32Keyboard
+	t.haveXTermKbd = t.forcedKbd == XTermKeyboard
+}
+
+func (t *tScreen) applyEnvironmentOverrides() {
+	switch os.Getenv("TCELL_KEYBOARD_PROTOCOL") {
+	case "auto":
+		t.forceKbd = false
+	case "":
+	default:
+		if p, ok := parseKeyboardProtocol(os.Getenv("TCELL_KEYBOARD_PROTOCOL")); ok {
+			t.forceKeyboardProtocol(p)
+		}
+	}
+
+	switch os.Getenv("TCELL_NEGOTIATE") {
+	case "auto":
+		t.negotiate = true
+	case "disable":
+		t.negotiate = false
+	}
+
+	t.mouseDisabled = os.Getenv("TCELL_MOUSE") == "disable"
 }
 
 func (t *tScreen) Init() error {
@@ -344,6 +428,8 @@ func (t *tScreen) Init() error {
 		// these terminals are "legacy" and not expected to support most OSC functions
 		t.legacy = true
 	}
+
+	t.applyEnvironmentOverrides()
 
 	t.initted = false
 	t.quit = make(chan struct{})
@@ -956,7 +1042,10 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 	// so we enable the mouse unconditionally unless we get a report
 	// that says we have mouse, but not SGR mouse.  This is suboptimal, but
 	// a concession forced by the sorry state of terminal emulators.
-	if t.haveMouse && !t.haveMouseSgr {
+	if t.mouseDisabled {
+		f = 0
+	}
+	if f != 0 && t.haveMouse && !t.haveMouseSgr {
 		return
 	}
 
@@ -1277,19 +1366,26 @@ func (t *tScreen) applyKnownTerminalProfile(goos, termProgram string) bool {
 		t.termVers = os.Getenv("TERM_PROGRAM_VERSION")
 		return true
 	case "WezTerm":
+		// The WezTerm keyboard protocol to use is in theory driven by its
+		// own configuration, but we have found this unreliable because it
+		// does not mask unsupported capabilities.  Furthermore, on Windows
+		// builds the kitty protocol implementation is broken, while on other
+		// builds win32-input-mode is broken.  This is a best effort to make
+		// WezTerm work reasonably; our stronger advice is to choose another
+		// terminal program altogether.  This workaround will probably not
+		// apply to ssh sessions, as TERM_PROGRAM is not normally propagated.
 		if goos == "windows" {
-			// Local WezTerm sessions on Windows support these features, but
-			// ConPTY prevents the normal negotiation from reaching us
-			// reliably. Remote sessions do not inherit TERM_PROGRAM by
-			// default, so they continue to use ordinary negotiation.
 			t.haveWin32Kbd = true
-			t.haveMouse = true
-			t.haveMouseSgr = true
-			t.initted = true
-			t.termName = "WezTerm"
-			t.termVers = os.Getenv("TERM_PROGRAM_VERSION")
-			return true
+		} else {
+			t.haveKittyKbd = true
+			t.haveWin32Kbd = false
 		}
+		t.haveMouse = true
+		t.haveMouseSgr = true
+		t.initted = true
+		t.termName = "WezTerm"
+		t.termVers = os.Getenv("TERM_PROGRAM_VERSION")
+		return true
 	}
 	return false
 }
@@ -1330,27 +1426,32 @@ func (t *tScreen) engage() error {
 		// Eventually they'll hopefully fix this.  As the environment variable
 		// does not convey by default via ssh, remote sessions might see spurious characters
 		// emitted during startup.  See the blog post for alternatives.
-		if !t.applyKnownTerminalProfile(runtime.GOOS, os.Getenv("TERM_PROGRAM")) {
+		if !t.applyKnownTerminalProfile(runtime.GOOS, os.Getenv("TERM_PROGRAM")) && t.negotiate {
 			if useVTWindowSizeQuery(runtime.GOOS) {
 				t.Print(requestWindowSize)
 			}
 			t.Print(vt.PmResizeReports.Query())
 			t.Print(vt.PmMouseButton.Query())
 			t.Print(vt.PmMouseSgr.Query())
-			t.Print(vt.PmWin32Input.Query())
-			t.Print(queryKittyKbd)
-			if useXTermKeyboardQuery(runtime.GOOS) {
-				// XTerm's modifyOtherKeys mode is mainly useful for XTerm
-				// itself, and we do not use it on Windows.
-				t.Print(queryXTermKbd)
+			if !t.forceKbd {
+				t.Print(vt.PmWin32Input.Query())
+				t.Print(queryKittyKbd)
+				if useXTermKeyboardQuery(runtime.GOOS) {
+					// XTerm's modifyOtherKeys mode is mainly useful for XTerm
+					// itself, and we do not use it on Windows.
+					t.Print(queryXTermKbd)
+				}
 			}
 			t.Print(requestExtAttr)
 		}
-		if !t.initted {
+		if !t.negotiate {
+			t.initted = true
+		} else if !t.initted {
 			t.Print(requestPrimaryDA) // NB: MUST BE LAST
 		}
 	}
 	t.processInitQ()
+	t.applyKeyboardProtocolOverride()
 	if t.useAltScreen() {
 		// Technically this may not be right, but every terminal we know about
 		// (even Wyse 60) uses this to enter the alternate screen buffer, and
@@ -1389,7 +1490,7 @@ func (t *tScreen) engage() error {
 	if t.title != "" && t.setTitle != "" {
 		t.Printf(t.setTitle, t.title)
 	}
-	if useVTWindowSizeQuery(runtime.GOOS) {
+	if t.negotiate && useVTWindowSizeQuery(runtime.GOOS) {
 		t.Print(requestWindowSize)
 	}
 

--- a/tscreen.go
+++ b/tscreen.go
@@ -1345,10 +1345,6 @@ func (t *tScreen) engage() error {
 				t.Print(queryXTermKbd)
 			}
 			t.Print(requestExtAttr)
-			// Some terminals can answer DA ahead of earlier startup queries,
-			// despite receiving DA last.  Give the preceding query batch a
-			// small head start before using DA as the initialization sentinel.
-			time.Sleep(25 * time.Millisecond)
 		}
 		if !t.initted {
 			t.Print(requestPrimaryDA) // NB: MUST BE LAST

--- a/tscreen.go
+++ b/tscreen.go
@@ -1266,6 +1266,38 @@ func (t *tScreen) Tty() (Tty, bool) {
 	return t.tty, true
 }
 
+func (t *tScreen) applyKnownTerminalProfile(goos, termProgram string) bool {
+	switch termProgram {
+	case "Apple_Terminal":
+		// macOS Terminal.app cannot handle the startup queries, but it does
+		// support modern mouse reporting.
+		t.haveMouse = true
+		t.haveMouseSgr = true
+		return true
+	case "WezTerm":
+		if goos == "windows" {
+			// Local WezTerm sessions on Windows support these features, but
+			// ConPTY prevents the normal negotiation from reaching us
+			// reliably. Remote sessions do not inherit TERM_PROGRAM by
+			// default, so they continue to use ordinary negotiation.
+			t.haveWin32Kbd = true
+			t.haveMouse = true
+			t.haveMouseSgr = true
+			t.initted = true
+			return true
+		}
+	}
+	return false
+}
+
+func useVTWindowSizeQuery(goos string) bool {
+	return goos != "windows"
+}
+
+func useXTermKeyboardQuery(goos string) bool {
+	return goos != "windows"
+}
+
 // engage is used to place the terminal in raw mode and establish screen size, etc.
 // Think of this is as tcell "engaging" the clutch, as it's going to be driving the
 // terminal interface.
@@ -1289,22 +1321,34 @@ func (t *tScreen) engage() error {
 	go t.mainLoop(stopQ)
 
 	if !t.initted {
-		t.Print(requestWindowSize)
 		// macOS Terminal.app is brain damaged
 		// https://garrett.damore.org/2025/12/macos-terminal-still-missing-mark-apple.html
 		// Eventually they'll hopefully fix this.  As the environment variable
 		// does not convey by default via ssh, remote sessions might see spurious characters
 		// emitted during startup.  See the blog post for alternatives.
-		if os.Getenv("TERM_PROGRAM") != "Apple_Terminal" {
+		if !t.applyKnownTerminalProfile(runtime.GOOS, os.Getenv("TERM_PROGRAM")) {
+			if useVTWindowSizeQuery(runtime.GOOS) {
+				t.Print(requestWindowSize)
+			}
 			t.Print(vt.PmResizeReports.Query())
 			t.Print(vt.PmMouseButton.Query())
 			t.Print(vt.PmMouseSgr.Query())
 			t.Print(vt.PmWin32Input.Query())
 			t.Print(queryKittyKbd)
-			t.Print(queryXTermKbd)
+			if useXTermKeyboardQuery(runtime.GOOS) {
+				// XTerm's modifyOtherKeys mode is mainly useful for XTerm
+				// itself, and we do not use it on Windows.
+				t.Print(queryXTermKbd)
+			}
 			t.Print(requestExtAttr)
+			// Some terminals can answer DA ahead of earlier startup queries,
+			// despite receiving DA last.  Give the preceding query batch a
+			// small head start before using DA as the initialization sentinel.
+			time.Sleep(25 * time.Millisecond)
 		}
-		t.Print(requestPrimaryDA) // NB: MUST BE LAST
+		if !t.initted {
+			t.Print(requestPrimaryDA) // NB: MUST BE LAST
+		}
 	}
 	t.processInitQ()
 	if t.useAltScreen() {
@@ -1345,21 +1389,9 @@ func (t *tScreen) engage() error {
 	if t.title != "" && t.setTitle != "" {
 		t.Printf(t.setTitle, t.title)
 	}
-	if runtime.GOOS == "windows" {
-		// This workaround exists because of what we believe to be bugs in the
-		// interaction between ConPTY, the VT-Input layer, and some terminal emulators
-		// such as WezTerm.  Note that it is *not* needed for Windows Terminal, but
-		// should be benign there.  As another note, we have observed that at least Alacritty
-		// and WezTerm do not properly handle the primaryDA query on these platforms.
-		// (WezTerm performs much better when running a remote shell or on macOS.)
-		if t.advancedKeys {
-			t.Print(enableKittyKbdAdv)
-		} else {
-			t.Print(enableKittyKbd)
-		}
-		t.Print(vt.PmWin32Input.Enable())
+	if useVTWindowSizeQuery(runtime.GOOS) {
+		t.Print(requestWindowSize)
 	}
-	t.Print(requestWindowSize)
 
 	if t.inlineResize {
 		t.Print(vt.PmResizeReports.Enable())
@@ -1420,7 +1452,6 @@ func (t *tScreen) disengage() {
 	// Hack for Windows.
 	if runtime.GOOS == "windows" {
 		t.Print(vt.PmWin32Input.Disable())
-		t.Print(disableKittyKbd)
 	}
 
 	// t.Print(t.disableCsiU)

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -524,6 +524,43 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 	}
 }
 
+func TestAppleTerminalProfileSkipsStartupQueries(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	t.Setenv("TERM_PROGRAM_VERSION", "999")
+
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	out := tty.Output()
+	for _, seq := range []string{
+		vt.PmResizeReports.Query(),
+		vt.PmMouseButton.Query(),
+		vt.PmMouseSgr.Query(),
+		vt.PmWin32Input.Query(),
+		queryKittyKbd,
+		queryXTermKbd,
+		requestExtAttr,
+	} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("Apple Terminal profile emitted startup query %q", seq)
+		}
+	}
+	if !strings.Contains(out, requestPrimaryDA) {
+		t.Fatal("Apple Terminal profile did not emit primary DA")
+	}
+	name, version := s.Terminal()
+	if name != "Terminal.app" || version != "999" {
+		t.Fatalf("Terminal() = %q, %q, want %q, %q", name, version, "Terminal.app", "999")
+	}
+}
+
 func TestKeyboardProbePolicy(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -138,6 +138,44 @@ func TestOptAdvancedKeys(t *testing.T) {
 	}
 }
 
+func TestOptKeyboardProtocol(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt, OptKeyboardProtocol(KittyKeyboard))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if !ts.forceKbd || ts.forcedKbd != KittyKeyboard {
+		t.Fatalf("forced keyboard protocol = (%v, %v), want (true, %v)", ts.forceKbd, ts.forcedKbd, KittyKeyboard)
+	}
+}
+
+func TestOptNegotiation(t *testing.T) {
+	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
+	scr, err := NewTerminfoScreenFromTty(mt, OptNegotiation(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	bs, ok := scr.(*baseScreen)
+	if !ok {
+		t.Fatalf("expected *baseScreen, got %T", scr)
+	}
+	ts, ok := bs.screenImpl.(*tScreen)
+	if !ok {
+		t.Fatalf("expected *tScreen, got %T", bs.screenImpl)
+	}
+	if ts.negotiate {
+		t.Fatal("negotiation option was not applied")
+	}
+}
+
 func TestSetSizeTakesScreenLock(t *testing.T) {
 	mt := vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})
 	ts := &tScreen{tty: mt, w: 8, h: 2}
@@ -423,6 +461,7 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 		wantInitted  bool
 		wantMouse    bool
 		wantMouseSgr bool
+		wantKittyKbd bool
 		wantWin32Kbd bool
 	}{
 		{
@@ -444,9 +483,14 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 			wantWin32Kbd: true,
 		},
 		{
-			name:        "RemoteWezTerm",
-			goos:        "linux",
-			termProgram: "WezTerm",
+			name:         "LocalUnixWezTerm",
+			goos:         "linux",
+			termProgram:  "WezTerm",
+			wantKnown:    true,
+			wantInitted:  true,
+			wantMouse:    true,
+			wantMouseSgr: true,
+			wantKittyKbd: true,
 		},
 		{
 			name:        "UnknownTerminal",
@@ -469,6 +513,9 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 			}
 			if s.haveMouseSgr != tt.wantMouseSgr {
 				t.Fatalf("haveMouseSgr = %v, want %v", s.haveMouseSgr, tt.wantMouseSgr)
+			}
+			if s.haveKittyKbd != tt.wantKittyKbd {
+				t.Fatalf("haveKittyKbd = %v, want %v", s.haveKittyKbd, tt.wantKittyKbd)
 			}
 			if s.haveWin32Kbd != tt.wantWin32Kbd {
 				t.Fatalf("haveWin32Kbd = %v, want %v", s.haveWin32Kbd, tt.wantWin32Kbd)
@@ -505,6 +552,236 @@ func TestKeyboardProbePolicy(t *testing.T) {
 				t.Fatalf("useXTermKeyboardQuery() = %v, want %v", got, tt.wantXTermQuery)
 			}
 		})
+	}
+}
+
+func TestKeyboardProtocolHelpers(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      KeyProtocol
+		wantValid bool
+	}{
+		{name: "legacy", value: "legacy", want: LegacyKeyboard, wantValid: true},
+		{name: "kitty", value: "kitty", want: KittyKeyboard, wantValid: true},
+		{name: "win32", value: "win32", want: Win32Keyboard, wantValid: true},
+		{name: "xterm", value: "xterm", want: XTermKeyboard, wantValid: true},
+		{name: "invalid", value: "bogus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseKeyboardProtocol(tt.value)
+			if got != tt.want || ok != tt.wantValid {
+				t.Fatalf("parseKeyboardProtocol(%q) = (%v, %v), want (%v, %v)", tt.value, got, ok, tt.want, tt.wantValid)
+			}
+		})
+	}
+
+	if validKeyboardProtocol(KeyProtocol(99)) {
+		t.Fatal("invalid keyboard protocol was accepted")
+	}
+}
+
+func TestForceKeyboardProtocol(t *testing.T) {
+	s := &tScreen{
+		haveKittyKbd: true,
+		haveWin32Kbd: true,
+		haveXTermKbd: true,
+	}
+	if s.forceKeyboardProtocol(KeyProtocol(99)) {
+		t.Fatal("invalid keyboard protocol was forced")
+	}
+	if s.forceKbd {
+		t.Fatal("invalid keyboard protocol changed override state")
+	}
+	if !s.forceKeyboardProtocol(XTermKeyboard) {
+		t.Fatal("valid keyboard protocol was not forced")
+	}
+	s.applyKeyboardProtocolOverride()
+	if s.haveKittyKbd || s.haveWin32Kbd || !s.haveXTermKbd {
+		t.Fatalf("forced XTerm protocol state = kitty:%v win32:%v xterm:%v", s.haveKittyKbd, s.haveWin32Kbd, s.haveXTermKbd)
+	}
+}
+
+func TestApplyEnvironmentOverrides(t *testing.T) {
+	tests := []struct {
+		name             string
+		keyboardProtocol string
+		negotiate        string
+		mouse            string
+		startForceKbd    bool
+		startForcedKbd   KeyProtocol
+		startNegotiate   bool
+		wantForceKbd     bool
+		wantForcedKbd    KeyProtocol
+		wantNegotiate    bool
+		wantMouseOff     bool
+	}{
+		{
+			name:           "defaults",
+			startNegotiate: true,
+			wantNegotiate:  true,
+			wantForcedKbd:  LegacyKeyboard,
+		},
+		{
+			name:             "force all",
+			keyboardProtocol: "win32",
+			negotiate:        "disable",
+			mouse:            "disable",
+			startNegotiate:   true,
+			wantForceKbd:     true,
+			wantForcedKbd:    Win32Keyboard,
+			wantMouseOff:     true,
+		},
+		{
+			name:             "auto resets options",
+			keyboardProtocol: "auto",
+			negotiate:        "auto",
+			startForceKbd:    true,
+			startForcedKbd:   KittyKeyboard,
+			wantNegotiate:    true,
+			wantForcedKbd:    KittyKeyboard,
+		},
+		{
+			name:             "invalid leaves options",
+			keyboardProtocol: "bogus",
+			negotiate:        "bogus",
+			startForceKbd:    true,
+			startForcedKbd:   XTermKeyboard,
+			startNegotiate:   false,
+			wantForceKbd:     true,
+			wantForcedKbd:    XTermKeyboard,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TCELL_KEYBOARD_PROTOCOL", tt.keyboardProtocol)
+			t.Setenv("TCELL_NEGOTIATE", tt.negotiate)
+			t.Setenv("TCELL_MOUSE", tt.mouse)
+			s := &tScreen{
+				forceKbd:  tt.startForceKbd,
+				forcedKbd: tt.startForcedKbd,
+				negotiate: tt.startNegotiate,
+			}
+			s.applyEnvironmentOverrides()
+			if s.forceKbd != tt.wantForceKbd {
+				t.Fatalf("forceKbd = %v, want %v", s.forceKbd, tt.wantForceKbd)
+			}
+			if s.forcedKbd != tt.wantForcedKbd {
+				t.Fatalf("forcedKbd = %v, want %v", s.forcedKbd, tt.wantForcedKbd)
+			}
+			if s.negotiate != tt.wantNegotiate {
+				t.Fatalf("negotiate = %v, want %v", s.negotiate, tt.wantNegotiate)
+			}
+			if s.mouseDisabled != tt.wantMouseOff {
+				t.Fatalf("mouseDisabled = %v, want %v", s.mouseDisabled, tt.wantMouseOff)
+			}
+		})
+	}
+}
+
+func TestForcedKeyboardProtocolSkipsKeyboardQueries(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "")
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptKeyboardProtocol(KittyKeyboard), OptAdvancedKeys(true), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	out := tty.Output()
+	for _, seq := range []string{vt.PmWin32Input.Query(), queryKittyKbd, queryXTermKbd} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("forced keyboard protocol emitted competing query %q", seq)
+		}
+	}
+	for _, seq := range []string{vt.PmResizeReports.Query(), vt.PmMouseButton.Query(), vt.PmMouseSgr.Query(), requestExtAttr} {
+		if !strings.Contains(out, seq) {
+			t.Fatalf("forced keyboard protocol suppressed unrelated query %q", seq)
+		}
+	}
+	if !strings.Contains(out, enableKittyKbdAdv) {
+		t.Fatalf("forced Kitty protocol did not emit advanced enable sequence")
+	}
+}
+
+func TestNegotiationDisabledSkipsStartupQueries(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "")
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	out := tty.Output()
+	for _, seq := range []string{
+		requestWindowSize,
+		vt.PmResizeReports.Query(),
+		vt.PmMouseButton.Query(),
+		vt.PmMouseSgr.Query(),
+		vt.PmWin32Input.Query(),
+		queryKittyKbd,
+		queryXTermKbd,
+		requestExtAttr,
+		requestPrimaryDA,
+	} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("disabled negotiation emitted startup query %q", seq)
+		}
+	}
+}
+
+func TestMouseDisabledPreventsEnablement(t *testing.T) {
+	t.Setenv("TCELL_MOUSE", "disable")
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	s.EnableMouse()
+	out := tty.Output()
+	for _, seq := range []string{vt.PmMouseButton.Enable(), vt.PmMouseDrag.Enable(), vt.PmMouseMotion.Enable(), vt.PmMouseSgr.Enable()} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("disabled mouse emitted enable sequence %q", seq)
+		}
+	}
+}
+
+func TestMouseWithoutSgrPreventsEnablement(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	ts := s.(*baseScreen).screenImpl.(*tScreen)
+	ts.haveMouse = true
+	ts.haveMouseSgr = false
+	s.EnableMouse()
+
+	out := tty.Output()
+	for _, seq := range []string{vt.PmMouseButton.Enable(), vt.PmMouseDrag.Enable(), vt.PmMouseMotion.Enable(), vt.PmMouseSgr.Enable()} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("mouse without SGR support emitted enable sequence %q", seq)
+		}
 	}
 }
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -414,6 +414,100 @@ func TestKeyboardProtocol(t *testing.T) {
 	}
 }
 
+func TestApplyKnownTerminalProfile(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		termProgram  string
+		wantKnown    bool
+		wantInitted  bool
+		wantMouse    bool
+		wantMouseSgr bool
+		wantWin32Kbd bool
+	}{
+		{
+			name:         "AppleTerminal",
+			goos:         "darwin",
+			termProgram:  "Apple_Terminal",
+			wantKnown:    true,
+			wantMouse:    true,
+			wantMouseSgr: true,
+		},
+		{
+			name:         "LocalWindowsWezTerm",
+			goos:         "windows",
+			termProgram:  "WezTerm",
+			wantKnown:    true,
+			wantInitted:  true,
+			wantMouse:    true,
+			wantMouseSgr: true,
+			wantWin32Kbd: true,
+		},
+		{
+			name:        "RemoteWezTerm",
+			goos:        "linux",
+			termProgram: "WezTerm",
+		},
+		{
+			name:        "UnknownTerminal",
+			goos:        "linux",
+			termProgram: "Other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &tScreen{}
+			if got := s.applyKnownTerminalProfile(tt.goos, tt.termProgram); got != tt.wantKnown {
+				t.Fatalf("applyKnownTerminalProfile() = %v, want %v", got, tt.wantKnown)
+			}
+			if s.initted != tt.wantInitted {
+				t.Fatalf("initted = %v, want %v", s.initted, tt.wantInitted)
+			}
+			if s.haveMouse != tt.wantMouse {
+				t.Fatalf("haveMouse = %v, want %v", s.haveMouse, tt.wantMouse)
+			}
+			if s.haveMouseSgr != tt.wantMouseSgr {
+				t.Fatalf("haveMouseSgr = %v, want %v", s.haveMouseSgr, tt.wantMouseSgr)
+			}
+			if s.haveWin32Kbd != tt.wantWin32Kbd {
+				t.Fatalf("haveWin32Kbd = %v, want %v", s.haveWin32Kbd, tt.wantWin32Kbd)
+			}
+		})
+	}
+}
+
+func TestKeyboardProbePolicy(t *testing.T) {
+	tests := []struct {
+		name                string
+		goos                string
+		wantWindowSizeQuery bool
+		wantXTermQuery      bool
+	}{
+		{
+			name:                "Unix",
+			goos:                "linux",
+			wantWindowSizeQuery: true,
+			wantXTermQuery:      true,
+		},
+		{
+			name: "Windows",
+			goos: "windows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := useVTWindowSizeQuery(tt.goos); got != tt.wantWindowSizeQuery {
+				t.Fatalf("useVTWindowSizeQuery() = %v, want %v", got, tt.wantWindowSizeQuery)
+			}
+			if got := useXTermKeyboardQuery(tt.goos); got != tt.wantXTermQuery {
+				t.Fatalf("useXTermKeyboardQuery() = %v, want %v", got, tt.wantXTermQuery)
+			}
+		})
+	}
+}
+
 func TestProcessInitQKeyboardProtocol(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- skip the XTerm keyboard probe on Windows
- give startup capability probes a short lead before using DA as the init sentinel
- only use the Windows fallback when negotiation found neither Win32 nor Kitty, and stop forcing Kitty cleanup there
- show the selected keyboard protocol in the mouse demo for terminal verification

This keeps the Windows path on the native Win32 keyboard protocol unless negotiation already selected a supported richer protocol, reducing protocol overlap during startup. The demo readout makes manual cross-terminal validation explicit. Validated with `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined startup negotiation and query sequencing for terminals, improving cross-platform initialization and Windows behavior
  * Removed a legacy Windows-only keyboard hack in favor of negotiated detection for more reliable keyboard handling

* **New Features**
  * Display of terminal keyboard protocol in the demo interface

* **Tests**
  * Added tests covering terminal profile detection and keyboard/window probe policies across OSes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->