### PR TITLE
docs: SimulationScreen is removed notice. (fixes #1119)

### DIFF
--- a/CHANGESv3.md
+++ b/CHANGESv3.md
@@ -100,7 +100,7 @@ These functions weren't reliable and served no useful purpose.
 `NewConsoleScreen` is removed as is support for Windows console mode.
 
 Instead this uses the more modern Windows VT modes.
-As a consequence, this means that _Tcell_ on Windows requires at least Winows 10 build 1703 (the Creators Update).
+As a consequence, this means that _Tcell_ on Windows requires at least Windows 10 build 1703 (the Creators Update).
 If you are using a version of Windows 10 older than that, you should really upgrade for _many_ reasons, not just
 because _Tcell_ doesn't support it anymore.
 
@@ -108,3 +108,11 @@ because _Tcell_ doesn't support it anymore.
 
 This structure, and the associated `NewInputProcessor` function, were made public incorrectly.
 They are not part of our public API going forward, and are now private symbols.
+
+## SimulationScreen is Removed
+
+While never part of the public _Tcell_ API, some projects may have used the
+`SimulationScreen` for their own tests.  That facility was very limited, and
+we implemented a much more complete emulation of a terminal in `MockScreen`
+and `MockTerm`.  (To be clear, those facilities are still intended for _Tcell_'s
+own testing, and are still not part of the public API.)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a clearer Windows compatibility note, now requiring Windows 10 build 1703 (Creators Update).
  * Clarified that `InputProcessor` is not part of the public API.
  * Added a note that `SimulationScreen` has been removed, with guidance that terminal testing should use the existing mock screens instead.
  * Corrected a typo in the previous Windows-related wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->