### PR TITLE
fix: unblock tty read before shutdown wait

### DIFF
--- a/tty/tty_unix.go
+++ b/tty/tty_unix.go
@@ -55,6 +55,15 @@ func (tty *devTty) Close() error {
 	return tty.f.Close()
 }
 
+func fileDescriptor(f *os.File) (fd int, err error) {
+	raw, err := f.SyscallConn()
+	if err != nil {
+		return -1, err
+	}
+	err = raw.Control(func(rawFd uintptr) { fd = int(rawFd) })
+	return
+}
+
 func (tty *devTty) Start() error {
 
 	if tty.started {
@@ -72,7 +81,10 @@ func (tty *devTty) Start() error {
 		return err
 	}
 
-	tty.fd = int(tty.f.Fd())
+	if tty.fd, err = fileDescriptor(tty.f); err != nil {
+		tty.f.Close()
+		return err
+	}
 
 	if !term.IsTerminal(tty.fd) {
 		tty.f.Close()

--- a/tty/tty_unix_test.go
+++ b/tty/tty_unix_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+
+package tty
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFileDescriptorPreservesDeadline(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if _, err = fileDescriptor(r); err != nil {
+		t.Fatal(err)
+	}
+	if err = r.SetReadDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	errQ := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		errQ <- err
+	}()
+	select {
+	case err = <-errQ:
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("got %v, want deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("read did not honor deadline")
+	}
+}


### PR DESCRIPTION
Closes #1148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal handling on Unix systems to preserve read timeouts and deadlines.
  * Ensured terminal resources are properly closed when descriptor access fails.

* **Tests**
  * Added coverage verifying that timed terminal reads return promptly when deadlines are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->