### PR TITLE
Fix screen Init/Fini races

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -243,6 +243,7 @@ type tScreen struct {
 	legacy             bool
 	hasClipboard       bool // true if OSC 52 reported via DA1
 	finiOnce           sync.Once
+	initFiniLock       sync.Mutex
 	enterUrl           string
 	exitUrl            string
 	setWinSize         string
@@ -258,6 +259,7 @@ type tScreen struct {
 	running            bool
 	startTime          time.Time
 	wg                 sync.WaitGroup
+	eventWg            sync.WaitGroup
 	mouseFlags         MouseFlags
 	pasteEnabled       bool
 	focusEnabled       bool
@@ -355,6 +357,20 @@ func (t *tScreen) applyEnvironmentOverrides() {
 }
 
 func (t *tScreen) Init() error {
+	t.initFiniLock.Lock()
+	defer t.initFiniLock.Unlock()
+
+	t.Lock()
+	if t.fini {
+		t.Unlock()
+		return errors.New("screen finalized")
+	}
+	if t.running {
+		t.Unlock()
+		return errors.New("already initialized")
+	}
+	t.Unlock()
+
 	if e := t.initialize(); e != nil {
 		return e
 	}
@@ -525,7 +541,9 @@ func (t *tScreen) processInitQ() {
 
 func (t *tScreen) filterEvents() chan Event {
 	inQ := make(chan Event, 128)
+	t.eventWg.Add(1)
 	go func() {
+		defer t.eventWg.Done()
 		for {
 			var ev Event
 			select {
@@ -541,7 +559,11 @@ func (t *tScreen) filterEvents() chan Event {
 				}
 
 			default:
-				t.eventQ <- ev
+				select {
+				case t.eventQ <- ev:
+				case <-t.quit:
+					return
+				}
 			}
 		}
 	}()
@@ -596,6 +618,9 @@ func (t *tScreen) prepareCursorStyles() {
 }
 
 func (t *tScreen) Fini() {
+	t.initFiniLock.Lock()
+	defer t.initFiniLock.Unlock()
+
 	// Ensure that enough time passes for terminals to  finish sending
 	// their initial response (gnome-terminal sends terminal dimensions
 	// asynchronously later than the response to primary DA for some reason.)
@@ -1659,6 +1684,7 @@ func (t *tScreen) Beep() error {
 func (t *tScreen) finalize() {
 	t.disengage()
 	_ = t.tty.Close()
+	t.eventWg.Wait()
 	close(t.eventQ)
 }
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -146,6 +147,114 @@ func TestFiniPreventsSetStyleMutation(t *testing.T) {
 	}
 }
 
+func TestInitWhileInitializedFailsWithoutReplacingEventQ(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
+	scr, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer scr.Fini()
+
+	eventQ := scr.EventQ()
+	if err := scr.Init(); err == nil {
+		t.Fatal("second Init succeeded while screen was initialized")
+	}
+	if scr.EventQ() != eventQ {
+		t.Fatal("failed Init replaced the event queue")
+	}
+}
+
+func TestInitAfterFiniFails(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
+	scr, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	scr.Fini()
+
+	if err := scr.Init(); err == nil {
+		t.Fatal("Init succeeded after Fini")
+	}
+}
+
+func TestConcurrentFiniIsIdempotent(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
+	scr, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			scr.Fini()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent Fini calls did not return")
+	}
+}
+
+func TestConcurrentInitAndFini(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
+	scr, err := NewTerminfoScreenFromTty(tty, OptNegotiation(false), OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := scr.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+
+	start := make(chan struct{})
+	finiDone := make(chan struct{})
+	initDone := make(chan error, 1)
+
+	go func() {
+		<-start
+		scr.Fini()
+		close(finiDone)
+	}()
+	go func() {
+		<-start
+		initDone <- scr.Init()
+	}()
+
+	close(start)
+	select {
+	case err := <-initDone:
+		if err == nil {
+			t.Fatal("concurrent Init succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("concurrent Init did not return")
+	}
+	select {
+	case <-finiDone:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent Fini did not return")
+	}
+}
+
 func TestFiniPreventsFurtherTerminalMutation(t *testing.T) {
 	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 2})}
 	scr, err := NewTerminfoScreenFromTty(tty)
@@ -222,6 +331,35 @@ func TestFiniPreventsFurtherTerminalMutation(t *testing.T) {
 	}
 	if ts.focusEnabled != beforeFocusEnabled {
 		t.Fatal("focus state changed after Fini")
+	}
+}
+
+func TestFilterEventsStopsWhileEventQBlocked(t *testing.T) {
+	ts := &tScreen{
+		quit:   make(chan struct{}),
+		eventQ: make(chan Event),
+	}
+	inQ := ts.filterEvents()
+
+	inQ <- NewEventResize(1, 1)
+
+	done := make(chan struct{})
+	go func() {
+		ts.eventWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("filterEvents exited before shutdown")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(ts.quit)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("filterEvents did not stop after shutdown")
 	}
 }
 


### PR DESCRIPTION
This fixes races between screen initialization and finalization by serializing `Init` and `Fini`, rejecting `Init` once a screen is finalized or already initialized, and preserving idempotent `Fini` behavior through `sync.Once`.

It also waits for the `filterEvents` goroutine before closing `eventQ`, and makes the event forwarding send abort when shutdown closes `quit`.

The tests cover repeated `Init`, `Init` after `Fini`, concurrent `Init`/`Fini`, concurrent `Fini`, and a blocked event router during shutdown.

Validated with focused root-package tests, repeated `-race` runs for the lifecycle/original repro tests, the demos/colors race repro, and `go test .`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen startup and shutdown handling to avoid race conditions during concurrent lifecycle calls.
  * Ensured event processing stops cleanly before shutdown, preventing issues when the event queue is blocked.
  * Made repeated shutdown calls safe and non-blocking.

* **Tests**
  * Added coverage for repeated initialization/shutdown, concurrent lifecycle calls, and event handling during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->