### PR TITLE
fix(tscreen): guard inputLoop keyQ send against shutdown deadlock (revives #673)

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1373,7 +1373,11 @@ func (t *tScreen) inputLoop(stopQ chan struct{}) {
 			return
 		}
 		if n > 0 {
-			t.keyQ <- chunk[:n]
+			select {
+			case t.keyQ <- chunk[:n]:
+			case <-t.quit:
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`inputLoop`'s send of input bytes onto `keyQ` is **unguarded**:

```go
// tscreen.go, inputLoop()
if n > 0 {
    t.keyQ <- chunk[:n]   // bare send — no select on stopQ / t.quit
}
```

This deadlocks `Screen.Fini()`. It is a faithful revival of **#673** ("Fix deadlock on screen.Fini"), which was closed without merge or comment. The bug is still present on `main` (and on the `v2` branch, identical save the channel name `keychan`).

## The deadlock

`Fini()` → `finish()` closes `t.quit`, then `finalize()` → `disengage()` closes `stopQ` and blocks on `t.wg.Wait()`. `t.wg` has two members (added in `engage`): `inputLoop` and `mainLoop`.

- `mainLoop` exits cleanly: its `eventQ` send (in `scanInput`) is already guarded by `<-t.quit`, and its outer select sees `stopQ`/`quit`. So `mainLoop` returns and **stops draining `keyQ`**.
- `inputLoop`, however, can be **parked on the bare `keyQ <-` send** (the `stopQ` check is only at the top of the loop). With `mainLoop` gone, `keyQ` has no consumer, so the send never completes and `inputLoop` never reaches the `stopQ` return.
- `disengage`'s `t.wg.Wait()` waits on `inputLoop` forever → the goroutine that called `Fini()` hangs forever.

The goroutine calling `Fini()` is very often the application's event loop (e.g. tview's `Application.Stop()` calls `screen.Fini()` synchronously from the event-loop goroutine). So the whole process wedges and must be killed with `SIGQUIT`.

## Reproduction

Real `kill -QUIT` dump from a long-running [go-nomadnet](https://github.com/gmlewis/go-nomadnet) session (tview v0.42.0 + tcell v2.8.1) after the user pressed Ctrl-Q:

```
goroutine 1 [sync.WaitGroup.Wait]:              // the event loop
  ...
  sync.(*WaitGroup).Wait
  tcell.(*tScreen).disengage          tscreen.go:2069   // t.wg.Wait()
  tcell.(*tScreen).finalize
  tcell.(*tScreen).finish
  tcell.(*tScreen).Fini
  tview.(*Application).Stop
  ... (quit key handler → app.Stop, on the event-loop goroutine)

goroutine 3 [chan send]:                         // inputLoop
  tcell.(*tScreen).inputLoop          tscreen.go:1895   // t.keychan <- chunk[:n]

goroutine 5 [chan send]:                         // tview event-waiter
  tview.(*Application).QueueEvent    // a.events <- event  (event loop stopped draining)
```

Note `mainLoop` is **absent** from the dump — it already exited via `quit`/`stopQ` — while `inputLoop` is parked on the bare send. `disengage` is waiting on exactly that `inputLoop`. Classic self-join: the event loop abandoned its drain to call `Fini()`, which joins a worker that needs the drain to keep flowing.

## Fix

Guard the send with `t.quit`, mirroring `mainLoop`'s `eventQ` send (already quit-guarded in `scanInput`):

```go
if n > 0 {
    select {
    case t.keyQ <- chunk[:n]:
    case <-t.quit:
        return
    }
}
```

`t.quit` is closed in `finish()` *before* `disengage()`'s `t.wg.Wait()`, so a parked `inputLoop` is released and `wg.Wait()` returns. This is the same one-line guard proposed in #673.

## Notes

- The `v2` branch has the identical bug (channel named `keychan` there). I've applied the same guard to a `v2` branch on my fork as well; happy to open a backport PR against `v2` if useful.
- This is a narrow, latent race (requires `keyQ` full at shutdown, i.e. `mainLoop` stopped draining), so it doesn't reproduce on every quit — but it does reproduce reliably in long sessions / SSH tunnels / when trailing input arrives during shutdown (see also #835 for a related-but-distinct SSH `tty.Read` deadlock).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so the application exits cleanly without hanging while waiting for input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->