### PR TITLE
[codex] Fix OSC 8 hyperlink state transitions

### DIFF
--- a/style.go
+++ b/style.go
@@ -261,8 +261,9 @@ func (s Style) Url(url string) Style {
 // were one Url, even if it spans multiple lines.
 func (s Style) UrlId(id string) Style {
 	s2 := s
-	s2.url = &urlInfo{
-		id: "id=" + stripOSCControlsIfNeeded(id),
+	s2.url = &urlInfo{}
+	if id = stripOSCControlsIfNeeded(id); id != "" {
+		s2.url.id = "id=" + id
 	}
 	if s.url != nil {
 		s2.url.url = s.url.url

--- a/style.go
+++ b/style.go
@@ -249,6 +249,9 @@ func (s Style) Url(url string) Style {
 	if s.url != nil {
 		s2.url.id = s.url.id
 	}
+	if s2.url.url == "" && s2.url.id == "" {
+		s2.url = nil
+	}
 	return s2
 }
 
@@ -263,6 +266,9 @@ func (s Style) UrlId(id string) Style {
 	}
 	if s.url != nil {
 		s2.url.url = s.url.url
+	}
+	if s2.url.url == "" && s2.url.id == "" {
+		s2.url = nil
 	}
 	return s2
 }

--- a/style_test.go
+++ b/style_test.go
@@ -99,6 +99,11 @@ func TestStyle(t *testing.T) {
 		t.Errorf("url id not preserved across clear: %q %q", id, url)
 	}
 
+	us = us.UrlId("")
+	if id, url := us.GetUrl(); id != "" || url != "http://example.net" {
+		t.Errorf("url id clear did not preserve url: %q %q", id, url)
+	}
+
 	orphan := StyleDefault.UrlId("orphan")
 	if id, url := orphan.GetUrl(); id != "orphan" || url != "" {
 		t.Errorf("url id without url should be retained: %q %q", id, url)
@@ -107,6 +112,14 @@ func TestStyle(t *testing.T) {
 	orphan = orphan.Url("http://example.org")
 	if id, url := orphan.GetUrl(); id != "orphan" || url != "http://example.org" {
 		t.Errorf("url id set before url was not preserved: %q %q", id, url)
+	}
+
+	if id, url := StyleDefault.Url("").GetUrl(); id != "" || url != "" {
+		t.Errorf("empty url should leave no hyperlink state: %q %q", id, url)
+	}
+
+	if id, url := StyleDefault.UrlId("").GetUrl(); id != "" || url != "" {
+		t.Errorf("empty url id should leave no hyperlink state: %q %q", id, url)
 	}
 
 	us = us.Normal().Reverse(true).Italic(false)

--- a/style_test.go
+++ b/style_test.go
@@ -89,6 +89,26 @@ func TestStyle(t *testing.T) {
 		t.Errorf("wrong underline style: %v", us.GetUnderlineStyle())
 	}
 
+	us = us.Url("")
+	if id, url := us.GetUrl(); id != "someId" || url != "" {
+		t.Errorf("url clear should preserve id state: %q %q", id, url)
+	}
+
+	us = us.Url("http://example.net")
+	if id, url := us.GetUrl(); id != "someId" || url != "http://example.net" {
+		t.Errorf("url id not preserved across clear: %q %q", id, url)
+	}
+
+	orphan := StyleDefault.UrlId("orphan")
+	if id, url := orphan.GetUrl(); id != "orphan" || url != "" {
+		t.Errorf("url id without url should be retained: %q %q", id, url)
+	}
+
+	orphan = orphan.Url("http://example.org")
+	if id, url := orphan.GetUrl(); id != "orphan" || url != "http://example.org" {
+		t.Errorf("url id set before url was not preserved: %q %q", id, url)
+	}
+
 	us = us.Normal().Reverse(true).Italic(false)
 	if us.GetAttributes() != AttrReverse {
 		t.Errorf("wrong attributes: %v", us.GetAttributes())

--- a/tscreen.go
+++ b/tscreen.go
@@ -793,6 +793,13 @@ func (t *tScreen) emitUrl(u urlInfo) {
 	}
 }
 
+// urlNeedsEmission reports whether a hyperlink transition has any wire effect.
+// Url ids can be staged before the Url itself, and id-only transitions have no
+// OSC 8 representation of their own.
+func urlNeedsEmission(oldUrl, newUrl urlInfo) bool {
+	return oldUrl != newUrl && (oldUrl.url != "" || newUrl.url != "")
+}
+
 func (t *tScreen) drawCell(x, y int) int {
 
 	str, style, width := t.cells.Get(x, y)
@@ -826,8 +833,8 @@ func (t *tScreen) drawCell(x, y int) int {
 		if style.url != nil {
 			newUrl = *style.url
 		}
-		// URL string can be long, so don't send it unless we really need to
-		if newUrl != oldUrl {
+		// URL string can be long, so don't send it unless we really need to.
+		if urlNeedsEmission(oldUrl, newUrl) {
 			t.emitUrl(newUrl)
 		}
 
@@ -1013,7 +1020,7 @@ func (t *tScreen) draw() {
 		}
 	}
 
-	if t.curstyle.url != nil {
+	if t.curstyle.url != nil && t.curstyle.url.url != "" {
 		t.emitUrl(urlInfo{})
 	}
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -502,6 +502,26 @@ func TestOSC8ControlsAreStrippedFromOutput(t *testing.T) {
 	}
 }
 
+func TestOSC8IdWithoutUrlDoesNotEmitClose(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	tty.writes.Reset()
+	s.PutStrStyled(0, 0, "X", StyleDefault.UrlId("orphan"))
+	s.Show()
+
+	if out := tty.Output(); strings.Contains(out, "\x1b]8;;\x1b\\") {
+		t.Fatalf("unexpected OSC 8 close sequence for id-only style: %q", out)
+	}
+}
+
 func TestKeyboardProtocol(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Fix hyperlink URL state handling so URL ids can be staged independently of URLs without producing inconsistent OSC 8 output.

This keeps both setter orders working, preserves ids across URL clears, and avoids emitting a close-hyperlink sequence for id-only intermediate states. The root cause was that in-memory URL/id state and terminal emission logic treated an empty URL as a close operation even when only the id had changed.

Validated with new regression tests plus `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hyperlink state handling so empty URL+ID clears link state; preserves ID or URL when only the other is cleared.
  * Prevented emission of unnecessary terminal hyperlink close sequences when an ID exists without a URL; emit enter/exit only when needed.

* **Tests**
  * Added coverage for hyperlink clearing, ID preservation, and ID-only hyperlink emission behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->