### PR TITLE
fix(vt): let the segmenter decide clustering, not Go's unicode tables

### DIFF
--- a/vt/coverage_test.go
+++ b/vt/coverage_test.go
@@ -16,7 +16,9 @@ package vt
 
 import (
 	"testing"
+	"unicode/utf8"
 
+	"github.com/clipperhouse/uax29/v2/graphemes"
 	"github.com/gdamore/tcell/v3/color"
 )
 
@@ -232,9 +234,11 @@ func TestShouldCheckGrapheme(t *testing.T) {
 		{name: "zwj", prev: 'x', r: '\u200d', want: true},
 		{name: "vs16", prev: 'x', r: '\uFE0F', want: true},
 		{name: "supplementary vs", prev: 'x', r: '\U000E0100', want: true},
-		// Non-ascii is always handed to the segmenter: whether it clusters
-		// depends on Unicode tables this function does not have.
-		{name: "plain non-ascii", prev: 'x', r: 'π', want: true},
+		{name: "plain non-ascii", prev: 'x', r: 'π', want: false},
+		// runes Go's unicode tables get wrong, and the segmenter does not
+		{name: "zwnj", prev: 'a', r: '‌', want: true},
+		{name: "emoji modifier", prev: 'a', r: '\U0001F3FB', want: true},
+		{name: "unicode 16 mark", prev: 'a', r: '᫏', want: true},
 	}
 
 	for _, tc := range cases {
@@ -246,6 +250,40 @@ func TestShouldCheckGrapheme(t *testing.T) {
 				t.Fatalf("shouldCheckGrapheme(%q, %q) = %v, want %v", tc.prev, tc.r, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestGraphemeJoinerBlocks re-derives graphemeJoinerBlocks from the segmenter.
+// shouldCheckGrapheme is only allowed to skip the segmenter for runes the
+// segmenter would never join, so a stale table after a uax29 upgrade has to
+// fail here rather than silently split clusters again.
+func TestGraphemeJoinerBlocks(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, 0, 1+utf8.UTFMax)
+	joiners, skipped := 0, 0
+	for r := rune(utf8.RuneSelf); r <= utf8.MaxRune; r++ {
+		if !utf8.ValidRune(r) {
+			continue
+		}
+		buf = utf8.AppendRune(append(buf[:0], 'e'), r)
+		iter := graphemes.FromBytes(buf)
+		joins := iter.Next() && len(iter.Value()) == len(buf)
+		check := shouldCheckGrapheme('e', r)
+		if joins {
+			joiners++
+			if !check {
+				t.Fatalf("U+%04X joins an ASCII base but graphemeJoinerBlocks skips it", r)
+			}
+		}
+		if !check {
+			skipped++
+		}
+	}
+	// Guard against a table of all ones, which would pass the check above
+	// while making the fast path pointless.
+	if joiners == 0 || skipped < joiners {
+		t.Fatalf("implausible table: %d joiners, %d runes skipped", joiners, skipped)
 	}
 }
 

--- a/vt/coverage_test.go
+++ b/vt/coverage_test.go
@@ -232,7 +232,9 @@ func TestShouldCheckGrapheme(t *testing.T) {
 		{name: "zwj", prev: 'x', r: '\u200d', want: true},
 		{name: "vs16", prev: 'x', r: '\uFE0F', want: true},
 		{name: "supplementary vs", prev: 'x', r: '\U000E0100', want: true},
-		{name: "plain non-ascii", prev: 'x', r: 'π', want: false},
+		// Non-ascii is always handed to the segmenter: whether it clusters
+		// depends on Unicode tables this function does not have.
+		{name: "plain non-ascii", prev: 'x', r: 'π', want: true},
 	}
 
 	for _, tc := range cases {

--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/clipperhouse/uax29/v2/graphemes"
@@ -1970,16 +1969,11 @@ func (em *emulator) putRune(r rune) {
 				if em.graphemeIter.Next() && len(em.graphemeIter.Value()) == len(buf) {
 					// we are adding to a cluster
 					cluster := em.graphemeIter.Value()
-					width := em.cells[lastIdx].W
-					if w := textWidthOptions.Rune(r); w > width {
-						width = w
-					}
-					if isRegionalIndicator(r) && width < 2 {
-						width = 2
-					}
-					if r == '\uFE0F' && width < 2 {
-						width = 2
-					}
+					// Measure the whole cluster. Taking the widest rune in it
+					// is not the same thing: a regional indicator pair is two
+					// width-1 runes but a width-2 flag, and an emoji modifier
+					// is a width-2 rune that does not widen a narrow base.
+					width := textWidthOptions.Bytes(cluster)
 					em.cells[lastIdx].C = em.clusterString(cluster)
 					em.cells[lastIdx].W = width
 					col := Col(lastIdx) % dim.X
@@ -2052,29 +2046,16 @@ func (em *emulator) clusterString(cluster []byte) string {
 	return em.clusterStrings.stringFor(cluster)
 }
 
+// shouldCheckGrapheme reports whether r might extend a cluster whose last
+// character is the ASCII byte prev. It must never say no when the segmenter
+// would say yes, so the only case it rules out is the one guaranteed by
+// UAX #29 itself: an ASCII pair never clusters, except CR LF. Anything
+// non-ASCII is handed to the segmenter, which owns the Unicode tables.
 func shouldCheckGrapheme(prev byte, r rune) bool {
 	if r < utf8.RuneSelf {
 		return prev == '\r' && r == '\n'
 	}
-
-	if unicode.Is(unicode.M, r) {
-		return true
-	}
-	if r == '\u200d' {
-		return true
-	}
-	if r >= 0xFE00 && r <= 0xFE0F {
-		return true
-	}
-	if r >= 0xE0100 && r <= 0xE01EF {
-		return true
-	}
-
-	return false
-}
-
-func isRegionalIndicator(r rune) bool {
-	return r >= 0x1F1E6 && r <= 0x1F1FF
+	return true
 }
 
 // eraseCell erases a single cell at the given offset.

--- a/vt/emulate.go
+++ b/vt/emulate.go
@@ -1969,10 +1969,8 @@ func (em *emulator) putRune(r rune) {
 				if em.graphemeIter.Next() && len(em.graphemeIter.Value()) == len(buf) {
 					// we are adding to a cluster
 					cluster := em.graphemeIter.Value()
-					// Measure the whole cluster. Taking the widest rune in it
-					// is not the same thing: a regional indicator pair is two
-					// width-1 runes but a width-2 flag, and an emoji modifier
-					// is a width-2 rune that does not widen a narrow base.
+					// not the same as the widest rune in the cluster: a flag
+					// is two width-1 runes but occupies two columns.
 					width := textWidthOptions.Bytes(cluster)
 					em.cells[lastIdx].C = em.clusterString(cluster)
 					em.cells[lastIdx].W = width
@@ -2046,16 +2044,15 @@ func (em *emulator) clusterString(cluster []byte) string {
 	return em.clusterStrings.stringFor(cluster)
 }
 
-// shouldCheckGrapheme reports whether r might extend a cluster whose last
-// character is the ASCII byte prev. It must never say no when the segmenter
-// would say yes, so the only case it rules out is the one guaranteed by
-// UAX #29 itself: an ASCII pair never clusters, except CR LF. Anything
-// non-ASCII is handed to the segmenter, which owns the Unicode tables.
+// shouldCheckGrapheme reports whether r might extend a cluster ending in the
+// ASCII byte prev.  It may say yes needlessly, but never no wrongly.
 func shouldCheckGrapheme(prev byte, r rune) bool {
 	if r < utf8.RuneSelf {
+		// an ASCII pair never clusters, except CR LF
 		return prev == '\r' && r == '\n'
 	}
-	return true
+	b := uint32(r) >> 6
+	return graphemeJoinerBlocks[b>>6]&(1<<(b&63)) != 0
 }
 
 // eraseCell erases a single cell at the given offset.

--- a/vt/graphemetable.go
+++ b/vt/graphemetable.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The TCell Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vt
+
+// graphemeJoinerBlocks has one bit per 64 runes, set if any rune in that
+// block can extend a grapheme cluster.  A clear bit means the segmenter
+// cannot join anything in the block, so putRune may skip it.  Only 2619 of
+// the 1113984 runes above U+007F can join, so nearly every bit is clear.
+//
+// The table is derived from the segmenter, not from Go's unicode tables,
+// and TestGraphemeJoinerBlocks re-derives it to catch drift.
+var graphemeJoinerBlocks = [272]uint64{
+	0:   0xfffffffffbc43000,
+	1:   0x0089ff15f0002007,
+	2:   0x00a8000000000009,
+	3:   0x0000000000000005,
+	10:  0x00008ffd0e000000,
+	15:  0x4100100000000000,
+	16:  0x6c30090000002880,
+	17:  0x387527b117cffbff,
+	19:  0x0000000000020000,
+	22:  0xe000180000000010,
+	27:  0x0004000000000000,
+	28:  0x3000000000000000,
+	29:  0x0000070000000260,
+	30:  0x0000002808880c15,
+	31:  0x0000000000008000,
+	224: 0x00000000000000f3,
+}

--- a/vt/tests/mock_test.go
+++ b/vt/tests/mock_test.go
@@ -1300,6 +1300,38 @@ func TestGraphemeCluster(t *testing.T) {
 	CheckContent(t, term, 0, 1, "A")
 }
 
+// Characters that attach to an ASCII base must cluster with it even when
+// Go's unicode tables do not classify them as marks. U+200C is a format
+// character (Cf), U+1F3FB a modifier symbol (Sk), and U+1ACF is a combining
+// mark that Go's tables, currently Unicode 15, still report as unassigned.
+func TestGraphemeClusterAsciiBase(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		next Col
+	}{
+		{"zwnj", "a\u200c", 1},
+		{"emoji modifier", "a\U0001f3fb", 1},
+		{"recent combining mark", "a\u1acf", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			term := vt.NewMockTerm(vt.MockOptSize{X: 10, Y: 5})
+			defer MustClose(t, term)
+			MustStart(t, term)
+
+			WriteF(t, term, "\x1b[?2027h")
+			WriteF(t, term, "\x1b[H\x1b[J")
+			WriteF(t, term, "%s", tc.text)
+
+			CheckContent(t, term, 0, 0, tc.text)
+			CheckPos(t, term, tc.next, 0)
+
+			// the cell past the cluster must not have been written to
+			CheckContent(t, term, tc.next, 0, "")
+		})
+	}
+}
+
 func TestEraseAbove(t *testing.T) {
 	term := vt.NewMockTerm(vt.MockOptSize{X: 10, Y: 5})
 	defer MustClose(t, term)


### PR DESCRIPTION
`putRune` asks two Unicode tables the same question and they disagree.

`shouldCheckGrapheme` decides whether a rune can extend a cluster from `unicode.M` plus some hand-listed ranges. Go's tables are Unicode 15.0.0; the uax29 segmenter called two lines later is newer. Sweeping every rune: 199 cluster with an ASCII base per the segmenter while the predicate says no, so each lands in its own cell and clobbers the next one. Categories: Cf 97, Cn 93 (marks Go doesn't know yet), Sk 5, Lm 2, Lo 2.

With mode 2027 on, `"a‌"` (ZWNJ, e.g. suppressing a ligature) gives cell 0 = `"a"` and cell 1 = ZWNJ, instead of one cell holding both.

Widening the list doesn't fix it. I tried `M|Cf|Sk|Lm`: still misses 95, because 93 are unassigned as far as Go is concerned. Any accept-list here ages. So the predicate now rules out only what UAX #29 guarantees, an ASCII pair except CR LF, and hands the rest to the segmenter.

Cluster width had the same shape: widest rune in the cluster, then regional indicators and U+FE0F patched back up by hand. `displaywidth.Bytes(cluster)` measures the cluster instead.

**Correcting the cost figures in an earlier version of this description.** Those numbers described the first commit; the second one adds a lookup table that skips the segmenter for runes that cannot join a cluster, and it reverses them. `BenchmarkPutRuneCurrent`, `benchstat` over 12 interleaved A/B rounds at 2M iterations, main vs head: ascii -1.87%, width -9.13%, wide -8.42%, line -18.42%, mixed32 -13.31%, mixed64 -12.66%, combining +11.88%. Geomean **-7.85%**, all p<=0.004, B/op and allocs/op unchanged. So the only remaining regression is `combining`, and the net is faster than main rather than slower.

`go test ./...` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode grapheme-cluster handling in terminal text.
  * Corrected display widths and cursor positioning for non-ASCII characters, combining marks, emoji modifiers, regional indicators, and variation selectors.
  * Fixed characters that attach to ASCII bases so they remain part of the same visual cluster when grapheme clustering is enabled.
  * Improved rendering consistency for complex Unicode sequences across supported terminal content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
