### PR TITLE
fix(windows): preserve Windows key release state (fixes #1124)

### DIFF
--- a/tty_win.go
+++ b/tty_win.go
@@ -20,10 +20,12 @@ package tcell
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync"
 	"syscall"
 	"time"
 	"unicode/utf16"
+	"unicode/utf8"
 	"unsafe"
 )
 
@@ -55,6 +57,65 @@ type inputRecord struct {
 	typ  uint16
 	_    uint16
 	data [16]byte
+}
+
+func encodeWinKeyRecord(data [16]byte, surrogate *rune) []byte {
+	keyDown := binary.LittleEndian.Uint32(data[0:]) != 0
+	repeat := binary.LittleEndian.Uint16(data[4:])
+	virtualKey := binary.LittleEndian.Uint16(data[6:])
+	scanCode := binary.LittleEndian.Uint16(data[8:])
+	// we normally only expect to see ascii, but paste data may come in as UTF-16.
+	wc := rune(binary.LittleEndian.Uint16(data[10:]))
+	controlState := binary.LittleEndian.Uint32(data[12:])
+
+	if virtualKey != 0 || scanCode != 0 {
+		kd := 0
+		if keyDown {
+			kd = 1
+		}
+		return fmt.Appendf(nil, "\x1b[%d;%d;%d;%d;%d;%d_",
+			virtualKey, scanCode, wc, kd, controlState, max(1, repeat))
+	}
+
+	if !keyDown {
+		return nil
+	}
+
+	var encoded []byte
+	decodedRunes := decodeUTF16Rune(surrogate, wc)
+	for range max(1, repeat) {
+		for _, decoded := range decodedRunes {
+			encoded = append(encoded, []byte(string(decoded))...)
+		}
+	}
+	return encoded
+}
+
+// decodeUTF16Rune decodes one UTF-16 code unit at a time while preserving
+// malformed input as replacement characters instead of silently discarding it.
+func decodeUTF16Rune(surrogate *rune, wc rune) []rune {
+	switch {
+	case wc >= 0xD800 && wc <= 0xDBFF:
+		if *surrogate != 0 {
+			*surrogate = wc
+			return []rune{utf8.RuneError}
+		}
+		*surrogate = wc
+		return nil
+	case wc >= 0xDC00 && wc <= 0xDFFF:
+		if *surrogate == 0 {
+			return []rune{utf8.RuneError}
+		}
+		decoded := utf16.DecodeRune(*surrogate, wc)
+		*surrogate = 0
+		return []rune{decoded}
+	default:
+		if *surrogate != 0 {
+			*surrogate = 0
+			return []rune{utf8.RuneError, wc}
+		}
+		return []rune{wc}
+	}
 }
 
 type winTty struct {
@@ -168,20 +229,7 @@ func (w *winTty) getConsoleInput() error {
 			ir := rec[i]
 			switch ir.typ {
 			case keyEvent:
-				// we normally only expect to see ascii, but paste data may come in as UTF-16.
-				wc := rune(binary.LittleEndian.Uint16(ir.data[10:]))
-				if wc >= 0xD800 && wc <= 0xDBFF {
-					// if it was a high surrogate, which happens for pasted UTF-16,
-					// then save it until we get the low and can decode it.
-					w.surrogate = wc
-					continue
-				} else if wc >= 0xDC00 && wc <= 0xDFFF {
-					wc = utf16.DecodeRune(w.surrogate, wc)
-				}
-				w.surrogate = 0
-				for _, chr := range []byte(string(wc)) {
-					// We normally expect only to see ASCII (win32-input-mode),
-					// but apparently pasted data can arrive in UTF-16 here.
+				for _, chr := range encodeWinKeyRecord(ir.data, &w.surrogate) {
 					select {
 					case w.buf <- chr:
 					case <-w.stopQ:

--- a/tty_win_test.go
+++ b/tty_win_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package tcell
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func makeWinKeyRecord(keyDown bool, repeat, virtualKey, scanCode, unicodeChar uint16, controlState uint32) [16]byte {
+	var data [16]byte
+	if keyDown {
+		binary.LittleEndian.PutUint32(data[0:], 1)
+	}
+	binary.LittleEndian.PutUint16(data[4:], repeat)
+	binary.LittleEndian.PutUint16(data[6:], virtualKey)
+	binary.LittleEndian.PutUint16(data[8:], scanCode)
+	binary.LittleEndian.PutUint16(data[10:], unicodeChar)
+	binary.LittleEndian.PutUint32(data[12:], controlState)
+	return data
+}
+
+func TestEncodeWinKeyRecordPreservesKeyState(t *testing.T) {
+	tests := []struct {
+		name string
+		data [16]byte
+		want string
+	}{
+		{
+			name: "press",
+			data: makeWinKeyRecord(true, 3, 65, 30, 'A', 0x10),
+			want: "\x1b[65;30;65;1;16;3_",
+		},
+		{
+			name: "release",
+			data: makeWinKeyRecord(false, 1, 65, 30, 'A', 0x10),
+			want: "\x1b[65;30;65;0;16;1_",
+		},
+		{
+			name: "zero repeat becomes one",
+			data: makeWinKeyRecord(true, 0, 65, 30, 'A', 0),
+			want: "\x1b[65;30;65;1;0;1_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var surrogate rune
+			if got := string(encodeWinKeyRecord(tt.data, &surrogate)); got != tt.want {
+				t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodeWinKeyRecordFallbackIgnoresRelease(t *testing.T) {
+	var surrogate rune
+	data := makeWinKeyRecord(false, 1, 0, 0, 'A', 0)
+	if got := encodeWinKeyRecord(data, &surrogate); len(got) != 0 {
+		t.Fatalf("encodeWinKeyRecord() = %q, want no bytes", string(got))
+	}
+
+	data = makeWinKeyRecord(true, 1, 0, 0, 'A', 0)
+	if got := string(encodeWinKeyRecord(data, &surrogate)); got != "A" {
+		t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, "A")
+	}
+
+	data = makeWinKeyRecord(true, 3, 0, 0, 'A', 0)
+	if got := string(encodeWinKeyRecord(data, &surrogate)); got != "AAA" {
+		t.Fatalf("encodeWinKeyRecord() = %q, want %q", got, "AAA")
+	}
+}


### PR DESCRIPTION
Backport of v3 commit fe2979ab8bd1f3266a87cb2d8ad0b340e2978fea (PR #1128) to v2.

Fixes #1124. On Windows, every key was reported twice: once on key down and again on key up.

## Motivation

tview pins tcell v2.8.1. That version predates the Windows tscreen refactor from #777, so it avoids the duplicate-key bug, but it still uses the legacy Windows console screen instead of the common VT-based screen that newer tcell versions use.

tview does run on tcell v2.13.10, which switched Windows to the tscreen path by default (that was the fix for #777). The new screen is faster and better, but the same change introduced a regression: every key is reported twice, once on key press and again on key release (#1124).

That puts users in a bind: stay on 2.8.1 with the legacy screen, or upgrade to 2.13.10 and get duplicated input.

This change fixes the duplicate-key bug in the Windows input layer, backported from the v3 fix (PR #1128, commit fe2979a). Once it is merged, tview and other apps can move to v2.13.10 and get the improved VT screen without the input regression.

## Root cause

Since eae6882 (tscreen by default on Windows, #777), tty_win.go read raw `KEY_EVENT_RECORDs` and reduced each one to its UnicodeChar bytes, ignoring the bKeyDown flag. Key release records therefore emitted the same character again.

## Changes in tty_win.go

- Added `encodeWinKeyRecord()`. Records with a non-zero virtual key or scan code are encoded as win32-input-mode sequences (`ESC[Vk;Sc;Uc;Kd;Cs;Rc_`) including the key-down bit. The existing input processor already drops key-up events (Kd=0) in handleWinKey, so key releases no longer produce a duplicate.
- Records with `Vk=0` and `Sc=0` (pasted text, escape sequence characters) fall back to emitting the character bytes on key down only, preserving the repeat count and UTF-16 surrogate handling. This keeps the paste path working.
- Added the decodeUTF16Rune() helper used by that fallback.

## Tests
Added `tty_win_test.go`, ported from v3, covering key press/release encoding, repeat count normalization, and the `Vk=0` fallback.

## Verification
Tested on Windows 10: typing emits one event per press, and paste works in Windows Terminal.

## AI Disclaimer
DeepSeek V4 was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows keyboard input handling for virtual keys, scan codes, Unicode characters, and control keys.
  * Correctly supports repeated key presses and ignores key-release events where appropriate.
  * Preserves malformed Unicode input as replacement characters instead of failing.
  * Normalizes zero-repeat key events and provides safer fallback behavior for release events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->