### PR TITLE
fix(input): extend escape sequence timeouts

### DIFF
--- a/input.go
+++ b/input.go
@@ -63,10 +63,22 @@ const (
 // before they can grow without bound while waiting for a string terminator.
 const defaultControlStringLimit = 64 * 1024
 
+const (
+	// loneEscapeTimeout keeps bare Escape responsive when using legacy
+	// keyboard reporting, where ESC can also prefix an Alt-modified key.
+	loneEscapeTimeout = 200 * time.Millisecond
+
+	// escapeSequenceTimeout bounds incomplete escape sequences. Once a
+	// sequence introducer has arrived, it is no longer ambiguous with a lone
+	// Escape and can tolerate a substantially longer inter-byte delay.
+	escapeSequenceTimeout = time.Second
+)
+
 func newInputParser(eq chan<- Event) *inputParser {
 	return &inputParser{
 		evch:             eq,
 		buf:              make([]rune, 0, 128),
+		legacy:           true,
 		controlStringMax: defaultControlStringLimit,
 	}
 }
@@ -91,6 +103,7 @@ type inputParser struct {
 	nested           *inputParser // for buggy win32-input-mode implementations
 	surrogate        rune         // high surrogate pair seen (for Win32 input mode)
 	advanced         bool         // use advanced key reporting semantics
+	legacy           bool         // keyboard protocol has ambiguous ESC prefixes
 	controlStringMax int          // maximum inbound OSC/XDA payload size; 0 means unlimited
 	discardString    bool         // drop the rest of an over-limit OSC/XDA sequence
 }
@@ -127,6 +140,35 @@ func (ip *inputParser) Waiting() bool {
 	ip.l.Lock()
 	defer ip.l.Unlock()
 	return ip.state != istInit
+}
+
+// waitDuration reports how long to wait for the next byte before resetting an
+// incomplete escape sequence. A bare ESC is only ambiguous with legacy
+// keyboard reporting; other protocols can use the longer sequence deadline.
+func (ip *inputParser) waitDuration() time.Duration {
+	if ip.state == istInit {
+		return 0
+	}
+	if ip.state == istEsc && ip.legacy {
+		return loneEscapeTimeout
+	}
+	return escapeSequenceTimeout
+}
+
+func (ip *inputParser) WaitDuration() time.Duration {
+	ip.l.Lock()
+	defer ip.l.Unlock()
+	return ip.waitDuration()
+}
+
+func (ip *inputParser) SetKeyboardProtocol(protocol KeyProtocol) {
+	ip.l.Lock()
+	ip.legacy = protocol == LegacyKeyboard
+	nested := ip.nested
+	ip.l.Unlock()
+	if nested != nil {
+		nested.SetKeyboardProtocol(protocol)
+	}
 }
 
 // SetPixelMouse toggles whether SGR mouse reports are interpreted as
@@ -778,7 +820,7 @@ func (ip *inputParser) scan() {
 		}
 	}
 
-	if ip.state != istInit && time.Since(ip.keyTime) > time.Millisecond*50 {
+	if timeout := ip.waitDuration(); timeout > 0 && time.Since(ip.keyTime) > timeout {
 		if ip.state == istEsc {
 			ip.postKey(KeyEscape, "", ModNone)
 		} else if ec := ip.escChar; ec != 0 {
@@ -1077,6 +1119,7 @@ func (ip *inputParser) handleWinKey(P []int) {
 					rows:             ip.rows,
 					cols:             ip.cols,
 					advanced:         ip.advanced,
+					legacy:           ip.legacy,
 					pixelMouse:       ip.pixelMouse,
 					controlStringMax: ip.controlStringMax,
 				}

--- a/input_test.go
+++ b/input_test.go
@@ -135,6 +135,40 @@ func TestInputControlKeys(t *testing.T) {
 	}
 }
 
+func TestInputEscapeTimeouts(t *testing.T) {
+	evch := make(chan Event, 2)
+	ip := newInputParser(evch)
+
+	ip.ScanUTF8([]byte{'\x1b'})
+	if got := ip.WaitDuration(); got != loneEscapeTimeout {
+		t.Fatalf("bare legacy ESC timeout = %v, want %v", got, loneEscapeTimeout)
+	}
+
+	// A byte that starts a control sequence gets the longer deadline, so it
+	// can arrive well after the bare-ESC deadline without being discarded.
+	ip.ScanUTF8([]byte{'['})
+	if got := ip.WaitDuration(); got != escapeSequenceTimeout {
+		t.Fatalf("CSI timeout = %v, want %v", got, escapeSequenceTimeout)
+	}
+	ip.keyTime = time.Now().Add(-loneEscapeTimeout * 2)
+	ip.Scan()
+	select {
+	case ev := <-evch:
+		t.Fatalf("CSI timed out at the bare-ESC deadline: %v", ev)
+	default:
+	}
+	ip.ScanUTF8([]byte{'A'})
+	if ev := <-evch; ev.(*EventKey).Key() != KeyUp {
+		t.Fatalf("delayed CSI key = %v, want %v", ev, KeyUp)
+	}
+
+	ip.ScanUTF8([]byte{'\x1b'})
+	ip.SetKeyboardProtocol(KittyKeyboard)
+	if got := ip.WaitDuration(); got != escapeSequenceTimeout {
+		t.Fatalf("bare kitty ESC timeout = %v, want %v", got, escapeSequenceTimeout)
+	}
+}
+
 // TestInputNullVsOtherControlChars tests the boundary between
 // null byte and other control characters.
 func TestInputNullVsOtherControlChars(t *testing.T) {
@@ -678,6 +712,9 @@ func TestSpecialKeys(t *testing.T) {
 				}
 
 			case <-time.After(100 * time.Millisecond):
+				// Force any incomplete escape sequence to expire without making
+				// every legacy-key test wait for its full timeout.
+				ip.keyTime = time.Now().Add(-2 * escapeSequenceTimeout)
 				ip.Scan()
 				select {
 				case ev := <-evch:

--- a/input_test.go
+++ b/input_test.go
@@ -167,6 +167,20 @@ func TestInputEscapeTimeouts(t *testing.T) {
 	if got := ip.WaitDuration(); got != escapeSequenceTimeout {
 		t.Fatalf("bare kitty ESC timeout = %v, want %v", got, escapeSequenceTimeout)
 	}
+
+	nested := newInputParser(make(chan Event, 1))
+	ip.nested = nested
+	ip.SetKeyboardProtocol(Win32Keyboard)
+	if nested.legacy {
+		t.Fatal("nested parser retained legacy keyboard protocol")
+	}
+
+	win := newInputParser(make(chan Event, 1))
+	win.SetKeyboardProtocol(KittyKeyboard)
+	win.handleWinKey([]int{0, 0, 'A', 1})
+	if win.nested == nil || win.nested.legacy {
+		t.Fatal("Win32 nested parser did not inherit keyboard protocol")
+	}
 }
 
 // TestInputNullVsOtherControlChars tests the boundary between

--- a/tscreen.go
+++ b/tscreen.go
@@ -1354,13 +1354,18 @@ func (t *tScreen) mainLoop(stopQ chan struct{}) {
 		case chunk := <-t.keyQ:
 			buf.Write(chunk)
 			t.scanInput(buf)
-			if t.input.Waiting() {
-				ta = time.After(time.Millisecond * 100)
+			if timeout := t.input.WaitDuration(); timeout > 0 {
+				ta = time.After(timeout)
 			} else {
 				ta = nil
 			}
 		case <-ta:
 			t.input.Scan()
+			if timeout := t.input.WaitDuration(); timeout > 0 {
+				ta = time.After(timeout)
+			} else {
+				ta = nil
+			}
 		}
 	}
 }
@@ -1597,6 +1602,7 @@ func (t *tScreen) engageLocked() error {
 	}
 	t.processInitQ()
 	t.applyKeyboardProtocolOverride()
+	t.input.SetKeyboardProtocol(t.keyboardProtocol())
 	if t.useAltScreen() {
 		// Technically this may not be right, but every terminal we know about
 		// (even Wyse 60) uses this to enter the alternate screen buffer, and
@@ -1819,6 +1825,11 @@ func (t *tScreen) Terminal() (string, string) {
 func (t *tScreen) KeyboardProtocol() KeyProtocol {
 	t.Lock()
 	defer t.Unlock()
+	return t.keyboardProtocol()
+}
+
+// keyboardProtocol reports the selected keyboard protocol while t is locked.
+func (t *tScreen) keyboardProtocol() KeyProtocol {
 	if t.haveWin32Kbd {
 		return Win32Keyboard
 	}

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gdamore/tcell/v3/tty"
 	"github.com/gdamore/tcell/v3/vt"
+	"golang.org/x/text/transform"
 )
 
 // This just offers some very basic tests that do not require a full mock.
@@ -110,6 +111,67 @@ func TestOptAltScreenDefault(t *testing.T) {
 	}
 	if !strings.Contains(out, exitCA) {
 		t.Fatalf("alternate screen exit escape was not emitted")
+	}
+}
+
+func TestMainLoopEscapeTimeout(t *testing.T) {
+	evch := make(chan Event, 2)
+	tscreen := &tScreen{
+		keyQ:    make(chan []byte, 2),
+		quit:    make(chan struct{}),
+		resizeQ: make(chan bool),
+		input:   newInputParser(evch),
+		decoder: transform.Nop,
+	}
+	stopQ := make(chan struct{})
+	done := make(chan struct{})
+	tscreen.wg.Add(1)
+	go func() {
+		tscreen.mainLoop(stopQ)
+		close(done)
+	}()
+
+	tscreen.keyQ <- []byte{'\x1b'}
+	deadline := time.After(time.Second)
+	for tscreen.input.WaitDuration() != loneEscapeTimeout {
+		select {
+		case <-deadline:
+			t.Fatal("input timeout was not scheduled")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	// Refresh the parser timestamp before the first timer fires. This verifies
+	// that mainLoop re-arms its timer when parsing remains incomplete.
+	time.Sleep(loneEscapeTimeout / 2)
+	tscreen.input.l.Lock()
+	tscreen.input.keyTime = time.Now()
+	tscreen.input.l.Unlock()
+	select {
+	case ev := <-evch:
+		if key, ok := ev.(*EventKey); !ok || key.Key() != KeyEscape {
+			t.Fatalf("expired ESC event = %T %v, want KeyEscape", ev, ev)
+		}
+	case <-time.After(loneEscapeTimeout * 4):
+		t.Fatal("bare ESC did not expire")
+	}
+
+	// Verify that the loop clears its timer after a complete key is parsed.
+	tscreen.keyQ <- []byte{'A'}
+	select {
+	case ev := <-evch:
+		if key, ok := ev.(*EventKey); !ok || key.Str() != "A" {
+			t.Fatalf("plain key event = %T %v, want A", ev, ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("plain key was not processed")
+	}
+
+	close(stopQ)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("input main loop did not stop")
 	}
 }
 


### PR DESCRIPTION
Extends the legacy bare-ESC timeout to 200 ms and uses a 1 s deadline once an escape sequence is underway. Uses the longer bounded deadline for Kitty, Win32, and XTerm keyboard protocols, and re-arms the screen input timer while parsing incomplete input. Adds coverage for the timeout transitions and updates legacy fallback tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input handling for Escape sequences and incomplete key sequences.
  * Added protocol-aware timeouts for legacy and modern keyboard reporting.
  * Reduced delays when processing standalone Escape keys while allowing longer sequences to complete reliably.
  * Improved keyboard protocol handling for more responsive and accurate key recognition.
  * Improved timeout scheduling when parsing input in the terminal interface.

* **Tests**
  * Added coverage for legacy, CSI, and Kitty keyboard timeout behavior.
  * Added coverage for Escape-key handling in the terminal input loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->