### PR TITLE
fix(tscreen): Ensure tty read does not block Fini

### DIFF
--- a/tscreen.go
+++ b/tscreen.go
@@ -1374,13 +1374,24 @@ func (t *tScreen) inputLoop(stopQ chan struct{}) {
 
 	defer t.wg.Done()
 	for {
+		readDone := make(chan bool)
+		chunk := make([]byte, 128)
+		var n int
+		var e error
 		select {
 		case <-stopQ:
 			return
 		default:
+			go func() {
+				n, e = t.tty.Read(chunk)
+				close(readDone)
+			}()
+			select {
+			case <-stopQ:
+				return
+			case <-readDone:
+			}
 		}
-		chunk := make([]byte, 128)
-		n, e := t.tty.Read(chunk)
 		switch e {
 		case nil:
 		default:


### PR DESCRIPTION
The `SetReadDeadline` call during shutdown did not stop `t.tty.Read` from blocking on OpenBSD. This way, no extra key press is required to shut down a tcell program on OpenBSD.

I consider this a workaround for #1148. Ideally `SetReadDeadline` would cancel the read on OpenBSD as well, but I don't see a way of getting that to work. If anyone can see a better way, feel free to reject this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown responsiveness when terminal input is blocked.
  * The application can now exit promptly after a stop request, without waiting for terminal input to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->