### PR TITLE
feat: add FillArea to fill a rectangular region

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -252,3 +252,32 @@ func (cb *CellBuffer) Fill(r rune, style Style) {
 		c.width = 1
 	}
 }
+
+// FillArea fills a rectangular region of the cell buffer with the specified
+// character and style.  The region starts at column x, row y and extends w
+// columns to the right and h rows down; any part of it lying outside the
+// buffer is simply skipped, so callers do not need to clip coordinates
+// themselves.  A zero or negative width or height fills nothing.  As with
+// Fill, this doesn't support combining characters or wide runes, and a
+// ColorNone foreground or background leaves that color unchanged.
+func (cb *CellBuffer) FillArea(x, y, w, h int, r rune, style Style) {
+	x0 := max(x, 0)
+	y0 := max(y, 0)
+	x1 := min(x+w, cb.w)
+	y1 := min(y+h, cb.h)
+	for row := y0; row < y1; row++ {
+		for col := x0; col < x1; col++ {
+			c := &cb.cells[(row*cb.w)+col]
+			c.currStr = string(r)
+			cs := style
+			if cs.fg == ColorNone {
+				cs.fg = c.currStyle.fg
+			}
+			if cs.bg == ColorNone {
+				cs.bg = c.currStyle.bg
+			}
+			c.currStyle = cs
+			c.width = 1
+		}
+	}
+}

--- a/cell.go
+++ b/cell.go
@@ -261,10 +261,23 @@ func (cb *CellBuffer) Fill(r rune, style Style) {
 // Fill, this doesn't support combining characters or wide runes, and a
 // ColorNone foreground or background leaves that color unchanged.
 func (cb *CellBuffer) FillArea(x, y, w, h int, r rune, style Style) {
+	if w <= 0 || h <= 0 {
+		return
+	}
 	x0 := max(x, 0)
 	y0 := max(y, 0)
-	x1 := min(x+w, cb.w)
-	y1 := min(y+h, cb.h)
+	// Clip the far edge to the buffer without ever evaluating x+w or y+h when
+	// they would overflow a signed int.  Because w and h are positive here,
+	// x < cb.w-w is equivalent to x+w < cb.w but cannot overflow, and it is
+	// only true when x+w is small enough to compute safely.
+	x1 := cb.w
+	if x < cb.w-w {
+		x1 = x + w
+	}
+	y1 := cb.h
+	if y < cb.h-h {
+		y1 = y + h
+	}
 	for row := y0; row < y1; row++ {
 		for col := x0; col < x1; col++ {
 			c := &cb.cells[(row*cb.w)+col]

--- a/cell_test.go
+++ b/cell_test.go
@@ -252,3 +252,64 @@ func TestCellBufferPutASCIIFastPathMatchesGraphemeIterator(t *testing.T) {
 		}
 	}
 }
+
+func TestCellBufferFillArea(t *testing.T) {
+	cb := &CellBuffer{w: 4, h: 3, cells: make([]cell, 12)}
+	cb.Fill('.', StyleDefault)
+
+	red := StyleDefault.Foreground(ColorRed).Background(ColorBlue)
+	cb.FillArea(1, 1, 2, 1, 'x', red)
+
+	// Cells inside the region should have changed.
+	for _, xy := range [][2]int{{1, 1}, {2, 1}} {
+		got, style, width := cb.Get(xy[0], xy[1])
+		if got != "x" || width != 1 || style != red {
+			t.Fatalf("cell %v not filled: got %q style=%v width=%d", xy, got, style, width)
+		}
+	}
+	// Neighbours just outside the region should be untouched.
+	for _, xy := range [][2]int{{0, 1}, {3, 1}, {1, 0}, {1, 2}} {
+		if got, _, _ := cb.Get(xy[0], xy[1]); got != "." {
+			t.Fatalf("cell %v should be untouched, got %q", xy, got)
+		}
+	}
+}
+
+func TestCellBufferFillAreaClipping(t *testing.T) {
+	cb := &CellBuffer{w: 3, h: 3, cells: make([]cell, 9)}
+	cb.Fill('.', StyleDefault)
+
+	// A region that starts off-screen and overflows the far edge should only
+	// paint the cells that actually fall inside the buffer.
+	cb.FillArea(-2, -2, 4, 4, '#', StyleDefault)
+	for y := 0; y < 3; y++ {
+		for x := 0; x < 3; x++ {
+			want := "."
+			if x < 2 && y < 2 {
+				want = "#"
+			}
+			if got, _, _ := cb.Get(x, y); got != want {
+				t.Fatalf("cell (%d,%d): got %q want %q", x, y, got, want)
+			}
+		}
+	}
+
+	// Zero and negative extents must not change anything.
+	cb.FillArea(0, 0, 0, 3, '!', StyleDefault)
+	cb.FillArea(0, 0, 3, -1, '!', StyleDefault)
+	if got, _, _ := cb.Get(0, 0); got != "#" {
+		t.Fatalf("empty region should be a no-op, got %q", got)
+	}
+}
+
+func TestCellBufferFillAreaColorNone(t *testing.T) {
+	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
+	base := StyleDefault.Foreground(ColorRed).Background(ColorBlue)
+	cb.Fill(' ', base)
+
+	// ColorNone should leave the existing fg/bg in place, matching Fill.
+	cb.FillArea(0, 0, 1, 1, 'y', StyleDefault.Foreground(ColorNone).Background(ColorNone))
+	if _, style, _ := cb.Get(0, 0); style != base {
+		t.Fatalf("ColorNone should preserve existing colors, got %v", style)
+	}
+}

--- a/cell_test.go
+++ b/cell_test.go
@@ -302,6 +302,42 @@ func TestCellBufferFillAreaClipping(t *testing.T) {
 	}
 }
 
+func TestCellBufferFillAreaOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
+	const minInt = -maxInt - 1
+
+	// A width that overflows x+w must still fill every in-bounds cell from x
+	// onward rather than clipping to a wrapped-around negative endpoint.
+	cb := &CellBuffer{w: 4, h: 3, cells: make([]cell, 12)}
+	cb.Fill('.', StyleDefault)
+	cb.FillArea(1, 1, maxInt, maxInt, '#', StyleDefault)
+	for y := 0; y < 3; y++ {
+		for x := 0; x < 4; x++ {
+			want := "."
+			if x >= 1 && y >= 1 {
+				want = "#"
+			}
+			if got, _, _ := cb.Get(x, y); got != want {
+				t.Fatalf("cell (%d,%d): got %q want %q", x, y, got, want)
+			}
+		}
+	}
+
+	// Negative extents (including the extreme minimum) must never underflow
+	// into filling cells; the region is empty and nothing changes.
+	cb2 := &CellBuffer{w: 4, h: 3, cells: make([]cell, 12)}
+	cb2.Fill('.', StyleDefault)
+	cb2.FillArea(minInt+1, minInt+1, minInt, minInt, '#', StyleDefault)
+	cb2.FillArea(0, 0, minInt, 2, '#', StyleDefault)
+	for y := 0; y < 3; y++ {
+		for x := 0; x < 4; x++ {
+			if got, _, _ := cb2.Get(x, y); got != "." {
+				t.Fatalf("cell (%d,%d) should be untouched, got %q", x, y, got)
+			}
+		}
+	}
+}
+
 func TestCellBufferFillAreaColorNone(t *testing.T) {
 	cb := &CellBuffer{w: 2, h: 1, cells: make([]cell, 2)}
 	base := StyleDefault.Foreground(ColorRed).Background(ColorBlue)

--- a/screen.go
+++ b/screen.go
@@ -39,6 +39,14 @@ type Screen interface {
 	// is called (or Sync).
 	Fill(rune, Style)
 
+	// FillArea fills a rectangular region of the screen with the given
+	// character and style.  The region starts at column x, row y and
+	// extends width columns to the right and height rows down.  Any part
+	// of the region outside the screen is ignored, so it's safe to pass
+	// coordinates that overflow the screen.  Like Fill, the change is not
+	// visible until Show (or Sync) is called.
+	FillArea(x int, y int, width int, height int, r rune, style Style)
+
 	// Put writes the first grapheme of the given string with th
 	// given style at the given coordinates. (Only the first grapheme
 	// occupying either one or two cells is stored.) It returns the
@@ -423,6 +431,13 @@ func (b *baseScreen) Fill(r rune, style Style) {
 	cb := b.GetCells()
 	b.Lock()
 	cb.Fill(r, style)
+	b.Unlock()
+}
+
+func (b *baseScreen) FillArea(x, y, width, height int, r rune, style Style) {
+	cb := b.GetCells()
+	b.Lock()
+	cb.FillArea(x, y, width, height, r, style)
 	b.Unlock()
 }
 

--- a/tscreen_test.go
+++ b/tscreen_test.go
@@ -1453,3 +1453,32 @@ func TestShowWhileSuspendedEmitsNothing(t *testing.T) {
 	}
 	s.Fini()
 }
+
+func TestScreenFillArea(t *testing.T) {
+	_, s := NewMockScreen(t, vt.MockOptSize{X: 20, Y: 10})
+	defer s.Fini()
+
+	style := StyleDefault.Foreground(ColorGreen).Background(ColorBlack)
+	s.FillArea(2, 3, 4, 2, '*', style)
+
+	// Inside the region.
+	if got, gotStyle, _ := s.Get(3, 3); got != "*" || gotStyle != style {
+		t.Errorf("filled cell wrong: got %q style=%v", got, gotStyle)
+	}
+	if got, _, _ := s.Get(5, 4); got != "*" {
+		t.Errorf("bottom-right corner not filled: got %q", got)
+	}
+	// Just outside the region should still be blank.
+	if got, _, _ := s.Get(6, 3); got != " " {
+		t.Errorf("cell past the region should be blank, got %q", got)
+	}
+	if got, _, _ := s.Get(3, 5); got != " " {
+		t.Errorf("cell below the region should be blank, got %q", got)
+	}
+
+	// Coordinates that overflow the screen must not panic and must be clipped.
+	s.FillArea(18, 8, 100, 100, '#', style)
+	if got, _, _ := s.Get(19, 9); got != "#" {
+		t.Errorf("overflowing fill should paint in-bounds cells, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #107. This adds a FillArea method to Screen so you can fill just a rectangle instead of the whole screen. You mentioned on the issue that this seemed reasonable, so I took a shot at it.

It works like Fill but takes an x, y, width, height rectangle, and it clips anything that runs past the edges so callers don't have to bounds-check the coordinates themselves. Same rules as Fill otherwise: single runes only, and ColorNone leaves whatever color was already in the cell. Tests cover the CellBuffer directly and a mock screen, including the clipping and overflow cases.

I left the scroll and border ideas from the issue out on purpose to keep this small and focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filling rectangular screen areas with a selected character and style.
  * Regions are automatically clipped to screen boundaries.
  * Existing foreground or background colors can be preserved when unspecified.
  * Updates become visible when the screen is refreshed.

* **Bug Fixes**
  * Invalid or non-positive dimensions safely perform no changes.
  * Out-of-bounds and extreme-size fill operations no longer cause errors or crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->