### PR TITLE
fix(input): decode CSI R as F3

### DIFF
--- a/input.go
+++ b/input.go
@@ -222,6 +222,7 @@ var csiAllKeys = map[csiParamMode]keyMap{
 	{M: 'L'}:         {Key: KeyInsert},
 	{M: 'P'}:         {Key: KeyF1}, // except for aixterm, where this is Delete
 	{M: 'Q'}:         {Key: KeyF2},
+	{M: 'R'}:         {Key: KeyF3},
 	{M: 'S'}:         {Key: KeyF4},
 	{M: 'Z'}:         {Key: KeyBacktab},
 	{M: 'a'}:         {Key: KeyUp, Mod: ModShift},

--- a/input_test.go
+++ b/input_test.go
@@ -553,6 +553,7 @@ func TestSpecialKeys(t *testing.T) {
 		{"CSI-L", []byte{'\x1b', '[', 'L'}, KeyInsert, ModNone, ""},
 		{"CSI-P", []byte{'\x1b', '[', 'P'}, KeyF1, ModNone, ""},
 		{"CSI-Q", []byte{'\x1b', '[', 'Q'}, KeyF2, ModNone, ""},
+		{"CSI-R", []byte{'\x1b', '[', 'R'}, KeyF3, ModNone, ""},
 		{"CSI-S", []byte{'\x1b', '[', 'S'}, KeyF4, ModNone, ""},
 		{"CSI-Z", []byte{'\x1b', '[', 'Z'}, KeyBacktab, ModNone, ""},
 		{"CSI-a", []byte{'\x1b', '[', 'a'}, KeyUp, ModShift, ""},


### PR DESCRIPTION
Some terminals emit F3 as CSI R instead of SS3 R or CSI 13~.

The parser already recognizes neighboring CSI P/Q/S forms for F1, F2, and F4, but omitted R, causing F3 to be swallowed.

Only the no-parameter form is mapped, so cursor position reports like `CSI row;col R` should remain unaffected.

Tested to enable F3 using iTerm2 to connect to an Ubuntu 24.04 machine over Mosh+SSH+tmux without any obvious side-effects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved special-key handling so an additional escape sequence is now recognized as **F3**.
  * This makes keyboard input more consistent for terminal-based interactions.
  * Added test coverage for the newly supported key sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->