### PR TITLE
fix: request kitty associated text for shifted keys

### DIFF
--- a/input.go
+++ b/input.go
@@ -867,6 +867,9 @@ func (ip *inputParser) handleXda(str string) {
 }
 
 func calcModifier(n int) ModMask {
+	if n < 1 {
+		return ModNone
+	}
 	n--
 	m := ModNone
 	if n&1 != 0 {
@@ -998,7 +1001,7 @@ func kittyKeyText(params string) string {
 	}
 	var b strings.Builder
 	for cp := range strings.SplitSeq(fields[2], ":") {
-		if n, err := strconv.ParseInt(cp, 10, 32); err == nil && n > 0 {
+		if n, err := strconv.ParseInt(cp, 10, 32); err == nil && n > 0 && utf8.ValidRune(rune(n)) {
 			b.WriteRune(rune(n))
 		}
 	}

--- a/input.go
+++ b/input.go
@@ -987,6 +987,24 @@ func kittyModifierKey(code int) ModMask {
 	}
 }
 
+// kittyKeyText extracts the associated text (kitty mode 16) from a csi-u
+// event's params: the third ;-field, codepoints :separated. Empty when
+// the event carries no text (control keys, specials, terminals without
+// mode 16), so callers fall back to the base key.
+func kittyKeyText(params string) string {
+	fields := strings.Split(params, ";")
+	if len(fields) < 3 || fields[2] == "" {
+		return ""
+	}
+	var b strings.Builder
+	for cp := range strings.SplitSeq(fields[2], ":") {
+		if n, err := strconv.ParseInt(cp, 10, 32); err == nil && n > 0 {
+			b.WriteRune(rune(n))
+		}
+	}
+	return b.String()
+}
+
 func (ip *inputParser) handleMouse(mode rune, params []int) {
 
 	// XTerm mouse events only report at most one button at a time,
@@ -1420,6 +1438,15 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 			}
 			if mod1 := kittyModifierKey(P0); mod1 != ModNone {
 				mod |= mod1
+			}
+			// kitty mode 16: a terminal that sends associated text reports
+			// the key's layout-correct output, already shifted - trust it
+			// over the base key. No text (e.g. terminals without mode 16)
+			// falls through to base key + modifiers.
+			if text := kittyKeyText(pstr); text != "" {
+				mod &^= ModShift // the shift is expressed in the text
+				ip.postKeyEx(KeyRune, text, mod, pressed, physical, repeat)
+				return
 			}
 			if key != KeyRune {
 				ip.postKeyEx(key, "", mod, pressed, physical, repeat)

--- a/input.go
+++ b/input.go
@@ -1000,8 +1000,10 @@ func kittyKeyText(params string) string {
 		return ""
 	}
 	var b strings.Builder
+	// Reject C0 control chars, DEL, and C1 control chars: they must never
+	// surface as key text.
 	for cp := range strings.SplitSeq(fields[2], ":") {
-		if n, err := strconv.ParseInt(cp, 10, 32); err == nil && n > 0 && utf8.ValidRune(rune(n)) {
+		if n, err := strconv.ParseInt(cp, 10, 32); err == nil && n >= 0x20 && (n < 0x7f || n > 0x9f) && utf8.ValidRune(rune(n)) {
 			b.WriteRune(rune(n))
 		}
 	}

--- a/input.go
+++ b/input.go
@@ -1442,12 +1442,9 @@ func (ip *inputParser) handleCsi(mode rune, params []byte, intermediate []byte) 
 			if mod1 := kittyModifierKey(P0); mod1 != ModNone {
 				mod |= mod1
 			}
-			// kitty mode 16: a terminal that sends associated text reports
-			// the key's layout-correct output, already shifted - trust it
-			// over the base key. No text (e.g. terminals without mode 16)
-			// falls through to base key + modifiers.
+			// kitty mode 16: text is the layout-correct output, sent with its
+			// modifiers - keep both. No text falls through to the base key.
 			if text := kittyKeyText(pstr); text != "" {
-				mod &^= ModShift // the shift is expressed in the text
 				ip.postKeyEx(KeyRune, text, mod, pressed, physical, repeat)
 				return
 			}

--- a/input_test.go
+++ b/input_test.go
@@ -667,6 +667,12 @@ func TestSpecialKeys(t *testing.T) {
 		{"XTerm-Alt-CJK", []byte{'\x1b', '[', '2', '7', ';', '3', ';', '2', '0', '3', '2', '0', '~'}, KeyRune, ModAlt, "你"},
 		{"Kitty-Esc", []byte{'\x1b', '[', '2', '7', 'u'}, KeyEsc, ModNone, ""},
 		{"Kitty-Control-I", []byte{'\x1b', '[', '1', '0', '5', ';', '5', 'u'}, 'I', ModCtrl, ""},
+		{"Kitty-Text-Empty-Mod", []byte{'\x1b', '[', '0', ';', ';', '2', '2', '9', 'u'}, KeyRune, ModNone, "å"},
+		{"Kitty-Text-Invalid-Codepoints", []byte{
+			'\x1b', '[', '2', '2', '9', ';', ';', '5', '5', '2', '9', '6',
+			':', '1', '1', '1', '4', '1', '1', '2',
+			':', '6', '5', 'u',
+		}, KeyRune, ModNone, "A"},
 		{"Win-Shift-A", []byte{'\x1b', '[', '6', '5', ';', '0', ';', '6', '5', ';', '1', ';', '1', '6', '_'}, KeyRune, ModNone, "A"},
 		{"Win-Ctrl-1", []byte{'\x1b', '[', '4', '9', ';', '0', ';', '4', '9', ';', '1', ';', '8', '_'}, KeyRune, ModCtrl, "1"},
 		{"Win-Ctrl-A", []byte{'\x1b', '[', '6', '5', ';', '0', ';', '1', ';', '1', ';', '8', '_'}, KeyCtrlA, ModCtrl, ""},

--- a/input_test.go
+++ b/input_test.go
@@ -673,6 +673,8 @@ func TestSpecialKeys(t *testing.T) {
 			':', '1', '1', '1', '4', '1', '1', '2',
 			':', '6', '5', 'u',
 		}, KeyRune, ModNone, "A"},
+		{"Kitty-Text-C0-Rejected", []byte{'\x1b', '[', '9', '7', ';', '1', ';', '9', 'u'}, KeyRune, ModNone, "a"},
+		{"Kitty-Text-C1-Rejected", []byte{'\x1b', '[', '9', '7', ';', '1', ';', '1', '4', '0', 'u'}, KeyRune, ModNone, "a"},
 		{"Win-Shift-A", []byte{'\x1b', '[', '6', '5', ';', '0', ';', '6', '5', ';', '1', ';', '1', '6', '_'}, KeyRune, ModNone, "A"},
 		{"Win-Ctrl-1", []byte{'\x1b', '[', '4', '9', ';', '0', ';', '4', '9', ';', '1', ';', '8', '_'}, KeyRune, ModCtrl, "1"},
 		{"Win-Ctrl-A", []byte{'\x1b', '[', '6', '5', ';', '0', ';', '1', ';', '1', ';', '8', '_'}, KeyCtrlA, ModCtrl, ""},

--- a/input_test.go
+++ b/input_test.go
@@ -1118,6 +1118,25 @@ func TestAdvancedBacktabReportsShiftTab(t *testing.T) {
 	}
 }
 
+func TestAdvancedKittyTextKeepsShift(t *testing.T) {
+	// kitty spec's own shift+a example: CSI 97 ; 2 ; 65 u - the associated
+	// text 'A' is delivered together with the shift modifier, which must not
+	// be dropped.
+	evch := make(chan Event, 10)
+	ip := newInputParser(evch)
+	ip.advanced = true
+
+	ip.ScanUTF8([]byte("\x1b[97;2;65u"))
+
+	got := nextKey(evch)
+	if got == nil {
+		t.Fatal("expected shifted A press")
+	}
+	if got.Key() != KeyRune || got.Str() != "A" || got.Modifiers() != ModShift {
+		t.Fatalf("expected shifted A with ModShift, got key=%v str=%q mod=%v", got.Key(), got.Str(), got.Modifiers())
+	}
+}
+
 func TestAdvancedKittyKeyMetadata(t *testing.T) {
 	evch := make(chan Event, 10)
 	ip := newInputParser(evch)

--- a/tscreen.go
+++ b/tscreen.go
@@ -179,7 +179,7 @@ const (
 	notifyDesktop777  = "\x1b]777;notify;%s;%s\x1b\\"       // Most commonly supported
 	queryKittyKbd     = "\x1b[?u"                           // Query for Kitty keyboard support
 	enableKittyKbd    = "\x1b[=1u"                          // Technically this pushes
-	enableKittyKbdAdv = "\x1b[=15u"                         // disambiguation, events, alternate keys, all keys
+	enableKittyKbdAdv = "\x1b[=31u"                         // disambiguation, events, alternate keys, all keys, text
 	disableKittyKbd   = "\x1b[=0u"                          // Technically this means pop previous mode
 	queryXTermKbd     = "\x1b[?4m"                          // Query for XTerm modify other keys support
 	enableXTermKbd    = "\x1b[>4;2m"                        // Enable modify other keys protocol


### PR DESCRIPTION
Enable kitty mode 16 and post the terminal-sent text as the rune,
clearing the shift that is already expressed in it. Without it the
shifted character is only recoverable per keyboard layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Kitty keyboard protocol support for associated text input.
  * Added the Kitty text capability when advanced keyboard input is enabled.

* **Bug Fixes**
  * Preserved the Shift modifier when decoding Kitty text events.
  * Improved fallback handling for missing or invalid associated text.
  * Ignored invalid Unicode codepoints, control characters, DEL, and nonpositive modifier values during input decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->