### PR TITLE
v2: provide tScreen.initialize on wasip1/wasip2

### DIFF
--- a/tscreen_wasi.go
+++ b/tscreen_wasi.go
@@ -1,0 +1,29 @@
+//go:build wasip1 || wasip2
+
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcell
+
+import "errors"
+
+// initialize on WASI: there is no /dev/tty and no termios control, so a
+// terminal screen can only work over an explicitly provided Tty
+// implementation; without one, initialization fails.
+func (t *tScreen) initialize() error {
+	if t.tty == nil {
+		return errors.New("tcell: no tty available")
+	}
+	return nil
+}


### PR DESCRIPTION
Hi, and thanks for maintaining tcell!

Since Go 1.21 added `GOOS=wasip1` (WASI preview 1), building `tcell/v2` for the WASI platforms fails:

```
tscreen.go:190:34: t.initialize undefined (type *tScreen has no field or method initialize)
```

`tscreen.go` itself builds there (it is gated `!(js && wasm)`), but the `initialize` implementations exist only in `tscreen_unix.go` (Unix GOOS list), `tscreen_win.go`, and `tscreen_plan9.go`. This breaks downstream users of the v2 line on wasip1 — for example `gh` (github.com/cli/cli), which imports tcell via its extension browser.

WASI preview 1/2 has no `/dev/tty` and no termios control, so a terminal screen can only work over an explicitly provided `Tty` implementation. This PR adds `tscreen_wasi.go` (gated `wasip1 || wasip2`) whose `initialize` fails with a clear error when no Tty was provided, mirroring the plan9 file's shape — construction errors loudly at runtime instead of the whole build failing.

Verified on the v2 branch:
- `GOOS=wasip1 GOARCH=wasm go build .` now succeeds
- native and js builds select the same files as before

(The v3 line has the same gap but a wider one — `tscreen.go` and its parser/charset internals are all gated `(!js && !wasm) || (js && wasm)`, so wasip1 needs those files widened too; happy to follow up there separately if you'd take it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)