### PR TITLE
perf: skip grapheme segmentation on identical cell re-Put

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -72,12 +72,18 @@ func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
 		var cl string
 		c := &cb.cells[(y*cb.w)+x]
-		g := textWidthOptions.StringGraphemes(str)
-		for width == 0 && g.Next() {
-			cluster := g.Value()
-			cl += cluster
-			width = g.Width()
-			str = str[len(cluster):]
+		if str == c.currStr && c.width > 0 {
+			// Identical re-Put (a full-screen redraw): the grapheme split is
+			// unchanged, so reuse the measured width instead of segmenting.
+			cl, width, str = str, c.width, ""
+		} else {
+			g := textWidthOptions.StringGraphemes(str)
+			for width == 0 && g.Next() {
+				cluster := g.Value()
+				cl += cluster
+				width = g.Width()
+				str = str[len(cluster):]
+			}
 		}
 
 		// Wide characters: we want to mark the "wide" cells

--- a/cell_bench_test.go
+++ b/cell_bench_test.go
@@ -54,3 +54,16 @@ func benchCellBufferPut(b *testing.B, name string, sanitize bool, put func(*Cell
 		})
 	}
 }
+
+// BenchmarkCellBufferPutRedraw measures re-Putting identical content into a
+// cell, as a full-screen redraw does for the bulk of the screen.
+func BenchmarkCellBufferPutRedraw(b *testing.B) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+	style := Style{}
+	cb.Put(0, 0, "x", style) // prime: measure the cell once
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = cb.Put(0, 0, "x", style)
+	}
+}

--- a/cell_test.go
+++ b/cell_test.go
@@ -186,3 +186,22 @@ func TestCellBufferOutOfRangeAndResizeNoop(t *testing.T) {
 		t.Fatalf("resize no-op changed size to %dx%d", w, h)
 	}
 }
+
+func TestCellBufferPutRedraw(t *testing.T) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+
+	// The first Put measures the cell; a re-Put of identical content takes the
+	// fast path and must return the same result without segmenting again.
+	rest1, width1 := cb.Put(0, 0, "x", StyleDefault)
+	rest2, width2 := cb.Put(0, 0, "x", StyleDefault)
+	if rest2 != rest1 || width2 != width1 {
+		t.Fatalf("re-Put mismatch: (%q,%d), want (%q,%d)", rest2, width2, rest1, width1)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		cb.Put(0, 0, "x", StyleDefault)
+	})
+	if allocs != 0 {
+		t.Fatalf("re-Put allocated %.0f times, want 0", allocs)
+	}
+}


### PR DESCRIPTION
```sh
BenchmarkCellBufferPutRedraw-8   	169342923	        6.631 ns/op	      0 B/op	      0 allocs/op
PASS
ok  	github.com/gdamore/tcell/v3	4.527s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized cell rendering when identical content is redrawn at the same location, eliminating unnecessary processing overhead.

* **Tests**
  * Added performance benchmark for repeated content rendering.
  * Added test validation for optimized rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdamore/tcell/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->