### PR TITLE
fix(webfiles): compute mouse cell coordinates per event

### DIFF
--- a/webfiles/tcell.js
+++ b/webfiles/tcell.js
@@ -227,33 +227,34 @@ function intToHex(n) {
 
 initialize();
 
-let fontwidth = term.clientWidth / width;
-let fontheight = term.clientHeight / height;
+// Cell metrics must be computed per event rather than at load time: the
+// terminal element is still empty here, so clientWidth/clientHeight are 0
+// and a cached value would map every mouse event to the bottom-right cell.
+// Coordinates are derived from clientX/clientY relative to the terminal
+// rect, not offsetX/offsetY: the latter are relative to event.target,
+// which is an inner cell span whenever the pointed-at cell is styled.
+function eventCell(e) {
+  var r = term.getBoundingClientRect();
+  var fontwidth = r.width / width;
+  var fontheight = r.height / height;
+  return [
+    Math.min((((e.clientX - r.left) / fontwidth) | 0), width - 1),
+    Math.min((((e.clientY - r.top) / fontheight) | 0), height - 1),
+  ];
+}
 
 document.addEventListener("keydown", (e) => {
   onKeyEvent(e.key, e.shiftKey, e.altKey, e.ctrlKey, e.metaKey);
 });
 
 term.addEventListener("click", (e) => {
-  onMouseClick(
-    Math.min((e.offsetX / fontwidth) | 0, width - 1),
-    Math.min((e.offsetY / fontheight) | 0, height - 1),
-    e.which,
-    e.shiftKey,
-    e.altKey,
-    e.ctrlKey
-  );
+  var cell = eventCell(e);
+  onMouseClick(cell[0], cell[1], e.which, e.shiftKey, e.altKey, e.ctrlKey);
 });
 
 term.addEventListener("mousemove", (e) => {
-  onMouseMove(
-    Math.min((e.offsetX / fontwidth) | 0, width - 1),
-    Math.min((e.offsetY / fontheight) | 0, height - 1),
-    e.which,
-    e.shiftKey,
-    e.altKey,
-    e.ctrlKey
-  );
+  var cell = eventCell(e);
+  onMouseMove(cell[0], cell[1], e.which, e.shiftKey, e.altKey, e.ctrlKey);
 });
 
 term.addEventListener("focus", (e) => {


### PR DESCRIPTION
## Problem

In the WebAssembly backend's `tcell.js`, the cell metrics used to translate mouse coordinates are computed once at script load:

```js
let fontwidth = term.clientWidth / width;
let fontheight = term.clientHeight / height;
```

At that point the `#terminal` element is still empty, so `clientWidth`/`clientHeight` are 0. Dividing by the resulting 0 produces `Infinity`, and `Math.min(Infinity | 0, width - 1)` clamps every mouse event to the bottom-right cell — clicks never reach the intended widget.

Additionally, `offsetX`/`offsetY` are relative to `event.target`. The terminal DOM consists of row spans and per-cell spans, so whenever the pointed-at cell is styled (colored / reverse video), the target is an inner span and the offsets are near zero, mapping the click to column 0.

## Fix

Compute the metrics per event and derive the position from `clientX`/`clientY` relative to the terminal's bounding rect. This also keeps coordinates correct if the terminal is resized (`SetSize`) or the page changes the font size after load.

## Testing

Verified in Chrome with a real gocui application compiled to wasm: before the change, clicks always mapped to the bottom-right cell (and, with a mid-script metric snapshot, clicks on styled cells mapped to column 0); after the change, clicking buttons and list rows selects the intended cell, including after a `SetSize` resize. Live instance of the same app (with the equivalent patch applied to its bundled tcell.js): https://koikoi.ngs.io

This targets `v2` since the `main` (v3) web renderer no longer uses the DOM-based `tcell.js` path. Related: #1150.