### PR TITLE
perf: skip grapheme iterator for printable ASCII

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -14,6 +14,8 @@
 
 package tcell
 
+import "unicode/utf8"
+
 type cell struct {
 	currStr   string
 	lastStr   string
@@ -76,6 +78,10 @@ func (cb *CellBuffer) put(x int, y int, str string, style Style) (string, int) {
 			// Identical re-Put (a full-screen redraw): the grapheme split is
 			// unchanged, so reuse the measured width instead of segmenting.
 			cl, width, str = str, c.width, ""
+		} else if len(str) > 0 && str[0] >= ' ' && str[0] <= '~' && (len(str) == 1 || str[1] < utf8.RuneSelf) {
+			// Printable ASCII followed by ASCII cannot be part of a larger
+			// grapheme cluster, so avoid constructing a grapheme iterator.
+			cl, width, str = str[:1], 1, str[1:]
 		} else {
 			g := textWidthOptions.StringGraphemes(str)
 			for width == 0 && g.Next() {

--- a/cell_bench_test.go
+++ b/cell_bench_test.go
@@ -67,3 +67,17 @@ func BenchmarkCellBufferPutRedraw(b *testing.B) {
 		_, _ = cb.Put(0, 0, "x", style)
 	}
 }
+
+func BenchmarkCellBufferPutChangedASCII(b *testing.B) {
+	cb := &CellBuffer{w: 8, h: 1, cells: make([]cell, 8)}
+	style := Style{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			_, _ = cb.Put(0, 0, "x", style)
+		} else {
+			_, _ = cb.Put(0, 0, "y", style)
+		}
+	}
+}

--- a/cell_test.go
+++ b/cell_test.go
@@ -205,3 +205,50 @@ func TestCellBufferPutRedraw(t *testing.T) {
 		t.Fatalf("re-Put allocated %.0f times, want 0", allocs)
 	}
 }
+
+func TestCellBufferPutASCIIBeforeCombiningCluster(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
+	rest, width := cb.Put(0, 0, "xe\u0301", StyleDefault)
+	if rest != "e\u0301" || width != 1 {
+		t.Fatalf("Put returned (%q,%d), want (%q,1)", rest, width, "e\u0301")
+	}
+
+	rest, width = cb.Put(1, 0, rest, StyleDefault)
+	if rest != "" || width != 1 {
+		t.Fatalf("combining Put returned (%q,%d), want (\"\",1)", rest, width)
+	}
+	str, _, _ := cb.Get(1, 0)
+	if str != "e\u0301" {
+		t.Fatalf("combining cell is %q, want %q", str, "e\u0301")
+	}
+}
+
+func TestCellBufferPutASCIIFastPathMatchesGraphemeIterator(t *testing.T) {
+	inputs := make([]string, 0, 95*96)
+	for first := byte(' '); first <= '~'; first++ {
+		inputs = append(inputs, string(first))
+		for second := byte(' '); second <= '~'; second++ {
+			inputs = append(inputs, string([]byte{first, second}))
+		}
+	}
+
+	for _, input := range inputs {
+		graphemes := textWidthOptions.StringGraphemes(input)
+		if !graphemes.Next() {
+			t.Fatalf("grapheme iterator returned no value for %q", input)
+		}
+		wantString := graphemes.Value()
+		wantWidth := graphemes.Width()
+		wantRest := input[len(wantString):]
+
+		cb := &CellBuffer{w: 1, h: 1, cells: make([]cell, 1)}
+		gotRest, gotWidth := cb.Put(0, 0, input, StyleDefault)
+		gotString, _, _ := cb.Get(0, 0)
+		if gotString != wantString || gotWidth != wantWidth || gotRest != wantRest {
+			t.Fatalf(
+				"Put(%q) = (%q,%d,%q), want (%q,%d,%q)",
+				input, gotString, gotWidth, gotRest, wantString, wantWidth, wantRest,
+			)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of printable ASCII text for faster cell updates.
  * Added benchmark coverage for repeated ASCII changes.

* **Bug Fixes**
  * Improved handling of ASCII characters followed by combining characters.
  * Ensured grapheme output, width, and remaining text remain consistent across ASCII inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->