### PR TITLE
fix(wscreen): clear cells covered by wide characters in the web renderer

### DIFF
--- a/webfiles/tcell.js
+++ b/webfiles/tcell.js
@@ -61,7 +61,7 @@ function clearScreen(fg, bg) {
   }
 }
 
-function drawCell(x, y, s, fg, bg, attrs, us, uc) {
+function drawCell(x, y, s, fg, bg, attrs, us, uc, w) {
   var span = document.createElement("span");
   var use = false;
 
@@ -129,6 +129,14 @@ function drawCell(x, y, s, fg, bg, attrs, us, uc) {
   content.dirty = true; // invalidate terminal- new cell
   content.data[y].previous = null; // invalidate row- new row
   content.data[y].data[x] = use ? span : textnode;
+
+  // A wide (multi-column) character occupies the following cells as well,
+  // but the Go side skips drawing them. Clear their previous content,
+  // otherwise stale characters remain visible next to wide text after
+  // partial redraws.
+  for (var i = x + 1; i < x + (w || 1) && i < width; i++) {
+    content.data[y].data[i] = document.createTextNode("");
+  }
 }
 
 function show() {

--- a/wscreen.go
+++ b/wscreen.go
@@ -143,7 +143,7 @@ func (t *wScreen) drawCell(x, y int) int {
 	}
 
 	t.cells.SetDirty(x, y, false)
-	js.Global().Call("drawCell", x, y, str, fg, bg, int(style.attrs), int(us), int(uc))
+	js.Global().Call("drawCell", x, y, str, fg, bg, int(style.attrs), int(us), int(uc), width)
 
 	return width
 }


### PR DESCRIPTION
## Problem

In the WebAssembly backend, the Go draw loop skips the cells occupied by a wide character (`x += width - 1` in `wScreen.draw`), but the DOM renderer's `drawCell` only updates the cell at `x`. Whatever was previously rendered at `x+1` stays in the row, so after a partial redraw, wide (CJK) text ends up interleaved with stale characters.

For example, drawing `CPUの札を引いています` over a status line that previously showed `Enter/Click: 止める` renders as:

```
CPUのr札Cをi引kい て い ま す ...
```

with the leftovers of `Enter/Click` showing through between the wide characters. A full clear repaints every cell so the corruption only appears on incremental updates, which is how gocui and similar frameworks draw.

## Fix

Pass the cell width — which `drawCell` on the Go side already has from `cells.Get` — through to the JavaScript `drawCell`, and blank the covered cells there.

The signature change is backward/forward compatible: an older `tcell.js` ignores the extra argument, and the new `tcell.js` defaults a missing argument to width 1, so either side can be updated first.

## Testing

- `go test ./...` passes; `GOOS=js GOARCH=wasm go build ./...` compiles
- Verified in Chrome with a real gocui application (a hanafuda card game, mostly CJK text) compiled to wasm against this branch: the interleaving corruption on partial redraws is gone. Live instance of the same app (with the equivalent patch applied to its bundled tcell.js): https://koikoi.ngs.io

This targets `v2` since the `main` (v3) web renderer no longer uses the DOM-based `tcell.js` path.