### PR TITLE
fix(st): The st terminal is very limited - disable extensions that br…

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -286,6 +286,11 @@ type tScreen struct {
 	advancedKeys       bool
 	controlStringLimit int
 	input              *inputParser
+	compat             struct {
+		mouseUnsupported         bool
+		focusUnsupported         bool
+		clipboardReadUnsupported bool
+	}
 	sync.Mutex
 }
 
@@ -780,6 +785,10 @@ func (t *tScreen) emitAttrs(attrs AttrMask) {
 // The assumption is that sgr0 was already printed ahead of this.
 func (t *tScreen) emitUnderline(us UnderlineStyle, uc Color) {
 	if us != UnderlineStyleNone {
+		if t.legacy {
+			t.Print(underline)
+			return
+		}
 		// NB: under color should have been reset by sgr0
 		if uc.IsRGB() {
 			r, g, b := uc.RGB()
@@ -1100,6 +1109,9 @@ func (t *tScreen) enableMouse(f MouseFlags) {
 	// so we enable the mouse unconditionally unless we get a report
 	// that says we have mouse, but not SGR mouse.  This is suboptimal, but
 	// a concession forced by the sorry state of terminal emulators.
+	if t.compat.mouseUnsupported {
+		return
+	}
 	if t.mouseDisabled {
 		f = 0
 	}
@@ -1203,10 +1215,16 @@ func (t *tScreen) DisableFocus() {
 }
 
 func (t *tScreen) enableFocusReporting() {
+	if t.compat.focusUnsupported {
+		return
+	}
 	t.Print(vt.PmFocusReports.Enable())
 }
 
 func (t *tScreen) disableFocusReporting() {
+	if t.compat.focusUnsupported {
+		return
+	}
 	t.Print(vt.PmFocusReports.Disable())
 }
 
@@ -1453,7 +1471,31 @@ func (t *tScreen) Tty() (Tty, bool) {
 	return t.tty, true
 }
 
-func (t *tScreen) applyKnownTerminalProfile(goos, termProgram string) bool {
+func isSTTerminal(term string) bool {
+	return term == "st" || strings.HasPrefix(term, "st-")
+}
+
+func (t *tScreen) applyKnownTerminalProfile(goos, term, termProgram string) bool {
+	if isSTTerminal(term) {
+		// st implements a small subset of xterm extensions.  In particular,
+		// it has neither an advanced keyboard protocol nor SGR mouse or focus
+		// reporting.  It also reports unsupported CSI and OSC sequences to
+		// stderr, so avoid probing or using extensions it does not implement.
+		t.legacy = true
+		t.compat.mouseUnsupported = true
+		t.compat.focusUnsupported = true
+		t.enterUrl = ""
+		t.exitUrl = ""
+		t.setWinSize = ""
+		t.saveTitle = ""
+		t.restoreTitle = ""
+		t.setTitle = "\x1b]2;%s\x1b\\"
+		t.notifyDesktop = ""
+		t.compat.clipboardReadUnsupported = true
+		t.termName = "st"
+		return true
+	}
+
 	switch termProgram {
 	case "Apple_Terminal":
 		// macOS Terminal.app cannot handle the startup queries, but it does
@@ -1529,7 +1571,7 @@ func (t *tScreen) engageLocked() error {
 		// Eventually they'll hopefully fix this.  As the environment variable
 		// does not convey by default via ssh, remote sessions might see spurious characters
 		// emitted during startup.  See the blog post for alternatives.
-		if !t.applyKnownTerminalProfile(runtime.GOOS, os.Getenv("TERM_PROGRAM")) && t.negotiate {
+		if !t.applyKnownTerminalProfile(runtime.GOOS, t.term, os.Getenv("TERM_PROGRAM")) && t.negotiate {
 			if useVTWindowSizeQuery(runtime.GOOS) {
 				t.Print(requestWindowSize)
 			}
@@ -1593,7 +1635,7 @@ func (t *tScreen) engageLocked() error {
 	if t.title != "" && t.setTitle != "" {
 		t.Printf(t.setTitle, t.title)
 	}
-	if t.negotiate && useVTWindowSizeQuery(runtime.GOOS) {
+	if t.negotiate && !t.legacy && useVTWindowSizeQuery(runtime.GOOS) {
 		t.Print(requestWindowSize)
 	}
 
@@ -1748,7 +1790,7 @@ func (t *tScreen) GetClipboard() {
 		t.Unlock()
 		return
 	}
-	if t.setClipboard != "" {
+	if !t.compat.clipboardReadUnsupported && t.setClipboard != "" {
 		t.Printf(t.setClipboard, "?")
 	}
 	t.Unlock()

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -734,10 +734,13 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 		wantMouseSgr bool
 		wantKittyKbd bool
 		wantWin32Kbd bool
+		term         string
+		wantLegacy   bool
 	}{
 		{
 			name:         "AppleTerminal",
 			goos:         "darwin",
+			term:         "xterm-256color",
 			termProgram:  "Apple_Terminal",
 			wantKnown:    true,
 			wantMouse:    true,
@@ -746,6 +749,7 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 		{
 			name:         "LocalWindowsWezTerm",
 			goos:         "windows",
+			term:         "wezterm",
 			termProgram:  "WezTerm",
 			wantKnown:    true,
 			wantInitted:  true,
@@ -756,6 +760,7 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 		{
 			name:         "LocalUnixWezTerm",
 			goos:         "linux",
+			term:         "wezterm",
 			termProgram:  "WezTerm",
 			wantKnown:    true,
 			wantInitted:  true,
@@ -766,14 +771,29 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 		{
 			name:        "UnknownTerminal",
 			goos:        "linux",
+			term:        "xterm-256color",
 			termProgram: "Other",
+		},
+		{
+			name:       "St",
+			goos:       "linux",
+			term:       "st",
+			wantKnown:  true,
+			wantLegacy: true,
+		},
+		{
+			name:       "St256Color",
+			goos:       "linux",
+			term:       "st-256color",
+			wantKnown:  true,
+			wantLegacy: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &tScreen{}
-			if got := s.applyKnownTerminalProfile(tt.goos, tt.termProgram); got != tt.wantKnown {
+			if got := s.applyKnownTerminalProfile(tt.goos, tt.term, tt.termProgram); got != tt.wantKnown {
 				t.Fatalf("applyKnownTerminalProfile() = %v, want %v", got, tt.wantKnown)
 			}
 			if s.initted != tt.wantInitted {
@@ -791,7 +811,67 @@ func TestApplyKnownTerminalProfile(t *testing.T) {
 			if s.haveWin32Kbd != tt.wantWin32Kbd {
 				t.Fatalf("haveWin32Kbd = %v, want %v", s.haveWin32Kbd, tt.wantWin32Kbd)
 			}
+			if s.legacy != tt.wantLegacy {
+				t.Fatalf("legacy = %v, want %v", s.legacy, tt.wantLegacy)
+			}
 		})
+	}
+}
+
+func TestStProfileSkipsUnsupportedOperations(t *testing.T) {
+	t.Setenv("TERM", "st-256color")
+	t.Setenv("TERM_PROGRAM", "")
+
+	tty := &spyTty{MockTerm: vt.NewMockTerm(vt.MockOptSize{X: 8, Y: 5})}
+	s, err := NewTerminfoScreenFromTty(tty, OptAltScreen(false))
+	if err != nil {
+		t.Fatalf("failed to get screen: %v", err)
+	}
+	if err := s.Init(); err != nil {
+		t.Fatalf("failed to initialize screen: %v", err)
+	}
+	defer s.Fini()
+
+	s.EnableMouse()
+	s.EnableFocus()
+	out := tty.Output()
+	for _, seq := range []string{
+		requestWindowSize,
+		vt.PmResizeReports.Query(),
+		vt.PmMouseButton.Query(),
+		vt.PmMouseSgr.Query(),
+		vt.PmWin32Input.Query(),
+		queryKittyKbd,
+		queryXTermKbd,
+		requestExtAttr,
+		vt.PmMouseButton.Enable(),
+		vt.PmMouseSgr.Enable(),
+		vt.PmFocusReports.Enable(),
+	} {
+		if strings.Contains(out, seq) {
+			t.Fatalf("st profile emitted unsupported sequence %q", seq)
+		}
+	}
+	if !strings.Contains(out, requestPrimaryDA) {
+		t.Fatal("st profile did not emit primary DA")
+	}
+	name, version := s.Terminal()
+	if name != "st" || version != "" {
+		t.Fatalf("Terminal() = %q, %q, want %q, %q", name, version, "st", "")
+	}
+
+	tScreen := s.(*baseScreen).screenImpl.(*tScreen)
+	start := len(tty.Output())
+	tScreen.emitUnderline(UnderlineStyleCurly, ColorDefault)
+	if got := tty.Output()[start:]; got != underline {
+		t.Fatalf("st underline escape = %q, want %q", got, underline)
+	}
+
+	start = len(tty.Output())
+	s.SetTitle("title")
+	s.GetClipboard()
+	if got, want := tty.Output()[start:], "\x1b]2;title\x1b\\"; got != want {
+		t.Fatalf("st title and clipboard escapes = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
…eak it (fixes#1152)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with `st` and `st-256color` terminals.
  * Disabled unsupported mouse, focus, clipboard, URL, window-size, title, and notification features for these terminals.
  * Prevented unsupported startup and clipboard-read requests.
  * Preserved supported terminal identification, metadata, underline rendering, and title behavior.
* **Tests**
  * Added coverage for terminal detection and compatibility behavior across supported terminal types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->