### PR TITLE
fix(tscreen): Guard inputLoop against shutdown deadlock (revives #673)

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1064,7 +1064,11 @@ func (t *tScreen) inputLoop(stopQ chan struct{}) {
 			return
 		}
 		if n > 0 {
-			t.keychan <- chunk[:n]
+			select {
+			case t.keychan <- chunk[:n]:
+			case <-t.quit:
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR is identical to #1155 but targets the `v2` branch instead of `main`.

It was written to address this comment:
https://github.com/gdamore/tcell/pull/1155#issuecomment-5331382710