### PR TITLE
feat: expose the negotiated sixel capability as Screen.Capabilities

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -20,6 +20,18 @@ import (
 	"github.com/gdamore/tcell/v3/color"
 )
 
+// Capabilities is a bitfield of terminal capabilities reported during Init.
+type Capabilities uint
+
+const (
+	// CapabilityClipboard: OSC 52 support.  Many terminals support the
+	// clipboard without reporting it, so a false bit is not conclusive.
+	CapabilityClipboard Capabilities = 1 << iota
+
+	// CapabilitySixel: sixel graphics support (DA1, param 4).
+	CapabilitySixel
+)
+
 // Screen represents the physical (or emulated) screen.
 // This can be a terminal window or a physical console.  Platforms implement
 // this differently.
@@ -239,10 +251,11 @@ type Screen interface {
 	// prevent this for security reasons.
 	GetClipboard()
 
-	// HasClipboard is true if the screen claims to support the clipboard.
-	// Note that GetClipboard may still not work, but SetClipboard should be functional.
-	// Note that many terminals that support the clipboard don't actually report that they
-	// do, so a false indication is not necessarily conclusive.
+	// Capabilities returns the terminal capabilities reported during Init.
+	Capabilities() Capabilities
+
+	// HasClipboard reports OSC 52 clipboard support; equivalent to
+	// Capabilities()&CapabilityClipboard != 0.
 	HasClipboard() bool
 
 	// ShowNotification is used to show a desktop notification, when the terminal
@@ -356,6 +369,7 @@ type screenImpl interface {
 	Tty() (Tty, bool)
 	SetClipboard([]byte)
 	GetClipboard()
+	Capabilities() Capabilities
 	HasClipboard() bool
 	ShowNotification(string, string)
 	KeyboardProtocol() KeyProtocol

--- a/screen.go
+++ b/screen.go
@@ -254,8 +254,8 @@ type Screen interface {
 	// Capabilities returns the terminal capabilities reported during Init.
 	Capabilities() Capabilities
 
-	// HasClipboard reports OSC 52 clipboard support; equivalent to
-	// Capabilities()&CapabilityClipboard != 0.
+	// Deprecated: HasClipboard is kept for compatibility; check
+	// Capabilities()&CapabilityClipboard instead.
 	HasClipboard() bool
 
 	// ShowNotification is used to show a desktop notification, when the terminal

--- a/tscreen.go
+++ b/tscreen.go
@@ -241,7 +241,7 @@ type tScreen struct {
 	truecolor          bool
 	noColor            bool
 	legacy             bool
-	hasClipboard       bool // true if OSC 52 reported via DA1
+	caps               Capabilities // capabilities reported via DA1
 	finiOnce           sync.Once
 	initFiniLock       sync.Mutex
 	enterUrl           string
@@ -509,7 +509,12 @@ func (t *tScreen) processInitQ() {
 				if ev.Clipboard && t.setClipboard == "" {
 					t.setClipboard = setClipboard
 				}
-				t.hasClipboard = ev.Clipboard
+				if ev.Clipboard {
+					t.caps |= CapabilityClipboard
+				}
+				if ev.Sixel {
+					t.caps |= CapabilitySixel
+				}
 				t.initted = true
 				return
 			case *eventTermName:
@@ -1813,8 +1818,12 @@ func (t *tScreen) GetClipboard() {
 	t.Unlock()
 }
 
+func (t *tScreen) Capabilities() Capabilities {
+	return t.caps
+}
+
 func (t *tScreen) HasClipboard() bool {
-	return t.hasClipboard
+	return t.caps&CapabilityClipboard != 0
 }
 
 func (t *tScreen) ShowNotification(title string, body string) {

--- a/tscreen.go
+++ b/tscreen.go
@@ -1822,8 +1822,9 @@ func (t *tScreen) Capabilities() Capabilities {
 	return t.caps
 }
 
+//go:fix inline
 func (t *tScreen) HasClipboard() bool {
-	return t.caps&CapabilityClipboard != 0
+	return t.Capabilities()&CapabilityClipboard != 0
 }
 
 func (t *tScreen) ShowNotification(title string, body string) {


### PR DESCRIPTION
I would like to know if the terminal support sixel, and since tcell already negotiates terminal capabilities it makes sense to just pass it through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified terminal capabilities check for clipboard and sixel graphics support.
  * Capabilities are detected during terminal initialization and exposed through the screen interface.
  * Added compatibility handling for terminals with limited feature support.
  * Clipboard support checks now use the unified capabilities information.

* **Bug Fixes**
  * Improved input processing reliability by preventing blocked reads and applying appropriate parser timeouts.
  * Enhanced keyboard protocol selection and legacy terminal rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->