### PR TITLE
Preserve Windows key release state

### DIFF
--- a/tty/tty_win.go
+++ b/tty/tty_win.go
@@ -20,6 +20,7 @@ package tty
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync"
 	"syscall"
 	"time"
@@ -96,6 +97,38 @@ type inputRecord struct {
 	typ  uint16
 	_    uint16
 	data [16]byte
+}
+
+func encodeWinKeyRecord(data [16]byte, surrogate *rune) []byte {
+	keyDown := binary.LittleEndian.Uint32(data[0:]) != 0
+	repeat := binary.LittleEndian.Uint16(data[4:])
+	virtualKey := binary.LittleEndian.Uint16(data[6:])
+	scanCode := binary.LittleEndian.Uint16(data[8:])
+	// we normally only expect to see ascii, but paste data may come in as UTF-16.
+	wc := rune(binary.LittleEndian.Uint16(data[10:]))
+	controlState := binary.LittleEndian.Uint32(data[12:])
+
+	if virtualKey != 0 || scanCode != 0 {
+		kd := 0
+		if keyDown {
+			kd = 1
+		}
+		return fmt.Appendf(nil, "\x1b[%d;%d;%d;%d;%d;%d_",
+			virtualKey, scanCode, wc, kd, controlState, max(1, repeat))
+	}
+
+	if !keyDown {
+		return nil
+	}
+
+	var encoded []byte
+	decodedRunes := decodeUTF16Rune(surrogate, wc)
+	for range max(1, repeat) {
+		for _, decoded := range decodedRunes {
+			encoded = append(encoded, []byte(string(decoded))...)
+		}
+	}
+	return encoded
 }
 
 type winTty struct {
@@ -207,17 +240,11 @@ func (w *winTty) getConsoleInput() error {
 			ir := rec[i]
 			switch ir.typ {
 			case keyEvent:
-				// we normally only expect to see ascii, but paste data may come in as UTF-16.
-				wc := rune(binary.LittleEndian.Uint16(ir.data[10:]))
-				for _, decoded := range decodeUTF16Rune(&w.surrogate, wc) {
-					for _, chr := range []byte(string(decoded)) {
-						// We normally expect only to see ASCII (win32-input-mode),
-						// but apparently pasted data can arrive in UTF-16 here.
-						select {
-						case w.buf <- chr:
-						case <-w.stopQ:
-							break loop
-						}
+				for _, chr := range encodeWinKeyRecord(ir.data, &w.surrogate) {
+					select {
+					case w.buf <- chr:
+					case <-w.stopQ:
+						break loop
 					}
 				}
 

--- a/tty/tty_win_test.go
+++ b/tty/tty_win_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package tty
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func makeWinKeyRecord(keyDown bool, repeat, virtualKey, scanCode, unicodeChar uint16, controlState uint32) [16]byte {
+	var data [16]byte
+	if keyDown {
+		binary.LittleEndian.PutUint32(data[0:], 1)
+	}
+	binary.LittleEndian.PutUint16(data[4:], repeat)
+	binary.LittleEndian.PutUint16(data[6:], virtualKey)
+	binary.LittleEndian.PutUint16(data[8:], scanCode)
+	binary.LittleEndian.PutUint16(data[10:], unicodeChar)
+	binary.LittleEndian.PutUint32(data[12:], controlState)
+	return data
+}
+
+func TestEncodeWinKeyRecordPreservesKeyState(t *testing.T) {
+	tests := []struct {
+		name string
+		data [16]byte
+		want string
+	}{
+		{
+			name: "press",
+			data: makeWinKeyRecord(true, 3, 65, 30, 'A', 0x10),
+			want: "\x1b[65;30;65;1;16;3_",
+		},
+		{
+			name: "release",
+			data: makeWinKeyRecord(false, 1, 65, 30, 'A', 0x10),
+			want: "\x1b[65;30;65;0;16;1_",
+		},
+		{
+			name: "zero repeat becomes one",
+			data: makeWinKeyRecord(true, 0, 65, 30, 'A', 0),
+			want: "\x1b[65;30;65;1;0;1_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var surrogate rune
+			if got := string(encodeWinKeyRecord(tt.data, &surrogate)); got != tt.want {
+				t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodeWinKeyRecordFallbackIgnoresRelease(t *testing.T) {
+	var surrogate rune
+	data := makeWinKeyRecord(false, 1, 0, 0, 'A', 0)
+	if got := encodeWinKeyRecord(data, &surrogate); len(got) != 0 {
+		t.Fatalf("encodeWinKeyRecord() = %q, want no bytes", string(got))
+	}
+
+	data = makeWinKeyRecord(true, 1, 0, 0, 'A', 0)
+	if got := string(encodeWinKeyRecord(data, &surrogate)); got != "A" {
+		t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, "A")
+	}
+
+	data = makeWinKeyRecord(true, 3, 0, 0, 'A', 0)
+	if got := string(encodeWinKeyRecord(data, &surrogate)); got != "AAA" {
+		t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, "AAA")
+	}
+}


### PR DESCRIPTION
## Summary
Preserve Windows console key state by forwarding KEY_EVENT_RECORD metadata as win32-input-mode sequences instead of reducing every key event to Unicode bytes.
This prevents key release records from being reported as duplicate key presses while still allowing advanced key reporting to surface releases through the existing parser.

Fixes #1124.

## Validation
`go test ./...`
`GOOS=windows go test -c -o .context/tcell-windows.test.exe .`
`GOOS=windows go test -c -o .context/tty-windows.test.exe ./tty`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows console keyboard input translation, enhancing support for key-down vs key-up behavior, repeat counts (with safe clamping), and character encoding.
  * Ensured key release events don’t emit output, while key presses and Unicode characters are correctly recorded.

* **Tests**
  * Added Windows-only tests to validate key-state handling, repeat=0 behavior, and fallback behavior for non-virtual/scan-key input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->