### PR TITLE
perf: avoid grapheme segmentation for common cell writes

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -14,6 +14,8 @@
 
 package tcell
 
+import "unicode/utf8"
+
 type cell struct {
 	currStr   string
 	lastStr   string
@@ -72,12 +74,22 @@ func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 	if x >= 0 && y >= 0 && x < cb.w && y < cb.h {
 		var cl string
 		c := &cb.cells[(y*cb.w)+x]
-		g := textWidthOptions.StringGraphemes(str)
-		for width == 0 && g.Next() {
-			cluster := g.Value()
-			cl += cluster
-			width = g.Width()
-			str = str[len(cluster):]
+		if str == c.currStr && c.width > 0 {
+			// Identical re-Put (a full-screen redraw): the grapheme split is
+			// unchanged, so reuse the measured width instead of segmenting.
+			cl, width, str = str, c.width, ""
+		} else if len(str) > 0 && str[0] >= ' ' && str[0] <= '~' && (len(str) == 1 || str[1] < utf8.RuneSelf) {
+			// Printable ASCII followed by ASCII cannot be part of a larger
+			// grapheme cluster, so avoid constructing a grapheme iterator.
+			cl, width, str = str[:1], 1, str[1:]
+		} else {
+			g := textWidthOptions.StringGraphemes(str)
+			for width == 0 && g.Next() {
+				cluster := g.Value()
+				cl += cluster
+				width = g.Width()
+				str = str[len(cluster):]
+			}
 		}
 
 		// Wide characters: we want to mark the "wide" cells

--- a/cell_bench_test.go
+++ b/cell_bench_test.go
@@ -54,3 +54,30 @@ func benchCellBufferPut(b *testing.B, name string, sanitize bool, put func(*Cell
 		})
 	}
 }
+
+// BenchmarkCellBufferPutRedraw measures re-Putting identical content into a
+// cell, as a full-screen redraw does for the bulk of the screen.
+func BenchmarkCellBufferPutRedraw(b *testing.B) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+	style := Style{}
+	cb.Put(0, 0, "x", style) // prime: measure the cell once
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = cb.Put(0, 0, "x", style)
+	}
+}
+
+func BenchmarkCellBufferPutChangedASCII(b *testing.B) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+	style := Style{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			_, _ = cb.Put(0, 0, "x", style)
+		} else {
+			_, _ = cb.Put(0, 0, "y", style)
+		}
+	}
+}

--- a/cell_test.go
+++ b/cell_test.go
@@ -186,3 +186,69 @@ func TestCellBufferOutOfRangeAndResizeNoop(t *testing.T) {
 		t.Fatalf("resize no-op changed size to %dx%d", w, h)
 	}
 }
+
+func TestCellBufferPutRedraw(t *testing.T) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+
+	// The first Put measures the cell; a re-Put of identical content takes the
+	// fast path and must return the same result without segmenting again.
+	rest1, width1 := cb.Put(0, 0, "x", StyleDefault)
+	rest2, width2 := cb.Put(0, 0, "x", StyleDefault)
+	if rest2 != rest1 || width2 != width1 {
+		t.Fatalf("re-Put mismatch: (%q,%d), want (%q,%d)", rest2, width2, rest1, width1)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		cb.Put(0, 0, "x", StyleDefault)
+	})
+	if allocs != 0 {
+		t.Fatalf("re-Put allocated %.0f times, want 0", allocs)
+	}
+}
+
+func TestCellBufferPutASCIIBeforeCombiningCluster(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
+	rest, width := cb.Put(0, 0, "xe\u0301", StyleDefault)
+	if rest != "e\u0301" || width != 1 {
+		t.Fatalf("Put returned (%q,%d), want (%q,1)", rest, width, "e\u0301")
+	}
+
+	rest, width = cb.Put(1, 0, rest, StyleDefault)
+	if rest != "" || width != 1 {
+		t.Fatalf("combining Put returned (%q,%d), want (\"\",1)", rest, width)
+	}
+	str, _, _ := cb.Get(1, 0)
+	if str != "e\u0301" {
+		t.Fatalf("combining cell is %q, want %q", str, "e\u0301")
+	}
+}
+
+func TestCellBufferPutASCIIFastPathMatchesGraphemeIterator(t *testing.T) {
+	inputs := make([]string, 0, 95*96)
+	for first := byte(' '); first <= '~'; first++ {
+		inputs = append(inputs, string(first))
+		for second := byte(' '); second <= '~'; second++ {
+			inputs = append(inputs, string([]byte{first, second}))
+		}
+	}
+
+	for _, input := range inputs {
+		graphemes := textWidthOptions.StringGraphemes(input)
+		if !graphemes.Next() {
+			t.Fatalf("grapheme iterator returned no value for %q", input)
+		}
+		wantString := graphemes.Value()
+		wantWidth := graphemes.Width()
+		wantRest := input[len(wantString):]
+
+		cb := &CellBuffer{w: 1, h: 1, cells: make([]cell, 1)}
+		gotRest, gotWidth := cb.Put(0, 0, input, StyleDefault)
+		gotString, _, _ := cb.Get(0, 0)
+		if gotString != wantString || gotWidth != wantWidth || gotRest != wantRest {
+			t.Fatalf(
+				"Put(%q) = (%q,%d,%q), want (%q,%d,%q)",
+				input, gotString, gotWidth, gotRest, wantString, wantWidth, wantRest,
+			)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved text rendering performance for repeated redraws and common printable ASCII content.
  * Reduced unnecessary grapheme processing and memory allocations during cell updates.

* **Bug Fixes**
  * Improved handling of ASCII characters followed by combining marks.
  * Preserved consistent cell widths and remaining text across optimized rendering paths.

* **Tests**
  * Added coverage for redraw behavior, ASCII fast paths, combining sequences, and allocation efficiency.
  * Added benchmarks for repeated and changing cell content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->