### PR TITLE
Fix draw spinning forever on a suspended screen

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1009,6 +1009,13 @@ func (t *tScreen) hideCursor() {
 }
 
 func (t *tScreen) draw() {
+	if !t.running {
+		// While disengaged (e.g. suspended) the terminal belongs to some
+		// other application, so we must not emit anything; also the cell
+		// buffer is released, so there is nothing valid to draw from.
+		return
+	}
+
 	// clobber cursor position, because we're going to change it all
 	t.cx = -1
 	t.cy = -1

--- a/tscreen.go
+++ b/tscreen.go
@@ -1047,6 +1047,10 @@ func (t *tScreen) draw() {
 					// actually will *draw* it.
 					t.cells.SetDirty(x+1, y, true)
 				}
+			} else if width < 1 {
+				// drawCell reports width 0 for coordinates outside the
+				// cell buffer; never let the scan stall
+				width = 1
 			}
 			x += width - 1
 		}

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -1269,3 +1269,45 @@ func TestShowNotificationStripsOSCControls(t *testing.T) {
 		t.Fatalf("notification payload missing sanitized strings: %q", delta)
 	}
 }
+
+// A Show on a suspended screen must return without emitting anything: the
+// terminal has been handed back to the caller on disengage, and the released
+// cell buffer disagrees with the screen's remembered width and height, which
+// used to make the draw scan loop spin forever — while holding the screen
+// lock, so a concurrent Resume would deadlock. Show runs in a goroutine so
+// that a regression fails the test instead of hanging the suite.
+func TestShowWhileSuspendedEmitsNothing(t *testing.T) {
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})}
+	s, err := NewTerminfoScreenFromTty(tty)
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	if err := s.Suspend(); err != nil {
+		t.Fatalf("failed to suspend screen: %v", err)
+	}
+
+	baseline := len(tty.Output())
+
+	done := make(chan struct{})
+	go func() {
+		s.Show()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Show hung on a suspended screen")
+	}
+
+	if emitted := tty.Output()[baseline:]; emitted != "" {
+		t.Fatalf("Show on a suspended screen emitted %q", emitted)
+	}
+
+	if err := s.Resume(); err != nil {
+		t.Fatalf("failed to resume screen: %v", err)
+	}
+	s.Fini()
+}


### PR DESCRIPTION
When a screen is suspended, `disengageFinish` releases the cell buffer (resizing it to 0x0) while the screen's remembered width and height keep their old values. If the application then draws — for example when a pending redraw races the `Resume` after a shell job-control suspend/`fg` cycle — the draw scan loop asks `drawCell` about coordinates outside the buffer, gets width 0 back, and its `x += width - 1` stops advancing: `draw` spins forever while holding the screen lock. A concurrent `Resume` then deadlocks on that lock, leaving the application wedged with a core pinned, and no way to recover short of killing the process. This is the root cause of a long-standing intermittent lazygit hang (jesseduffield/lazygit#5309), confirmed there with goroutine dumps.

Two changes:

- `draw` now returns immediately while the screen is not engaged. The terminal belongs to another application at that point, so nothing must be emitted anyway (with a stdio-based Tty, the sync/cursor wrapper bytes would otherwise land in the shell's screen).
- The scan loop clamps its advance to at least one cell, so no other disagreement between the remembered size and the cell buffer can ever stall it again.

The new test suspends a screen backed by a mock terminal, calls `Show` from a goroutine, and asserts that it returns without emitting anything. Without the fix it spins forever; the test fails via a timeout rather than hanging the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented screen refreshes from producing terminal output while the screen is suspended or disengaged.
  * Improved rendering reliability by preventing stalled screen scans when a cell has an invalid width.

* **Tests**
  * Added coverage confirming that displaying a suspended screen returns promptly and emits no output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->